### PR TITLE
Remove incomplete copy ctor

### DIFF
--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1336,9 +1336,6 @@ namespace detail
                 : lhs(in)
                 , m_assert_type(assert_type) {}
 
-        Expression_lhs(const Expression_lhs& other)
-                : lhs(other.lhs) {}
-
         DOCTEST_NOINLINE operator Result() {
             bool res = !!lhs;
             if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional


### PR DESCRIPTION
When making a copy of Expression_lhs, m_assert_type would be garbage.

This was caught by running `clang-tidy` on my own code.

```
third-party\doctest.h:1347:30: warning: The left operand of '&' is a garbage value [clang-analyzer-core.UndefinedBinaryOperatorResult]
            if(m_assert_type & assertType::is_false) //!OCLINT bitwise operator in conditional
                             ^
```