### PR TITLE
Update doctest.h to support bcc32c

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1717,6 +1717,9 @@ DOCTEST_TEST_SUITE_END();
 // required includes - will go only in one translation unit!
 #include <ctime>
 #include <cmath>
+#ifdef __BORLANDC__
+#include <math.h>
+#endif
 #include <new>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
The Borland (Embarcadero) compiler requires to include the math.h directly. Tested with the latest freely available C++ compiler by Embarcadero: http://altd.embarcadero.com/download/bcppbuilder/BCC101.zip