### PR TITLE
Correct DOCTEST_NO_INSTALL logic; do install unless it is set (#99)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ write_basic_package_version_file(
 
 configure_file("scripts/cmake/Config.cmake.in" "${project_config}" @ONLY)
 
-if (${DOCTEST_NO_INSTALL})
+if (NOT ${DOCTEST_NO_INSTALL})
     install(
         TARGETS ${PROJECT_NAME}
         EXPORT "${targets_export_name}"


### PR DESCRIPTION
the same change that went into the dev branch - now headed for master as well - sidestepping the release process - not worth going through all the hoops for this small fix to make 1.2.7 