### PR TITLE
Add two very simple examples of using doctest with CMake

### DIFF
--- a/examples/dll_installed_doctest/CMakeLists.txt
+++ b/examples/dll_installed_doctest/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(example_dll VERSION 0.0.1 LANGUAGES CXX)
+
+find_package(doctest REQUIRED)
+
+add_library("dll" SHARED dll.cpp)
+target_compile_features("dll" PRIVATE cxx_std_17)
+target_compile_definitions("dll" PUBLIC -D_EXPORT)
+target_link_libraries("dll" doctest::doctest)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} dll)

--- a/examples/dll_installed_doctest/dll.cpp
+++ b/examples/dll_installed_doctest/dll.cpp
@@ -5,27 +5,18 @@
 #include "dll.h"
 #include <stdio.h>
 
-extern "C"
-{
-    void say_hello_dll()
-    {
-        printf("%s", "Hello, World!\n");
-    }
+extern "C" {
+void say_hello_dll() { printf("%s", "Hello, World!\n"); }
 }
 
-int factorial(int number)
-{
-    return number < 1
-        ? 1
-        : number <= 1
-            ? number
-            : factorial(number - 1) * number;
+int factorial(int number) {
+  return number < 1 ? 1 : number <= 1 ? number : factorial(number - 1) * number;
 }
 
 TEST_CASE("testing the factorial function") {
-    CHECK(factorial(0) == 1);
-    CHECK(factorial(1) == 1);
-    CHECK(factorial(2) == 2);
-    CHECK(factorial(3) == 6);
-    CHECK(factorial(10) == 3628800);
+  CHECK(factorial(0) == 1);
+  CHECK(factorial(1) == 1);
+  CHECK(factorial(2) == 2);
+  CHECK(factorial(3) == 6);
+  CHECK(factorial(10) == 3628800);
 }

--- a/examples/dll_installed_doctest/dll.cpp
+++ b/examples/dll_installed_doctest/dll.cpp
@@ -1,0 +1,31 @@
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+#include "dll.h"
+#include <stdio.h>
+
+extern "C"
+{
+    void say_hello_dll()
+    {
+        printf("%s", "Hello, World!\n");
+    }
+}
+
+int factorial(int number)
+{
+    return number < 1
+        ? 1
+        : number <= 1
+            ? number
+            : factorial(number - 1) * number;
+}
+
+TEST_CASE("testing the factorial function") {
+    CHECK(factorial(0) == 1);
+    CHECK(factorial(1) == 1);
+    CHECK(factorial(2) == 2);
+    CHECK(factorial(3) == 6);
+    CHECK(factorial(10) == 3628800);
+}

--- a/examples/dll_installed_doctest/dll.h
+++ b/examples/dll_installed_doctest/dll.h
@@ -2,7 +2,6 @@
 
 #include "exporting.h"
 
-extern "C"
-{
-    DLL_API void say_hello_dll();
+extern "C" {
+DLL_API void say_hello_dll();
 }

--- a/examples/dll_installed_doctest/dll.h
+++ b/examples/dll_installed_doctest/dll.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "exporting.h"
+
+extern "C"
+{
+    DLL_API void say_hello_dll();
+}

--- a/examples/dll_installed_doctest/exporting.h
+++ b/examples/dll_installed_doctest/exporting.h
@@ -2,14 +2,14 @@
 
 #ifdef _EXPORT
 #ifdef _MSC_VER
-    #define DLL_API __declspec(dllexport)
+#define DLL_API __declspec(dllexport)
 #elif defined __GNUC__
-    #define DLL_API __attribute__ ((visibility("default")))
+#define DLL_API __attribute__((visibility("default")))
 #endif
 #else
 #ifdef _MSC_VER
-    #define DLL_API __declspec(dllimport)
+#define DLL_API __declspec(dllimport)
 #elif defined __GNUC__
-    #define DLL_API __attribute__ ((visibility ("hidden")))
+#define DLL_API __attribute__((visibility("hidden")))
 #endif
 #endif

--- a/examples/dll_installed_doctest/exporting.h
+++ b/examples/dll_installed_doctest/exporting.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef _EXPORT
+#ifdef _MSC_VER
+    #define DLL_API __declspec(dllexport)
+#elif defined __GNUC__
+    #define DLL_API __attribute__ ((visibility("default")))
+#endif
+#else
+#ifdef _MSC_VER
+    #define DLL_API __declspec(dllimport)
+#elif defined __GNUC__
+    #define DLL_API __attribute__ ((visibility ("hidden")))
+#endif
+#endif

--- a/examples/dll_installed_doctest/main.cpp
+++ b/examples/dll_installed_doctest/main.cpp
@@ -1,0 +1,35 @@
+#define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#include <doctest/doctest.h>
+
+#include "dll.h"
+
+int main(int argc, char** argv)
+{
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+
+    int res = context.run(); // run doctest
+
+    // important - query flags (and --exit) rely on the user doing this
+    if(context.shouldExit()) {
+        // propagate the result of the tests
+        return res;
+    }
+
+    say_hello_dll(); // test dll func
+}
+
+int square(const int number) { return number * number; }
+
+TEST_CASE("testing the square function") {
+    CHECK(square(2) == 4);
+    CHECK(square(4) == 16);
+    CHECK(square(5) == 25);
+    CHECK(square(8) == 64);
+}
+
+// running notes
+// ./program --no-run (run normal program)
+// ./program --exit (run tests then exit)
+// ./program (run tests then run program)
+// ./program --success (print successful test casts)

--- a/examples/dll_installed_doctest/main.cpp
+++ b/examples/dll_installed_doctest/main.cpp
@@ -28,7 +28,7 @@ TEST_CASE("testing the square function") {
 }
 
 // running notes
-// ./program --no-run (run normal program)
-// ./program --exit (run tests then exit)
-// ./program (run tests then run program)
-// ./program --success (print successful test casts)
+// ./example_dll --no-run (run normal program)
+// ./example_dll --exit (run tests then exit)
+// ./example_dll (run tests then run program)
+// ./example_dll --success (print successful test casts)

--- a/examples/dll_installed_doctest/main.cpp
+++ b/examples/dll_installed_doctest/main.cpp
@@ -3,29 +3,28 @@
 
 #include "dll.h"
 
-int main(int argc, char** argv)
-{
-    doctest::Context context;
-    context.applyCommandLine(argc, argv);
+int main(int argc, char **argv) {
+  doctest::Context context;
+  context.applyCommandLine(argc, argv);
 
-    int res = context.run(); // run doctest
+  int res = context.run(); // run doctest
 
-    // important - query flags (and --exit) rely on the user doing this
-    if(context.shouldExit()) {
-        // propagate the result of the tests
-        return res;
-    }
+  // important - query flags (and --exit) rely on the user doing this
+  if (context.shouldExit()) {
+    // propagate the result of the tests
+    return res;
+  }
 
-    say_hello_dll(); // test dll func
+  say_hello_dll(); // test dll func
 }
 
 int square(const int number) { return number * number; }
 
 TEST_CASE("testing the square function") {
-    CHECK(square(2) == 4);
-    CHECK(square(4) == 16);
-    CHECK(square(5) == 25);
-    CHECK(square(8) == 64);
+  CHECK(square(2) == 4);
+  CHECK(square(4) == 16);
+  CHECK(square(5) == 25);
+  CHECK(square(8) == 64);
 }
 
 // running notes

--- a/examples/executable_installed_doctest/CMakeLists.txt
+++ b/examples/executable_installed_doctest/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(example_exe VERSION 0.0.1 LANGUAGES CXX)
+
+find_package(doctest REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} doctest::doctest)

--- a/examples/executable_installed_doctest/main.cpp
+++ b/examples/executable_installed_doctest/main.cpp
@@ -1,37 +1,31 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
-int main(int argc, char** argv)
-{
-    doctest::Context context;
-    context.applyCommandLine(argc, argv);
+int main(int argc, char **argv) {
+  doctest::Context context;
+  context.applyCommandLine(argc, argv);
 
-    int res = context.run(); // run doctest
+  int res = context.run(); // run doctest
 
-    // important - query flags (and --exit) rely on the user doing this
-    if(context.shouldExit()) {
-        // propagate the result of the tests
-        return res;
-    }
+  // important - query flags (and --exit) rely on the user doing this
+  if (context.shouldExit()) {
+    // propagate the result of the tests
+    return res;
+  }
 
-    printf("%s", "Hello, World!");
+  printf("%s", "Hello, World!");
 }
 
-int factorial(const int number)
-{
-    return number < 1 
-        ? 1 
-        : number <= 1 
-            ? number 
-            : factorial(number - 1) * number;
+int factorial(const int number) {
+  return number < 1 ? 1 : number <= 1 ? number : factorial(number - 1) * number;
 }
 
 TEST_CASE("testing the factorial function") {
-    CHECK(factorial(0) == 1);
-    CHECK(factorial(1) == 1);
-    CHECK(factorial(2) == 2);
-    CHECK(factorial(3) == 6);
-    CHECK(factorial(10) == 3628800);
+  CHECK(factorial(0) == 1);
+  CHECK(factorial(1) == 1);
+  CHECK(factorial(2) == 2);
+  CHECK(factorial(3) == 6);
+  CHECK(factorial(10) == 3628800);
 }
 
 // running notes

--- a/examples/executable_installed_doctest/main.cpp
+++ b/examples/executable_installed_doctest/main.cpp
@@ -1,0 +1,41 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+int main(int argc, char** argv)
+{
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+
+    int res = context.run(); // run doctest
+
+    // important - query flags (and --exit) rely on the user doing this
+    if(context.shouldExit()) {
+        // propagate the result of the tests
+        return res;
+    }
+
+    printf("%s", "Hello, World!");
+}
+
+int factorial(const int number)
+{
+    return number < 1 
+        ? 1 
+        : number <= 1 
+            ? number 
+            : factorial(number - 1) * number;
+}
+
+TEST_CASE("testing the factorial function") {
+    CHECK(factorial(0) == 1);
+    CHECK(factorial(1) == 1);
+    CHECK(factorial(2) == 2);
+    CHECK(factorial(3) == 6);
+    CHECK(factorial(10) == 3628800);
+}
+
+// running notes
+// ./example_exe --no-run (run normal program)
+// ./example_exe --exit (run tests then exit)
+// ./example_exe (run tests then run program)
+// ./example_exe --success (print successful test casts)


### PR DESCRIPTION
## Description
I was hoping it might be possible to add a couple more minimal examples of how to set up and use doctest.

I found the existing examples helpful but there's also quite a lot going on in each. They can be a little confusing/intimidating to a newcomer to the library. These two new examples provide the bare minimum for using doctest with a plain exe or a dll.

There may well be some stuff I've missed and I'm happy to provide more info in a README file if you think that'd help. If you can think of better names or locations for the examples please let me know too.

The library is brilliant by the way and I'm hoping to use it a lot more in the future! 😄 

Thanks!


Tom