### PR TITLE
Prefer if(MSVC) in CMakeLists.txt.

### DIFF
--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -70,7 +70,7 @@ target_compile_definitions(disabled PRIVATE DOCTEST_CONFIG_DISABLE)
 doctest_add_test(NAME disabled COMMAND $<TARGET_FILE:disabled>)
 
 # TODO: think about fixing these in a different way! - see issue #61 or commit 6b61e8aa3818c5ea100cedc1bb48a60ea10df6e8
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(MSVC)
     target_compile_options(disabled PRIVATE /wd4505) # unreferenced local function has been removed
     target_compile_options(disabled PRIVATE /wd4100) # unreferenced formal parameter
     target_compile_options(disabled PRIVATE /wd4189) # local variable is initialized but not referenced

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -139,7 +139,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compiler_flags(-Qunused-arguments -fcolor-diagnostics) # needed for ccache integration on travis
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(MSVC)
     add_compiler_flags(/std:c++latest) # for post c++14 updates in MSVC
     add_compiler_flags(/permissive-) # force standard conformance - this is the better flag than /Za
     add_compiler_flags(/WX)


### PR DESCRIPTION
Prefer to use `if(MSVC)` in [`examples/all_features/CMakeLists.txt`](https://github.com/onqtam/doctest/blob/d3a9cabf18804ce5a21f89b8317f293fed395dbb/examples/all_features/CMakeLists.txt#L73), [`scripts/common/CMakeLists.txt`](https://github.com/onqtam/doctest/blob/d3a9cabf18804ce5a21f89b8317f293fed395dbb/scripts/cmake/common.cmake#L142).

See e.g. Stackoverflow [What's the CMake syntax to set and use variables?](https://stackoverflow.com/a/31044116/437272), section *Recursive substitutions*.