### PR TITLE
No undefined behavior per C++ standard in detecting endianess.

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -2790,14 +2790,12 @@ namespace {
         };
 
         static Arch which() {
-            union _
-            {
-                int  asInt;
-                char asChar[sizeof(int)];
-            } u;
-
-            u.asInt = 1;                                            // NOLINT
-            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
+            int x = 1;
+            // casting any data pointer to char* is allowed
+            auto ptr = reinterpret_cast<char*>(&x);
+            if(*ptr)
+                return Little;
+            return Big;
         }
     };
 } // namespace

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -177,14 +177,12 @@ namespace {
         };
 
         static Arch which() {
-            union _
-            {
-                int  asInt;
-                char asChar[sizeof(int)];
-            } u;
-
-            u.asInt = 1;                                            // NOLINT
-            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
+            int x = 1;
+            // casting any data pointer to char* is allowed
+            auto ptr = reinterpret_cast<char*>(&x);
+            if(*ptr)
+                return Little;
+            return Big;
         }
     };
 } // namespace


### PR DESCRIPTION
The union thingy is UB according to the standard, but not in GCC.
The char* pointer fix is always defined.