### PR TITLE
Fix UB of defining stuff in namespace std. Just include the headers.

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -363,39 +363,9 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
 #endif // linux
 
-#if DOCTEST_CLANG
-// to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
-#include <ciso646>
-#endif // clang
-
-// Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
-
-#if defined(_LIBCPP_VERSION) || defined(DOCTEST_CONFIG_USE_IOSFWD)
-// not forward declaring ostream for libc++ because I had some problems (inline namespaces vs c++98)
-// so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
-#include <iosfwd>
-#else  // _LIBCPP_VERSION
-namespace std {
-template <class charT>
-struct char_traits;
-template <>
-struct char_traits<char>;
-template <class charT, class traits>
-class basic_ostream;
-typedef basic_ostream<char, char_traits<char>> ostream;
-} // namespace std
-#endif // _LIBCPP_VERSION || DOCTEST_CONFIG_USE_IOSFWD
-
-#ifdef _LIBCPP_VERSION
 #include <cstddef>
-#else  // _LIBCPP_VERSION
-namespace std {
-typedef decltype(nullptr) nullptr_t;
-}
-#endif // _LIBCPP_VERSION
-
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#include <cstring>
+#include <iosfwd>
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
@@ -775,8 +745,6 @@ namespace detail {
     template <typename T>
     struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
     {};
-
-    DOCTEST_INTERFACE void my_memcpy(void* dest, const void* src, unsigned num);
 
     DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
     DOCTEST_INTERFACE String getTlsOssResult();
@@ -1549,7 +1517,7 @@ namespace detail {
             // copy the bytes for the whole object - including the vtable because we cant construct
             // the object directly in the buffer using placement new - need the <new> header...
             if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK) {
-                my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
+                memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
             } else {
                 auto curr  = new Node;
                 curr->next = nullptr;
@@ -1560,7 +1528,7 @@ namespace detail {
                     head = tail = curr;
                 }
 
-                my_memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
+                memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
             }
             ++numCaptures;
             return *this;
@@ -2700,7 +2668,6 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <new>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <limits>
 #include <utility>
 #include <sstream>
@@ -2801,8 +2768,6 @@ namespace {
 } // namespace
 
 namespace detail {
-    void my_memcpy(void* dest, const void* src, unsigned num) { memcpy(dest, src, num); }
-
     String rawMemoryToString(const void* object, unsigned size) {
         // Reverse order for little endian architectures
         int i = 0, end = static_cast<int>(size), inc = 1;

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -364,8 +364,8 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #endif // linux
 
 #include <cstddef>
-#include <cstring>
 #include <iosfwd>
+#include <new>
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
@@ -1478,8 +1478,7 @@ namespace detail {
 
         struct DOCTEST_INTERFACE Chunk
         {
-            char buf[sizeof(Capture<char>)] DOCTEST_ALIGNMENT(
-                    2 * sizeof(void*)); // place to construct a Capture<T>
+            alignas(Capture<char>) char buf[sizeof(Capture<char>)];
 
             DOCTEST_DECLARE_DEFAULTS(Chunk);
             DOCTEST_DELETE_COPIES(Chunk);
@@ -1511,13 +1510,8 @@ namespace detail {
 
         template <typename T>
         DOCTEST_NOINLINE ContextBuilder& operator<<(T& in) {
-            Capture<T> temp(&in);
-
-            // construct either on stack or on heap
-            // copy the bytes for the whole object - including the vtable because we cant construct
-            // the object directly in the buffer using placement new - need the <new> header...
             if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK) {
-                memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
+                new(stackChunks[numCaptures].buf) Capture<T>(&in);
             } else {
                 auto curr  = new Node;
                 curr->next = nullptr;
@@ -1528,7 +1522,7 @@ namespace detail {
                     head = tail = curr;
                 }
 
-                memcpy(tail->chunk.buf, &temp, sizeof(Chunk));
+                new(tail->chunk.buf) Capture<T>(&in);
             }
             ++numCaptures;
             return *this;
@@ -2668,6 +2662,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <new>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <utility>
 #include <sstream>

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -87,6 +87,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <new>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <utility>
 #include <sstream>

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -87,7 +87,6 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <new>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <limits>
 #include <utility>
 #include <sstream>
@@ -188,8 +187,6 @@ namespace {
 } // namespace
 
 namespace detail {
-    void my_memcpy(void* dest, const void* src, unsigned num) { memcpy(dest, src, num); }
-
     String rawMemoryToString(const void* object, unsigned size) {
         // Reverse order for little endian architectures
         int i = 0, end = static_cast<int>(size), inc = 1;


### PR DESCRIPTION
Having this UB may randomly break just by some compiler update.
Fixes #194 