### PR TITLE
Add exception handling to the framework

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -948,6 +948,7 @@ namespace detail
     void logTestEnd();
 
     void logTestCrashed();
+    void logTestException(const char* what);
 
     void logAssert(bool passed, const char* decomposition, bool threw, const char* expr,
                    assertType::Enum assert_type, const char* file, int line);
@@ -1825,6 +1826,7 @@ DOCTEST_TEST_SUITE_END();
 #include <iomanip>
 #include <vector>
 #include <set>
+#include <stdexcept>
 
 namespace doctest
 {
@@ -2605,7 +2607,13 @@ namespace detail
             if(getContextState()->numFailedAssertionsForCurrentTestcase)
                 res = EXIT_FAILURE;
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        } catch(const TestFailureException&) { res = EXIT_FAILURE; } catch(...) {
+        } catch(const TestFailureException&) {
+            res = EXIT_FAILURE;
+        } catch(const std::exception &e) {
+            DOCTEST_LOG_START();
+            logTestException(e.what());
+            res = EXIT_FAILURE;
+        } catch(...) {
             DOCTEST_LOG_START();
             logTestCrashed();
             res = EXIT_FAILURE;
@@ -2722,6 +2730,16 @@ namespace detail
         char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
 
         DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED! (threw exception)\n\n");
+
+        DOCTEST_PRINTF_COLORED(msg, Color::Red);
+
+        printToDebugConsole(String(msg));
+    }
+
+    void logTestException(const char *what) {
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED! (threw exception: %s)\n\n", what);
 
         DOCTEST_PRINTF_COLORED(msg, Color::Red);
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -945,6 +945,7 @@ namespace detail
     void logTestEnd();
 
     void logTestCrashed();
+    void logTestException(const char* what);
 
     void logAssert(bool passed, const char* decomposition, bool threw, const char* expr,
                    assertType::Enum assert_type, const char* file, int line);

--- a/doctest/parts/doctest_impl.h
+++ b/doctest/parts/doctest_impl.h
@@ -100,6 +100,7 @@
 #include <iomanip>
 #include <vector>
 #include <set>
+#include <stdexcept>
 
 namespace doctest
 {
@@ -880,7 +881,13 @@ namespace detail
             if(getContextState()->numFailedAssertionsForCurrentTestcase)
                 res = EXIT_FAILURE;
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        } catch(const TestFailureException&) { res = EXIT_FAILURE; } catch(...) {
+        } catch(const TestFailureException&) {
+            res = EXIT_FAILURE;
+        } catch(const std::exception &e) {
+            DOCTEST_LOG_START();
+            logTestException(e.what());
+            res = EXIT_FAILURE;
+        } catch(...) {
             DOCTEST_LOG_START();
             logTestCrashed();
             res = EXIT_FAILURE;
@@ -997,6 +1004,16 @@ namespace detail
         char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
 
         DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED! (threw exception)\n\n");
+
+        DOCTEST_PRINTF_COLORED(msg, Color::Red);
+
+        printToDebugConsole(String(msg));
+    }
+
+    void logTestException(const char *what) {
+        char msg[DOCTEST_SNPRINTF_BUFFER_LENGTH];
+
+        DOCTEST_SNPRINTF(msg, DOCTEST_COUNTOF(msg), "TEST CASE FAILED! (threw exception: %s)\n\n", what);
 
         DOCTEST_PRINTF_COLORED(msg, Color::Red);
 

--- a/examples/assertion_macros/main.cpp
+++ b/examples/assertion_macros/main.cpp
@@ -7,6 +7,12 @@ static int throws(bool in) {
     return 42;
 }
 
+static int throws_stdexcept(bool in) {
+    if(in)
+        throw std::runtime_error("Exception");
+    return 42;
+}
+
 using doctest::Approx;
 
 TEST_SUITE("meaningless macros");
@@ -14,6 +20,8 @@ TEST_SUITE("meaningless macros");
 TEST_CASE("an empty test that will succeed") {}
 
 TEST_CASE("an empty test that will fail because of an exception") { throws(true); }
+
+TEST_CASE("an empty test that will fail because of a std::exception") { throws_stdexcept(true); }
 
 TEST_SUITE_END();
 
@@ -40,11 +48,43 @@ TEST_CASE("normal macros") {
     throws(true);
 }
 
+TEST_CASE("normal macros with std::exception") {
+    int a = 5;
+    int b = 5;
+
+    CHECK(throws_stdexcept(true) == 42);
+
+    CHECK_FALSE(!(a == b));
+
+    REQUIRE(a == b);
+
+    CHECK_EQ(a, b);
+
+    FAST_CHECK_EQ(a, b);
+
+    // commented out because 32 vs 64 bit builds will fail when the output is compared
+    //WARN(reinterpret_cast<void*>(1000) == reinterpret_cast<void*>(1004));
+
+    CHECK(Approx(0.1000001) == 0.1000002);
+    CHECK(Approx(0.502) == 0.501);
+
+    throws(true);
+}
+
 TEST_CASE("exceptions-related macros") {
     CHECK_THROWS(throws(false));
     CHECK_THROWS_AS(throws(false), int);
     CHECK_THROWS_AS(throws(true), int);
     CHECK_THROWS_AS(throws(true), char);
 
-    REQUIRE_NOTHROW(throws(true));
+    CHECK_NOTHROW(throws(true));
+}
+
+TEST_CASE("exceptions-related macros for std::exception") {
+    CHECK_THROWS(throws_stdexcept(false));
+    CHECK_THROWS_AS(throws_stdexcept(false), std::exception);
+    CHECK_THROWS_AS(throws_stdexcept(true), std::exception);
+    CHECK_THROWS_AS(throws_stdexcept(true), int);
+
+    REQUIRE_NOTHROW(throws_stdexcept(true));
 }

--- a/examples/assertion_macros/test_output/assertion_macros.txt
+++ b/examples/assertion_macros/test_output/assertion_macros.txt
@@ -1,18 +1,24 @@
 [doctest] run with "--help" for options
 ===============================================================================
-main.cpp(16)
+main.cpp(22)
 an empty test that will fail because of an exception
 
 TEST CASE FAILED! (threw exception)
 
 ===============================================================================
-main.cpp(20)
+main.cpp(24)
+an empty test that will fail because of a std::exception
+
+TEST CASE FAILED! (threw exception: Exception)
+
+===============================================================================
+main.cpp(28)
 normal macros
 
-main.cpp(24) FAILED! (threw exception)
+main.cpp(32) FAILED! (threw exception)
   CHECK( throws(true) == 42 )
 
-main.cpp(38) FAILED! 
+main.cpp(46) FAILED! 
   CHECK( Approx(0.502) == 0.501 )
 with expansion:
   CHECK( Approx( 0.502 ) == 0.501 )
@@ -20,21 +26,51 @@ with expansion:
 TEST CASE FAILED! (threw exception)
 
 ===============================================================================
-main.cpp(43)
-exceptions-related macros
+main.cpp(51)
+normal macros with std::exception
 
-main.cpp(44) FAILED!
-  CHECK_THROWS( throws(false) )
+main.cpp(55) FAILED! (threw exception)
+  CHECK( throws_stdexcept(true) == 42 )
 
-main.cpp(45) FAILED! (didn't throw at all)
-  CHECK_THROWS_AS( throws(false), int )
+main.cpp(69) FAILED! 
+  CHECK( Approx(0.502) == 0.501 )
+with expansion:
+  CHECK( Approx( 0.502 ) == 0.501 )
 
-main.cpp(47) FAILED! (threw something else)
-  CHECK_THROWS_AS( throws(true), char )
-
-main.cpp(49) FAILED!
-  REQUIRE_NOTHROW( throws(true) )
+TEST CASE FAILED! (threw exception)
 
 ===============================================================================
-[doctest] test cases:    4 |    1 passed |    3 failed |    0 skipped
-[doctest] assertions:   12 |    6 passed |    6 failed |
+main.cpp(74)
+exceptions-related macros
+
+main.cpp(75) FAILED!
+  CHECK_THROWS( throws(false) )
+
+main.cpp(76) FAILED! (didn't throw at all)
+  CHECK_THROWS_AS( throws(false), int )
+
+main.cpp(78) FAILED! (threw something else)
+  CHECK_THROWS_AS( throws(true), char )
+
+main.cpp(80) FAILED!
+  CHECK_NOTHROW( throws(true) )
+
+===============================================================================
+main.cpp(83)
+exceptions-related macros for std::exception
+
+main.cpp(84) FAILED!
+  CHECK_THROWS( throws_stdexcept(false) )
+
+main.cpp(85) FAILED! (didn't throw at all)
+  CHECK_THROWS_AS( throws_stdexcept(false), std::exception )
+
+main.cpp(87) FAILED! (threw something else)
+  CHECK_THROWS_AS( throws_stdexcept(true), int )
+
+main.cpp(89) FAILED!
+  REQUIRE_NOTHROW( throws_stdexcept(true) )
+
+===============================================================================
+[doctest] test cases:    7 |    1 passed |    6 failed |    0 skipped
+[doctest] assertions:   24 |   12 passed |   12 failed |


### PR DESCRIPTION
This PR the functionality of handling exceptions occurring in tests better. I think this is much needed.

In case of an `std::exception` or alike, it prints out the exception message using `.what()`.