### PR TITLE
Fixed missing ostream include for MacOS when defining DOCTEST_CONFIG_…

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -369,10 +369,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
 #include <iosfwd>
 #include <cstddef>
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
 #include <ostream>
-#endif // VS 2019
 #else // DOCTEST_CONFIG_USE_STD_HEADERS
 
 #if DOCTEST_CLANG

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -366,10 +366,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
 #include <iosfwd>
 #include <cstddef>
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
 #include <ostream>
-#endif // VS 2019
 #else // DOCTEST_CONFIG_USE_STD_HEADERS
 
 #if DOCTEST_CLANG


### PR DESCRIPTION
…USE_STD_HEADERS

## Description
ostream isn't getting included on MacOS 10.13 when building with cmake. Doctest seems to rely on string including ostream when that is not reliable. As including ostream was already included for VS 2019 it makes sense to include it for all platforms that might need it when using the DOCTEST_CONFIG_USE_STD_HEADERS define.

## GitHub Issues
This fixes #126 

