### PR TITLE
No minimum version limitation of Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,2 +1,2 @@
-project('doctest', ['cpp'], version: '2.3.4', meson_version:'>=0.50')
+project('doctest', ['cpp'], version: '2.3.4')
 doctest_dep = declare_dependency(include_directories: include_directories('doctest'))


### PR DESCRIPTION
In order to support building a project using doctest with older versions of Meson, the minimum version limitation should be either further lowered or dropped at all.