### PR TITLE
Added meson file, to declare a dependency.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,3 @@
+project('doctest', ['cpp'], version: '2.3.1', meson_version:'>=0.50')
+doctest_dep = declare_dependency(include_directories: include_directories('doctest'))
+


### PR DESCRIPTION
Added a meson build file, so that doctest can be used as a subproject from git.

The build file doesn't actually build the project, but just defines a dependency.