### PR TITLE
Correctly document when a main() entry point will be created

### DIFF
--- a/doc/html_generated/configuration.html
+++ b/doc/html_generated/configuration.html
@@ -44,13 +44,13 @@ For most people the only configuration needed is telling **doctest** which sourc
 #include "doctest.h"
 ```
 
-This should be defined only in the source file where the library is implemented.
+This should be defined only in the source file where the library is implemented. It also creates a ```main()``` entry point.
 
 ### **```DOCTEST_CONFIG_IMPLEMENT```**
 
 If the client wants to [**supply the ```main()``` function**](main.html) (either to set an option with some value from the code or to integrate the framework into his existing project codebase) this identifier should be used.
 
-This should be defined only in the source file where the library is implemented. It also creates a ```main()``` entry point.
+This should be defined only in the source file where the library is implemented.
 
 ### **```DOCTEST_CONFIG_DISABLE```**
 

--- a/doc/markdown/configuration.md
+++ b/doc/markdown/configuration.md
@@ -39,13 +39,13 @@ For most people the only configuration needed is telling **doctest** which sourc
 #include "doctest.h"
 ```
 
-This should be defined only in the source file where the library is implemented.
+This should be defined only in the source file where the library is implemented. It also creates a ```main()``` entry point.
 
 ### **```DOCTEST_CONFIG_IMPLEMENT```**
 
 If the client wants to [**supply the ```main()``` function**](main.md) (either to set an option with some value from the code or to integrate the framework into his existing project codebase) this identifier should be used.
 
-This should be defined only in the source file where the library is implemented. It also creates a ```main()``` entry point.
+This should be defined only in the source file where the library is implemented.
 
 ### **```DOCTEST_CONFIG_DISABLE```**
 


### PR DESCRIPTION
The documentation was switched between DOCTEST_CONFIG_IMPLEMENT and
DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN.