### PR TITLE
Add CMake package support + options to skip examples or coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 set(PROJECT_NAME doctest)
-project(${PROJECT_NAME} VERSION 1.1.4)
+project(${PROJECT_NAME})
 
 option(DOCTEST_SKIP_COVERAGE "Skip coverage" OFF)
 option(DOCTEST_SKIP_EXAMPLES "Skip examples" OFF)
@@ -54,9 +54,10 @@ set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
+file(READ ${PROJECT_SOURCE_DIR}/scripts/version.txt PROJECT_VERSION)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${version_config}" COMPATIBILITY SameMajorVersion
+    "${version_config}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion
 )
 
 configure_file("cmake/Config.cmake.in" "${project_config}" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.0)
 set(PROJECT_NAME doctest)
 project(${PROJECT_NAME} VERSION 1.1.4)
 
+option(DOCTEST_SKIP_COVERAGE "Skip coverage" OFF)
+option(DOCTEST_SKIP_EXAMPLES "Skip examples" OFF)
+
 include(scripts/common.cmake)
 
 # when on Travis CI force 64 bit for gcc 4.4 under OSX because -m32 fails
@@ -13,28 +16,32 @@ endif()
 
 include_directories("doctest/") # needed here so the coverage tools work - otherwise the "../../doctest" relative path fucks up
 
-# setup coverage stuff only when COVERALLS_SERVICE_NAME is set (usually on travis CI)
-if(DEFINED ENV{COVERALLS_SERVICE_NAME})
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/scripts/coveralls-cmake/cmake)
-    include(Coveralls)
-    coveralls_turn_on_coverage()
-    
-    coveralls_setup("${CMAKE_SOURCE_DIR}/doctest/doctest.h" ON "${CMAKE_SOURCE_DIR}/scripts/coveralls-cmake/cmake")
-    
+if(NOT ${DOCTEST_SKIP_COVERAGE})
+    # setup coverage stuff only when COVERALLS_SERVICE_NAME is set (usually on travis CI)
+    if(DEFINED ENV{COVERALLS_SERVICE_NAME})
+        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/scripts/coveralls-cmake/cmake)
+        include(Coveralls)
+        coveralls_turn_on_coverage()
+        
+        coveralls_setup("${CMAKE_SOURCE_DIR}/doctest/doctest.h" ON "${CMAKE_SOURCE_DIR}/scripts/coveralls-cmake/cmake")
+        
+        add_subdirectory(scripts/code_coverage_source)
+        
+        return()
+    endif()
+
     add_subdirectory(scripts/code_coverage_source)
-    
-    return()
 endif()
 
-add_subdirectory(scripts/code_coverage_source)
-
-file(GLOB subdir_list "${CMAKE_SOURCE_DIR}/examples/*")
-foreach(dir ${subdir_list})
-    if(IS_DIRECTORY ${dir})
-        get_filename_component(DIRNAME ${dir} NAME)
-        add_subdirectory(examples/${DIRNAME})
-    endif()
-endforeach()
+if(NOT ${DOCTEST_SKIP_EXAMPLES})
+    file(GLOB subdir_list "${CMAKE_SOURCE_DIR}/examples/*")
+    foreach(dir ${subdir_list})
+        if(IS_DIRECTORY ${dir})
+            get_filename_component(DIRNAME ${dir} NAME)
+            add_subdirectory(examples/${DIRNAME})
+        endif()
+    endforeach()
+endif()
 
 add_library(${PROJECT_NAME} INTERFACE)
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(all)
+set(PROJECT_NAME doctest)
+project(${PROJECT_NAME} VERSION 1.1.4)
 
 include(scripts/common.cmake)
 
@@ -34,3 +35,43 @@ foreach(dir ${subdir_list})
         add_subdirectory(examples/${DIRNAME})
     endif()
 endforeach()
+
+add_library(${PROJECT_NAME} INTERFACE)
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+set(include_install_dir "include/doctest/")
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+configure_file("cmake/Config.cmake.in" "${project_config}" @ONLY)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT "${targets_export_name}"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+install(
+    FILES "doctest/doctest.h"
+    DESTINATION "${include_install_dir}"
+)
+
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
Add support to install doctest using CMake, as well as package config files (version, targets) useful to find_package [1] in some systems, like [hunter](https://github.com/ruslo/hunter/pull/727).

Add CMake options:
- DOCTEST_SKIP_COVERAGE: When ON, skip coverage build (default OFF)
- DOCTEST_SKIP_EXAMPLES: When ON, skip examples build (default OFF)

[1] https://cmake.org/cmake/help/git-master/manual/cmake-packages.7.html#creating-packages
