### PR TITLE
Fixed build error under Android NDK

### DIFF
--- a/doctest/parts/doctest_impl.h
+++ b/doctest/parts/doctest_impl.h
@@ -1430,7 +1430,7 @@ namespace {
             sigStack.ss_size  = sizeof(altStackMem);
             sigStack.ss_flags = 0;
             sigaltstack(&sigStack, &oldSigStack);
-            struct sigaction sa = {nullptr};
+            struct sigaction sa = {0};
 
             sa.sa_handler = handleSignal; // NOLINT
             sa.sa_flags   = SA_ONSTACK;


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 headers in the doctest/parts/ folder.
-->


## Description
This allow doctest to build cleanly with the Android NDK, using the clang compiler targeting arm64

Without it, clang will complain about
```
cannot initialize a member subobject of type 'int' with an rvalue of type 'nullptr_t'
            struct sigaction sa = {nullptr};
                                   ^~~~~~~
```

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

