### PR TITLE
Correct DOCTEST_NO_INSTALL logic; do install unless it is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ write_basic_package_version_file(
 
 configure_file("scripts/cmake/Config.cmake.in" "${project_config}" @ONLY)
 
-if (${DOCTEST_NO_INSTALL})
+if (NOT ${DOCTEST_NO_INSTALL})
     install(
         TARGETS ${PROJECT_NAME}
         EXPORT "${targets_export_name}"


### PR DESCRIPTION
## Description

Commit b63bf85ca872c5fd7f53c2e6d97f61813298936d (fixing #96) introduces the `DOCTEST_NO_INSTALL` variable, but it's use is reversed: by default it is set to `OFF` (meaning you _do_ want to install), but the test says "If set to ON, do install".

This made me upload a `doctest.h`-less `doctest-dev` package to Debian.

## Debian bug
This was detected through a failed build of `argagg` and reported as https://bugs.debian.org/880721 .