### PR TITLE
include windows.h in cmall caps to silence clang nonportable warnings

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -138,7 +138,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #include <io.h>
 

--- a/examples/executable_dll_and_plugin/main.cpp
+++ b/examples/executable_dll_and_plugin/main.cpp
@@ -24,7 +24,7 @@ TEST_CASE("executable") {
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
-#include <Windows.h>
+#include <windows.h>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #ifdef _MSC_VER
 #define LoadDynamicLib(lib) LoadLibrary(lib ".dll")


### PR DESCRIPTION
changed `#include <Windows.h>` to small caps to silence clang warnings on `-Wnonportable-system-include-path`

'Closes #312'