### PR TITLE
Add support for templated scenarios

### DIFF
--- a/doc/markdown/testcases.md
+++ b/doc/markdown/testcases.md
@@ -25,6 +25,10 @@ In addition to **doctest**'s take on the classic style of test cases, **doctest*
 
 This macro maps onto ```TEST_CASE``` and works in the same way, except that the test case name will be prefixed by "Scenario: "
 
+* **SCENARIO_TEMPLATE(** _scenario name_, _type_, _list of types_ **)**
+
+This macro maps onto ```TEST_CASE_TEMPLATE``` and works in the same way, except that the test case name will be prefixed by "Scenario: "
+
 * **GIVEN(** _something_ **)**
 * **WHEN(** _something_ **)**
 * **THEN(** _something_ **)**

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -2935,6 +2935,11 @@ constexpr T to_lvalue = x;
 // BDD style macros
 // clang-format off
 #define DOCTEST_SCENARIO(name)  TEST_CASE("  Scenario: " name)
+#ifdef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define  DOCTEST_SCENARIO_TEMPLATE(name, T, ...)  TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
+#else // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#define DOCTEST_SCENARIO_TEMPLATE(name, T, types) TEST_CASE_TEMPLATE("  Scenario: " name, T, types)
+#endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #define DOCTEST_GIVEN(name)     SUBCASE("   Given: " name)
 #define DOCTEST_WHEN(name)      SUBCASE("    When: " name)
 #define DOCTEST_AND_WHEN(name)  SUBCASE("And when: " name)
@@ -2999,6 +3004,7 @@ constexpr T to_lvalue = x;
 #define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
 
 #define SCENARIO DOCTEST_SCENARIO
+#define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
 #define GIVEN DOCTEST_GIVEN
 #define WHEN DOCTEST_WHEN
 #define AND_WHEN DOCTEST_AND_WHEN


### PR DESCRIPTION
## Description
There is no macro for templated scenarios, this commit adds `SCENARIO_TEMPLATE`  which in turn calls `TEST_CASE_TEMPLATE` as done with `SCENARIO`.

As I created this PR, I was also wondering if the BDD macros actually worked with `DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES` since it uses the short macro names and not the ones with the DOCTEST_ prefix.
If needed I will update and fix the BDD macros to use the DOCTEST_* variants.
