### PR TITLE
Fix nullptr access

### DIFF
--- a/doctest/parts/doctest_impl.h
+++ b/doctest/parts/doctest_impl.h
@@ -1442,7 +1442,7 @@ namespace detail
             forDebugConsole += d1;
             forDebugConsole += d2;
         }
-        if(tc.m_test_suite[0] != '\0') {
+        if(tc.m_test_suite && tc.m_test_suite[0] != '\0') {
             DOCTEST_PRINTF_COLORED(ts1, Color::Yellow);
             DOCTEST_PRINTF_COLORED(ts2, Color::None);
             forDebugConsole += ts1;


### PR DESCRIPTION
## Description

If no test suite has been set and we fail in a test, then `tc.m_test_suite` is `nullptr` and will crash the program.

