### PR TITLE
Remove architecture check from CMake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,19 @@ set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
 include(CMakePackageConfigHelpers)
+
+# CMake automatically adds an architecture compatibility check to make sure
+# 32 and 64 bit code is not accidentally mixed. For a header-only library this
+# is not required. The check can be disabled by temporarily unsetting
+# CMAKE_SIZEOF_VOID_P. In CMake 3.14 and later this can be achieved more cleanly
+# with write_basic_package_version_file(ARCH_INDEPENDENT).
+# TODO: Use this once a newer CMake can be required.
+set(DOCTEST_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+unset(CMAKE_SIZEOF_VOID_P)
 write_basic_package_version_file(
     "${version_config}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion
 )
+set(CMAKE_SIZEOF_VOID_P ${DOCTEST_SIZEOF_VOID_P})
 
 configure_file("scripts/cmake/Config.cmake.in" "${project_config}" @ONLY)
 


### PR DESCRIPTION
## Description
CMake adds an architecture check to each package by default. This causes the package to break if e. g. the package was built on a 32 bit system and used on a 64 bit system, even though this is a header-only library. This can happen if a caching package manager like conan is being used.

In CMake 3.14 this check can be disabled by passing `ARCH_INDEPENDENT` to `write_basic_package_version_file`. In versions prior to that `CMAKE_SIZEOF_VOID_P` needs to be unset for the duration of this function.

## GitHub Issues
catchorg/Catch2#1368
