### PR TITLE
Support std::string for SUBCASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,24 +24,6 @@
 *.ii
 *.s
 
-# Visual Studio garbage
-.vs/
-*.sln
-*.vcxproj
-*.vcxproj.filters
-*.vcxproj.user
-*.log
-*.tlog*
-*.ilk
-*.pdb
-*.exp
-
-# CMake garbage
-*.rule
-*.cmake
-generate.stamp*
-CMakeFiles/
-
 # My garbage :)
 Win32/
 x64/
@@ -55,6 +37,3 @@ build-mingw/
 *vscode*
 .idea/
 cmake-build-*/
-CMakeCache.txt
-examples/all_features/temp
-Testing/Temporary/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,24 @@
 *.ii
 *.s
 
+# Visual Studio garbage
+.vs/
+*.sln
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.log
+*.tlog*
+*.ilk
+*.pdb
+*.exp
+
+# CMake garbage
+*.rule
+*.cmake
+generate.stamp*
+CMakeFiles/
+
 # My garbage :)
 Win32/
 x64/
@@ -37,3 +55,6 @@ build-mingw/
 *vscode*
 .idea/
 cmake-build-*/
+CMakeCache.txt
+examples/all_features/temp
+Testing/Temporary/

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -675,7 +675,7 @@ struct DOCTEST_INTERFACE MessageData
 
 struct DOCTEST_INTERFACE SubcaseSignature
 {
-    std::string m_name;
+    String      m_name;
     const char* m_file;
     int         m_line;
 
@@ -3271,7 +3271,7 @@ bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
         return m_line < other.m_line;
     if(std::strcmp(m_file, other.m_file) != 0)
         return std::strcmp(m_file, other.m_file) < 0;
-    return m_name < other.m_name;
+    return m_name.compare(other.m_name) < 0;
 }
 
 IContextScope::IContextScope()  = default;
