### PR TITLE
fix : includeing windows.h header caause error

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -3432,7 +3432,7 @@ Approx& Approx::scale(double newScale) {
 bool operator==(double lhs, const Approx& rhs) {
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + std::max(std::fabs(lhs), std::fabs(rhs.m_value)));
+           rhs.m_epsilon * (rhs.m_scale + (std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 bool operator==(const Approx& lhs, double rhs) { return operator==(rhs, lhs); }
 bool operator!=(double lhs, const Approx& rhs) { return !operator==(lhs, rhs); }


### PR DESCRIPTION

## Description
includeing windows.h header caause error 
because includeing std:: max will call max in windows.h.
## GitHub Issues
Noting

