### PR TITLE
Add support for compiling with clang-cl

### DIFF
--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -90,7 +90,9 @@ if(MSVC)
     target_compile_options(disabled PRIVATE /wd4505) # unreferenced local function has been removed
     target_compile_options(disabled PRIVATE /wd4100) # unreferenced formal parameter
     target_compile_options(disabled PRIVATE /wd4189) # local variable is initialized but not referenced
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(disabled PRIVATE -Wno-unknown-warning-option)
     target_compile_options(disabled PRIVATE -Wno-unneeded-internal-declaration)
     target_compile_options(disabled PRIVATE -Wno-unused-function)

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -72,10 +72,14 @@ endmacro()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compiler_flags(-Werror)
-    add_compiler_flags(-pedantic)
-    add_compiler_flags(-pedantic-errors)
-    add_compiler_flags(-fvisibility=hidden)
     add_compiler_flags(-fstrict-aliasing)
+
+    # The following options are not valid when clang-cl is used.
+    if(NOT MSVC)
+        add_compiler_flags(-pedantic)
+        add_compiler_flags(-pedantic-errors)
+        add_compiler_flags(-fvisibility=hidden)
+    endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
The previous logic was adding GNU style command line flags when clang-cl was used which wants MSVC style command line flags. I've changed the logic to the same logic used in reproc to support clang-cl which fixes the issue.