@@ -3507,7 +3507,7 @@ namespace {
 namespace detail {
 
     Subcase::Subcase(const char* file, int line, std::string name)
-            : m_signature({name, file, line}) {
+            : m_signature({name.c_str(), file, line}) {
         ContextState* s = g_cs;
 
         // check subcase filters

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1003,7 +1003,7 @@ namespace detail {
         SubcaseSignature m_signature;
         bool             m_entered = false;
 
-        Subcase(const char* file, int line, std::string name);
+        Subcase(const char* file, int line, String name);
         ~Subcase();
 
         operator bool() const;
@@ -1873,9 +1873,12 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(...)                                                                      \
+#define DOCTEST_SUBCASE(...)                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-               doctest::detail::Subcase(__FILE__, __LINE__, __VA_ARGS__))
+               doctest::detail::Subcase(__FILE__, __LINE__, std::string(__VA_ARGS__).c_str()))     \
+               DOCTEST_GCC_SUPPRESS_WARNING_POP \
+
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
@@ -3513,8 +3516,8 @@ namespace {
 } // namespace
 namespace detail {
 
-    Subcase::Subcase(const char* file, int line, std::string name)
-            : m_signature({name.c_str(), file, line}) {
+    Subcase::Subcase(const char* file, int line, String name)
+            : m_signature({std::move(name), file, line}) {
         ContextState* s = g_cs;
 
         // check subcase filters

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -413,13 +413,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
-DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4365) // signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument X is not a string literal
-DOCTEST_MSVC_SUPPRESS_WARNING(4987) // nonstandard extension used: 'throw (...)'
-#include <string>
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -3941,10 +3941,11 @@ namespace {
 
     struct FatalConditionHandler
     {
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+        static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo) {
             for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
                 if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
                     reportFatal(signalDefs[i].name);
+                    break;
                 }
             }
             // If its not an exception we care about, pass it along.
@@ -3957,9 +3958,8 @@ namespace {
             // 32k seems enough for doctest to handle stack overflow,
             // but the value was found experimentally, so there is no strong guarantee
             guaranteeSize = 32 * 1024;
-            exceptionHandlerHandle = nullptr;
-            // Register as first handler in current chain
-            exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+            // Register an unhandled exception filter
+            previousTop = SetUnhandledExceptionFilter(handleException);
             // Pass in guarantee size to be filled
             SetThreadStackGuarantee(&guaranteeSize);
         }
@@ -3967,9 +3967,9 @@ namespace {
         static void reset() {
             if(isSet) {
                 // Unregister handler and restore the old guarantee
-                RemoveVectoredExceptionHandler(exceptionHandlerHandle);
+                SetUnhandledExceptionFilter(previousTop);
                 SetThreadStackGuarantee(&guaranteeSize);
-                exceptionHandlerHandle = nullptr;
+                previousTop = nullptr;
                 isSet = false;
             }
         }
@@ -3979,12 +3979,12 @@ namespace {
     private:
         static bool isSet;
         static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
+        static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
     bool FatalConditionHandler::isSet = false;
     ULONG FatalConditionHandler::guaranteeSize = 0;
-    PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -389,7 +389,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
 DOCTEST_STD_NAMESPACE_BEGIN // NOLINT (cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t;
+        typedef decltype(nullptr) nullptr_t;
 template <class charT>
 struct char_traits;
 template <>
@@ -587,7 +587,7 @@ namespace assertType {
         DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
         DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
         DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
-        
+
         DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
         DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
         DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
@@ -996,7 +996,8 @@ namespace detail {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
     [[noreturn]]
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    DOCTEST_INTERFACE void throwException();
+    DOCTEST_INTERFACE void
+    throwException();
 
     struct DOCTEST_INTERFACE Subcase
     {
@@ -1269,8 +1270,10 @@ namespace detail {
     DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
     DOCTEST_INTERFACE bool isDebuggerActive();
 
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+    template <typename T>
+    int instantiationHelper(const T&) {
+        return 0;
+    }
 
     namespace binaryAssertComparison {
         enum Enum
@@ -1487,23 +1490,27 @@ namespace detail {
     DOCTEST_INTERFACE void toStream(std::ostream* s, int long long in);
     DOCTEST_INTERFACE void toStream(std::ostream* s, int long long unsigned in);
 
-    // ContextScope base class used to allow implementing methods of ContextScope 
+    // ContextScope base class used to allow implementing methods of ContextScope
     // that don't depend on the template parameter in doctest.cpp.
-    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope
+    {
     protected:
         ContextScopeBase();
 
         void destroy();
     };
 
-    template <typename L> class ContextScope : public ContextScopeBase
+    template <typename L>
+    class ContextScope : public ContextScopeBase
     {
-        const L &lambda_;
+        const L& lambda_;
 
     public:
-        explicit ContextScope(const L &lambda) : lambda_(lambda) {}
+        explicit ContextScope(const L& lambda)
+                : lambda_(lambda) {}
 
-        ContextScope(ContextScope &&other) : lambda_(other.lambda_) {}
+        ContextScope(ContextScope&& other)
+                : lambda_(other.lambda_) {}
 
         void stringify(std::ostream* s) const override { lambda_(s); }
 
@@ -1527,9 +1534,9 @@ namespace detail {
         bool log();
         void react();
     };
-    
+
     template <typename L>
-    ContextScope<L> MakeContextScope(const L &lambda) {
+    ContextScope<L> MakeContextScope(const L& lambda) {
         return ContextScope<L>(lambda);
     }
 } // namespace detail
@@ -1710,7 +1717,8 @@ struct DOCTEST_INTERFACE IReporter
 namespace detail {
     typedef IReporter* (*reporterCreatorFunc)(const ContextOptions&);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c,
+                                                bool isReporter);
 
     template <typename Reporter>
     IReporter* reporterCreator(const ContextOptions& o) {
@@ -1829,11 +1837,13 @@ int registerReporter(const char* name, int priority, bool isReporter) {
         struct iter<std::tuple<Type, Rest...>>                                                     \
         {                                                                                          \
             iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::detail::type_to_string<Type>(),               \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
+                doctest::detail::regTest(                                                          \
+                        doctest::detail::TestCase(                                                 \
+                                func<Type>, file, line,                                            \
+                                doctest_detail_test_suite_ns::getCurrentTestSuite(),               \
+                                doctest::detail::type_to_string<Type>(),                           \
+                                int(line) * 1000 + index) *                                        \
+                        dec);                                                                      \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
             }                                                                                      \
         };                                                                                         \
@@ -1851,16 +1861,18 @@ int registerReporter(const char* name, int priority, bool isReporter) {
                                            DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) =                                         \
-        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0));\
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = doctest::detail::instantiationHelper(   \
+            DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ > (__FILE__, __LINE__, 0));                    \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_),         \
+                                                std::tuple<__VA_ARGS__>)                           \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_),         \
+                                                __VA_ARGS__)                                       \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
@@ -1877,8 +1889,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
                doctest::detail::Subcase(__FILE__, __LINE__, std::string(__VA_ARGS__).c_str()))     \
-               DOCTEST_GCC_SUPPRESS_WARNING_POP \
-
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
@@ -2699,7 +2710,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly d
 DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
-DOCTEST_MSVC_SUPPRESS_WARNING(4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
+DOCTEST_MSVC_SUPPRESS_WARNING(
+        4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
 // static analysis
 DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
 DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
@@ -3449,7 +3461,7 @@ namespace detail {
         g_cs->shouldLogCurrentException = false;
         throw TestFailureException();
     } // NOLINT(cert-err60-cpp)
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
     void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 } // namespace detail
@@ -3527,7 +3539,7 @@ namespace detail {
             if(matchesAny(m_signature.m_name.c_str(), s->filters[7], false, s->case_sensitive))
                 return;
         }
-        
+
         // if a Subcase on the same level has already been entered
         if(s->subcasesStack.size() < size_t(s->subcasesCurrentMaxLevel)) {
             s->should_reenter = true;
@@ -3544,7 +3556,7 @@ namespace detail {
         }
 
         s->subcasesCurrentMaxLevel = s->subcasesStack.size();
-        m_entered = true;
+        m_entered                  = true;
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
     }
@@ -3889,9 +3901,7 @@ namespace detail {
 
     DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+    ContextScopeBase::ContextScopeBase() { g_infoContexts.push_back(this); }
 
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
@@ -3937,7 +3947,7 @@ namespace {
 
     struct SignalDefs
     {
-        DWORD id;
+        DWORD       id;
         const char* name;
     };
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -3981,21 +3991,21 @@ namespace {
                 SetUnhandledExceptionFilter(previousTop);
                 SetThreadStackGuarantee(&guaranteeSize);
                 previousTop = nullptr;
-                isSet = false;
+                isSet       = false;
             }
         }
 
         ~FatalConditionHandler() { reset(); }
 
     private:
-        static bool isSet;
-        static ULONG guaranteeSize;
+        static bool                         isSet;
+        static ULONG                        guaranteeSize;
         static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
-    bool FatalConditionHandler::isSet = false;
-    ULONG FatalConditionHandler::guaranteeSize = 0;
-    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
+    bool                         FatalConditionHandler::isSet         = false;
+    ULONG                        FatalConditionHandler::guaranteeSize = 0;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop   = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
@@ -4079,7 +4089,7 @@ namespace {
 #else
     // TODO: integration with XCode and other IDEs
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) // NOLINT(clang-diagnostic-unused-macros)
-#endif // Platform
+#endif                                    // Platform
 
     void addAssert(assertType::Enum at) {
         if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
@@ -4143,7 +4153,8 @@ namespace detail {
     bool ResultBuilder::log() {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+        } else if((m_at & assertType::is_throws_as) &&
+                  (m_at & assertType::is_throws_with)) { //!OCLINT
             m_failed = !m_threw_as || (m_exception != m_exception_string);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
@@ -4661,8 +4672,7 @@ namespace {
                     xml.endElement();
                     open_ts_tag = true;
                 }
-            }
-            else {
+            } else {
                 open_ts_tag = true; // first test case ==> first test suite
             }
 
@@ -4703,10 +4713,11 @@ namespace {
                             .writeAttribute("name", curr.first.second);
             } else if(opt.count || opt.list_test_cases) {
                 for(unsigned i = 0; i < in.num_data; ++i) {
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
-                        .writeAttribute("testsuite", in.data[i]->m_test_suite)
-                        .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file))
-                        .writeAttribute("line", line(in.data[i]->m_line));
+                    xml.scopedElement("TestCase")
+                            .writeAttribute("name", in.data[i]->m_name)
+                            .writeAttribute("testsuite", in.data[i]->m_test_suite)
+                            .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file))
+                            .writeAttribute("line", line(in.data[i]->m_line));
                 }
                 xml.scopedElement("OverallResultsTestCases")
                         .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
@@ -4769,7 +4780,7 @@ namespace {
             test_case_start_impl(in);
             xml.ensureTagClosed();
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -5085,9 +5096,10 @@ namespace {
 
         void printRegisteredReporters() {
             printVersion();
-            auto printReporters = [this] (const reporterMap& reporters, const char* type) {
+            auto printReporters = [this](const reporterMap& reporters, const char* type) {
                 if(reporters.size()) {
-                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
+                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered "
+                      << type << "\n";
                     for(auto& curr : reporters)
                         s << "priority: " << std::setw(5) << curr.first.first
                           << " name: " << curr.first.second << "\n";
@@ -5192,7 +5204,7 @@ namespace {
             hasLoggedCurrentTestStart = false;
             tc                        = &in;
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -5331,7 +5343,8 @@ namespace {
             file_line_to_stream(s, mb.m_file, mb.m_line, " ");
             s << getSuccessOrFailColor(false, mb.m_severity)
               << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE") << ": ";
+                                        "MESSAGE")
+              << ": ";
             s << Color::None << mb.m_string << "\n";
             log_contexts();
         }
@@ -5380,8 +5393,10 @@ namespace {
         // going from the end to the beginning and stopping on the first occurrence from the end
         for(int i = argc; i > 0; --i) {
             auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
+            auto temp  = std::strstr(argv[index], pattern);
+            if(temp &&
+               (value ||
+                strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
                 // eliminate matches in which the chars before the option are not '-'
                 bool noBadCharsFound = true;
                 auto curr            = argv[index];
@@ -5411,8 +5426,8 @@ namespace {
     }
 
     // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
+    bool parseOption(int argc, const char* const* argv, const char* pattern,
+                     String* value = nullptr, const String& defaultVal = String()) {
         if(value)
             *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -5761,7 +5776,7 @@ int Context::run() {
 
     std::set<String> testSuitesPassingFilt;
 
-    bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
     std::vector<const TestCaseData*> queryResults;
 
     if(!query_mode)
@@ -5838,7 +5853,7 @@ int Context::run() {
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
             p->timer.start();
-            
+
             bool run_test = true;
 
             do {
@@ -5875,7 +5890,7 @@ int Context::run() {
                     run_test = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
-                
+
                 if(p->should_reenter && run_test)
                     DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
                 if(!p->should_reenter)
@@ -5907,8 +5922,9 @@ int Context::run() {
     // see these issues on the reasoning for this:
     // - https://github.com/onqtam/doctest/issues/143#issuecomment-414418903
     // - https://github.com/onqtam/doctest/issues/126
-    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE
-        { std::cout << std::string(); };
+    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE {
+        std::cout << std::string();
+    };
     DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS();
 
     return cleanup_and_return();
@@ -5927,11 +5943,14 @@ const String* IReporter::get_stringified_contexts() {
 }
 
 namespace detail {
-    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
+    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c,
+                              bool isReporter) {
         if(isReporter)
-            getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+            getReporters().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
         else
-            getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+            getListeners().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
     }
 } // namespace detail
 

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -412,7 +412,13 @@ DOCTEST_STD_NAMESPACE_END
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
+
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(4365) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument X is not a string literal
+DOCTEST_MSVC_SUPPRESS_WARNING(4987) // nonstandard extension used: 'throw (...)'
 #include <string>
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
@@ -2690,6 +2696,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly d
 DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
+DOCTEST_MSVC_SUPPRESS_WARNING(4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
 // static analysis
 DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
 DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -894,8 +894,8 @@ namespace {
 } // namespace
 namespace detail {
 
-    Subcase::Subcase(const char* file, int line, std::string name)
-            : m_signature({name.c_str(), file, line}) {
+    Subcase::Subcase(const char* file, int line, String name)
+            : m_signature({std::move(name), file, line}) {
         ContextState* s = g_cs;
 
         // check subcase filters

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -658,7 +658,7 @@ bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
         return m_line < other.m_line;
     if(std::strcmp(m_file, other.m_file) != 0)
         return std::strcmp(m_file, other.m_file) < 0;
-    return m_name < other.m_name;
+    return m_name.compare(other.m_name) < 0;
 }
 
 IContextScope::IContextScope()  = default;
@@ -894,7 +894,7 @@ namespace {
 namespace detail {
 
     Subcase::Subcase(const char* file, int line, std::string name)
-            : m_signature({name, file, line}) {
+            : m_signature({name.c_str(), file, line}) {
         ContextState* s = g_cs;
 
         // check subcase filters

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -77,7 +77,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly d
 DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
-DOCTEST_MSVC_SUPPRESS_WARNING(4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
+DOCTEST_MSVC_SUPPRESS_WARNING(
+        4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
 // static analysis
 DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
 DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
@@ -827,7 +828,7 @@ namespace detail {
         g_cs->shouldLogCurrentException = false;
         throw TestFailureException();
     } // NOLINT(cert-err60-cpp)
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
     void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 } // namespace detail
@@ -905,7 +906,7 @@ namespace detail {
             if(matchesAny(m_signature.m_name.c_str(), s->filters[7], false, s->case_sensitive))
                 return;
         }
-        
+
         // if a Subcase on the same level has already been entered
         if(s->subcasesStack.size() < size_t(s->subcasesCurrentMaxLevel)) {
             s->should_reenter = true;
@@ -922,7 +923,7 @@ namespace detail {
         }
 
         s->subcasesCurrentMaxLevel = s->subcasesStack.size();
-        m_entered = true;
+        m_entered                  = true;
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
     }
@@ -1267,9 +1268,7 @@ namespace detail {
 
     DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+    ContextScopeBase::ContextScopeBase() { g_infoContexts.push_back(this); }
 
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
@@ -1315,7 +1314,7 @@ namespace {
 
     struct SignalDefs
     {
-        DWORD id;
+        DWORD       id;
         const char* name;
     };
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -1359,21 +1358,21 @@ namespace {
                 SetUnhandledExceptionFilter(previousTop);
                 SetThreadStackGuarantee(&guaranteeSize);
                 previousTop = nullptr;
-                isSet = false;
+                isSet       = false;
             }
         }
 
         ~FatalConditionHandler() { reset(); }
 
     private:
-        static bool isSet;
-        static ULONG guaranteeSize;
+        static bool                         isSet;
+        static ULONG                        guaranteeSize;
         static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
-    bool FatalConditionHandler::isSet = false;
-    ULONG FatalConditionHandler::guaranteeSize = 0;
-    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
+    bool                         FatalConditionHandler::isSet         = false;
+    ULONG                        FatalConditionHandler::guaranteeSize = 0;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop   = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
@@ -1457,7 +1456,7 @@ namespace {
 #else
     // TODO: integration with XCode and other IDEs
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) // NOLINT(clang-diagnostic-unused-macros)
-#endif // Platform
+#endif                                    // Platform
 
     void addAssert(assertType::Enum at) {
         if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
@@ -1521,7 +1520,8 @@ namespace detail {
     bool ResultBuilder::log() {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+        } else if((m_at & assertType::is_throws_as) &&
+                  (m_at & assertType::is_throws_with)) { //!OCLINT
             m_failed = !m_threw_as || (m_exception != m_exception_string);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
@@ -2039,8 +2039,7 @@ namespace {
                     xml.endElement();
                     open_ts_tag = true;
                 }
-            }
-            else {
+            } else {
                 open_ts_tag = true; // first test case ==> first test suite
             }
 
@@ -2081,10 +2080,11 @@ namespace {
                             .writeAttribute("name", curr.first.second);
             } else if(opt.count || opt.list_test_cases) {
                 for(unsigned i = 0; i < in.num_data; ++i) {
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
-                        .writeAttribute("testsuite", in.data[i]->m_test_suite)
-                        .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file))
-                        .writeAttribute("line", line(in.data[i]->m_line));
+                    xml.scopedElement("TestCase")
+                            .writeAttribute("name", in.data[i]->m_name)
+                            .writeAttribute("testsuite", in.data[i]->m_test_suite)
+                            .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file))
+                            .writeAttribute("line", line(in.data[i]->m_line));
                 }
                 xml.scopedElement("OverallResultsTestCases")
                         .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
@@ -2147,7 +2147,7 @@ namespace {
             test_case_start_impl(in);
             xml.ensureTagClosed();
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -2463,9 +2463,10 @@ namespace {
 
         void printRegisteredReporters() {
             printVersion();
-            auto printReporters = [this] (const reporterMap& reporters, const char* type) {
+            auto printReporters = [this](const reporterMap& reporters, const char* type) {
                 if(reporters.size()) {
-                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
+                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered "
+                      << type << "\n";
                     for(auto& curr : reporters)
                         s << "priority: " << std::setw(5) << curr.first.first
                           << " name: " << curr.first.second << "\n";
@@ -2570,7 +2571,7 @@ namespace {
             hasLoggedCurrentTestStart = false;
             tc                        = &in;
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -2709,7 +2710,8 @@ namespace {
             file_line_to_stream(s, mb.m_file, mb.m_line, " ");
             s << getSuccessOrFailColor(false, mb.m_severity)
               << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE") << ": ";
+                                        "MESSAGE")
+              << ": ";
             s << Color::None << mb.m_string << "\n";
             log_contexts();
         }
@@ -2758,8 +2760,10 @@ namespace {
         // going from the end to the beginning and stopping on the first occurrence from the end
         for(int i = argc; i > 0; --i) {
             auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
+            auto temp  = std::strstr(argv[index], pattern);
+            if(temp &&
+               (value ||
+                strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
                 // eliminate matches in which the chars before the option are not '-'
                 bool noBadCharsFound = true;
                 auto curr            = argv[index];
@@ -2789,8 +2793,8 @@ namespace {
     }
 
     // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
+    bool parseOption(int argc, const char* const* argv, const char* pattern,
+                     String* value = nullptr, const String& defaultVal = String()) {
         if(value)
             *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -3139,7 +3143,7 @@ int Context::run() {
 
     std::set<String> testSuitesPassingFilt;
 
-    bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
     std::vector<const TestCaseData*> queryResults;
 
     if(!query_mode)
@@ -3216,7 +3220,7 @@ int Context::run() {
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
             p->timer.start();
-            
+
             bool run_test = true;
 
             do {
@@ -3253,7 +3257,7 @@ int Context::run() {
                     run_test = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
-                
+
                 if(p->should_reenter && run_test)
                     DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
                 if(!p->should_reenter)
@@ -3285,8 +3289,9 @@ int Context::run() {
     // see these issues on the reasoning for this:
     // - https://github.com/onqtam/doctest/issues/143#issuecomment-414418903
     // - https://github.com/onqtam/doctest/issues/126
-    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE
-        { std::cout << std::string(); };
+    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE {
+        std::cout << std::string();
+    };
     DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS();
 
     return cleanup_and_return();
@@ -3305,11 +3310,14 @@ const String* IReporter::get_stringified_contexts() {
 }
 
 namespace detail {
-    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
+    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c,
+                              bool isReporter) {
         if(isReporter)
-            getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+            getReporters().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
         else
-            getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+            getListeners().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
     }
 } // namespace detail
 

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -658,7 +658,7 @@ bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
         return m_line < other.m_line;
     if(std::strcmp(m_file, other.m_file) != 0)
         return std::strcmp(m_file, other.m_file) < 0;
-    return std::strcmp(m_name, other.m_name) < 0;
+    return m_name < other.m_name;
 }
 
 IContextScope::IContextScope()  = default;
@@ -893,15 +893,15 @@ namespace {
 } // namespace
 namespace detail {
 
-    Subcase::Subcase(const char* name, const char* file, int line)
+    Subcase::Subcase(const char* file, int line, std::string name)
             : m_signature({name, file, line}) {
         ContextState* s = g_cs;
 
         // check subcase filters
         if(s->subcasesStack.size() < size_t(s->subcase_filter_levels)) {
-            if(!matchesAny(m_signature.m_name, s->filters[6], true, s->case_sensitive))
+            if(!matchesAny(m_signature.m_name.c_str(), s->filters[6], true, s->case_sensitive))
                 return;
-            if(matchesAny(m_signature.m_name, s->filters[7], false, s->case_sensitive))
+            if(matchesAny(m_signature.m_name.c_str(), s->filters[7], false, s->case_sensitive))
                 return;
         }
         

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -77,6 +77,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly d
 DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
+DOCTEST_MSVC_SUPPRESS_WARNING(4061) // enumerator 'X' in switch of enum 'Y' is not explicitly handled by a case label
 // static analysis
 DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
 DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -672,7 +672,7 @@ struct DOCTEST_INTERFACE MessageData
 
 struct DOCTEST_INTERFACE SubcaseSignature
 {
-    std::string m_name;
+    String      m_name;
     const char* m_file;
     int         m_line;
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1000,7 +1000,7 @@ namespace detail {
         SubcaseSignature m_signature;
         bool             m_entered = false;
 
-        Subcase(const char* file, int line, std::string name);
+        Subcase(const char* file, int line, String name);
         ~Subcase();
 
         operator bool() const;
@@ -1870,9 +1870,12 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(...)                                                                      \
+#define DOCTEST_SUBCASE(...)                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-               doctest::detail::Subcase(__FILE__, __LINE__, __VA_ARGS__))
+               doctest::detail::Subcase(__FILE__, __LINE__, std::string(__VA_ARGS__).c_str()))     \
+               DOCTEST_GCC_SUPPRESS_WARNING_POP \
+
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -386,7 +386,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
 DOCTEST_STD_NAMESPACE_BEGIN // NOLINT (cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t;
+        typedef decltype(nullptr) nullptr_t;
 template <class charT>
 struct char_traits;
 template <>
@@ -584,7 +584,7 @@ namespace assertType {
         DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
         DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
         DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
-        
+
         DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
         DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
         DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
@@ -993,7 +993,8 @@ namespace detail {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
     [[noreturn]]
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    DOCTEST_INTERFACE void throwException();
+    DOCTEST_INTERFACE void
+    throwException();
 
     struct DOCTEST_INTERFACE Subcase
     {
@@ -1266,8 +1267,10 @@ namespace detail {
     DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
     DOCTEST_INTERFACE bool isDebuggerActive();
 
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+    template <typename T>
+    int instantiationHelper(const T&) {
+        return 0;
+    }
 
     namespace binaryAssertComparison {
         enum Enum
@@ -1484,23 +1487,27 @@ namespace detail {
     DOCTEST_INTERFACE void toStream(std::ostream* s, int long long in);
     DOCTEST_INTERFACE void toStream(std::ostream* s, int long long unsigned in);
 
-    // ContextScope base class used to allow implementing methods of ContextScope 
+    // ContextScope base class used to allow implementing methods of ContextScope
     // that don't depend on the template parameter in doctest.cpp.
-    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope
+    {
     protected:
         ContextScopeBase();
 
         void destroy();
     };
 
-    template <typename L> class ContextScope : public ContextScopeBase
+    template <typename L>
+    class ContextScope : public ContextScopeBase
     {
-        const L &lambda_;
+        const L& lambda_;
 
     public:
-        explicit ContextScope(const L &lambda) : lambda_(lambda) {}
+        explicit ContextScope(const L& lambda)
+                : lambda_(lambda) {}
 
-        ContextScope(ContextScope &&other) : lambda_(other.lambda_) {}
+        ContextScope(ContextScope&& other)
+                : lambda_(other.lambda_) {}
 
         void stringify(std::ostream* s) const override { lambda_(s); }
 
@@ -1524,9 +1531,9 @@ namespace detail {
         bool log();
         void react();
     };
-    
+
     template <typename L>
-    ContextScope<L> MakeContextScope(const L &lambda) {
+    ContextScope<L> MakeContextScope(const L& lambda) {
         return ContextScope<L>(lambda);
     }
 } // namespace detail
@@ -1707,7 +1714,8 @@ struct DOCTEST_INTERFACE IReporter
 namespace detail {
     typedef IReporter* (*reporterCreatorFunc)(const ContextOptions&);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c,
+                                                bool isReporter);
 
     template <typename Reporter>
     IReporter* reporterCreator(const ContextOptions& o) {
@@ -1826,11 +1834,13 @@ int registerReporter(const char* name, int priority, bool isReporter) {
         struct iter<std::tuple<Type, Rest...>>                                                     \
         {                                                                                          \
             iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::detail::type_to_string<Type>(),               \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
+                doctest::detail::regTest(                                                          \
+                        doctest::detail::TestCase(                                                 \
+                                func<Type>, file, line,                                            \
+                                doctest_detail_test_suite_ns::getCurrentTestSuite(),               \
+                                doctest::detail::type_to_string<Type>(),                           \
+                                int(line) * 1000 + index) *                                        \
+                        dec);                                                                      \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
             }                                                                                      \
         };                                                                                         \
@@ -1848,16 +1858,18 @@ int registerReporter(const char* name, int priority, bool isReporter) {
                                            DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) =                                         \
-        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0));\
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = doctest::detail::instantiationHelper(   \
+            DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ > (__FILE__, __LINE__, 0));                    \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_),         \
+                                                std::tuple<__VA_ARGS__>)                           \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_),         \
+                                                __VA_ARGS__)                                       \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
@@ -1874,8 +1886,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
                doctest::detail::Subcase(__FILE__, __LINE__, std::string(__VA_ARGS__).c_str()))     \
-               DOCTEST_GCC_SUPPRESS_WARNING_POP \
-
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -409,7 +409,13 @@ DOCTEST_STD_NAMESPACE_END
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
+
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(4365) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument X is not a string literal
+DOCTEST_MSVC_SUPPRESS_WARNING(4987) // nonstandard extension used: 'throw (...)'
 #include <string>
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -409,6 +409,7 @@ DOCTEST_STD_NAMESPACE_END
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
+#include <string>
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
@@ -671,7 +672,7 @@ struct DOCTEST_INTERFACE MessageData
 
 struct DOCTEST_INTERFACE SubcaseSignature
 {
-    const char* m_name;
+    std::string m_name;
     const char* m_file;
     int         m_line;
 
@@ -993,7 +994,7 @@ namespace detail {
         SubcaseSignature m_signature;
         bool             m_entered = false;
 
-        Subcase(const char* name, const char* file, int line);
+        Subcase(const char* file, int line, std::string name);
         ~Subcase();
 
         operator bool() const;
@@ -1863,9 +1864,9 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(name)                                                                      \
+#define DOCTEST_SUBCASE(...)                                                                      \
     if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-               doctest::detail::Subcase(name, __FILE__, __LINE__))
+               doctest::detail::Subcase(__FILE__, __LINE__, __VA_ARGS__))
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -410,13 +410,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
-DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4365) // signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument X is not a string literal
-DOCTEST_MSVC_SUPPRESS_WARNING(4987) // nonstandard extension used: 'throw (...)'
-#include <string>
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS

--- a/examples/all_features/alternative_macros.cpp
+++ b/examples/all_features/alternative_macros.cpp
@@ -1,6 +1,8 @@
 #include "doctest_proxy.h"
 
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <string>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 my_testcase("custom macros") {
     my_check(1 == 1);

--- a/examples/all_features/alternative_macros.cpp
+++ b/examples/all_features/alternative_macros.cpp
@@ -1,5 +1,7 @@
 #include "doctest_proxy.h"
 
+#include <string>
+
 my_testcase("custom macros") {
     my_check(1 == 1);
     

--- a/examples/all_features/subcases.cpp
+++ b/examples/all_features/subcases.cpp
@@ -10,7 +10,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 TEST_CASE("lots of nested subcases") {
     cout << endl << "root" << endl;
-    SUBCASE("" + 1) {
+    SUBCASE("" + std::string("1")) {
         cout << "1" << endl;
         SUBCASE("") { cout << "1.1" << endl; }
     }

--- a/examples/all_features/subcases.cpp
+++ b/examples/all_features/subcases.cpp
@@ -4,6 +4,7 @@
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <iostream>
+#include <string>
 #include <vector>
 using namespace std;
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END

--- a/examples/all_features/subcases.cpp
+++ b/examples/all_features/subcases.cpp
@@ -10,7 +10,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 TEST_CASE("lots of nested subcases") {
     cout << endl << "root" << endl;
-    SUBCASE("") {
+    SUBCASE("" + 1) {
         cout << "1" << endl;
         SUBCASE("") { cout << "1.1" << endl; }
     }

--- a/examples/all_features/test_output/subcases.cpp_xml.txt
+++ b/examples/all_features/test_output/subcases.cpp_xml.txt
@@ -5,7 +5,7 @@
     <TestCase name="lots of nested subcases" filename="subcases.cpp" line="0">
 
 root
-      <SubCase name="&lt;doctest::String>" filename="subcases.cpp" line="0">
+      <SubCase name="1" filename="subcases.cpp" line="0">
 1
         <SubCase filename="subcases.cpp" line="0">
 1.1

--- a/examples/all_features/test_output/subcases.cpp_xml.txt
+++ b/examples/all_features/test_output/subcases.cpp_xml.txt
@@ -5,7 +5,7 @@
     <TestCase name="lots of nested subcases" filename="subcases.cpp" line="0">
 
 root
-      <SubCase filename="subcases.cpp" line="0">
+      <SubCase name="&lt;doctest::String>" filename="subcases.cpp" line="0">
 1
         <SubCase filename="subcases.cpp" line="0">
 1.1

--- a/examples/executable_dll_and_plugin/plugin.cpp
+++ b/examples/executable_dll_and_plugin/plugin.cpp
@@ -3,6 +3,7 @@
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <cstdio>
+#include <string>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 // most of these are used here just to test that they compile successfully from within a plugin


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 headers in the doctest/parts/ folder.
-->


## Description
Allow SUBCASE to use std::string operators

## GitHub Issues
We're trying to convert from Catch2 to doctest, and have a lot of cases like this:
`SUBCASE("Test " + name) {}`
Where name is a std::string. This works fine in Catch2 and I'd like to do the same in doctest.
