### PR TITLE
Add basic thread safety

### DIFF
--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -66,7 +66,9 @@ If you want better aliases for the asserts instead of the long ones you could us
 
 ### Is doctest thread-aware?
 
-Currently no. Asserts cannot be used in multiple threads and test cases cannot be ran in parallel. These are long-term features that are planned on the [**roadmap**](roadmap.md).
+Yes when your compiler supports C++11, with some caveats.
+
+When doing assertions from multiple tests, some atomic variables will be updated which should have a negligeible impact on timings.  However, when doctest needs to log something (e.g. when an assertion fails, or when the ```-s``` argument is given) a mutex will be locked which could influence your test timings.
 
 For now tests are ran serially and doing asserts in multiple user threads will lead to crashes.
 

--- a/doc/markdown/roadmap.md
+++ b/doc/markdown/roadmap.md
@@ -106,8 +106,6 @@ Planned features for future releases - order changes constantly...
 - detect floating point exceptions
 - checkpoint/passpoint - like in [boost test](http://www.boost.org/doc/libs/1_63_0/libs/test/doc/html/boost_test/test_output/test_tools_support_for_logging/checkpoints.html) (also make all assert/subcase/logging macros to act as passpoints and print the last one on crashes or exceptions)
 - queries for the current test case - name (and probably decorators)
-- thread safety - asserts/subcases/captures should be safe to be used by multiple threads simultaneously
-    - https://github.com/blastrock/doctest/tree/threadsafe
 - support for running tests in parallel in multiple threads
 - death tests - as in [google test](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#death-tests)
 - config options

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -267,6 +267,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is no
 #ifndef DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #define DOCTEST_CONFIG_WITH_VARIADIC_MACROS
 #endif // DOCTEST_CONFIG_WITH_VARIADIC_MACROS
+#ifndef DOCTEST_CONFIG_WITH_THREAD_SAFETY
+#define DOCTEST_CONFIG_WITH_THREAD_SAFETY
+#endif // DOCTEST_CONFIG_WITH_THREAD_SAFETY
 #endif // __cplusplus >= 201103L
 
 // MSVC C++11 feature support table: https://msdn.microsoft.com/en-us/library/hh567368.aspx


### PR DESCRIPTION
## Description

I added basic thread-safety to doctest to be able to do assertions in multiple threads. It only works with C++11 support though.

I ran some tests with clang's thread sanitizer to make sure there are no more races.

## GitHub Issues

Closes #4 