### PR TITLE
Fix GitHub CI and add GitHub build badges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,16 +46,16 @@ jobs:
           windows-2019-clang-cl,
           windows-2019-clang,
           windows-2019-gcc,
-          macOS-10.14-xcode-9.4.1,
-          macOS-10.14-xcode-10.0,
-          macOS-10.14-xcode-10.1,
-          macOS-10.14-xcode-10.2,
-          macOS-10.14-xcode-10.2.1,
-          macOS-10.14-xcode-10.3,
-          macOS-10.14-xcode-11.0,
-          macOS-10.14-gcc-7,
-          macOS-10.14-gcc-8,
-          macOS-10.14-gcc-9,
+          macOS-latest-xcode-9.4.1,
+          macOS-latest-xcode-10.0,
+          macOS-latest-xcode-10.1,
+          macOS-latest-xcode-10.2,
+          macOS-latest-xcode-10.2.1,
+          macOS-latest-xcode-10.3,
+          macOS-latest-xcode-11.0,
+          macOS-latest-gcc-7,
+          macOS-latest-gcc-8,
+          macOS-latest-gcc-9,
         ]
 
         include:
@@ -181,53 +181,53 @@ jobs:
             os: windows-2019
             compiler: gcc
 
-          - name: macOS-10.14-xcode-9.4.1
-            os: macOS-10.14
+          - name: macOS-latest-xcode-9.4.1
+            os: macOS-latest
             compiler: xcode
             version: "9.4.1"
 
-          - name: macOS-10.14-xcode-10.0
-            os: macOS-10.14
+          - name: macOS-latest-xcode-10.0
+            os: macOS-latest
             compiler: xcode
             version: "10"
 
-          - name: macOS-10.14-xcode-10.1
-            os: macOS-10.14
+          - name: macOS-latest-xcode-10.1
+            os: macOS-latest
             compiler: xcode
             version: "10.1"
 
-          - name: macOS-10.14-Xcode-10.2
-            os: macOS-10.14
+          - name: macOS-latest-Xcode-10.2
+            os: macOS-latest
             compiler: xcode
             version: "10.2"
 
-          - name: macOS-10.14-xcode-10.2.1
-            os: macOS-10.14
+          - name: macOS-latest-xcode-10.2.1
+            os: macOS-latest
             compiler: xcode
             version: "10.2.1"
 
-          - name: macOS-10.14-xcode-10.3
-            os: macOS-10.14
+          - name: macOS-latest-xcode-10.3
+            os: macOS-latest
             compiler: xcode
             version: "10.3"
 
-          - name: macOS-10.14-xcode-11.0
-            os: macOS-10.14
+          - name: macOS-latest-xcode-11.0
+            os: macOS-latest
             compiler: xcode
             version: "11"
 
-          - name: macOS-10.14-gcc-7
-            os: macOS-10.14
+          - name: macOS-latest-gcc-7
+            os: macOS-latest
             compiler: gcc
             version: "7"
 
-          - name: macOS-10.14-gcc-8
-            os: macOS-10.14
+          - name: macOS-latest-gcc-8
+            os: macOS-latest
             compiler: gcc
             version: "8"
 
-          - name: macOS-10.14-gcc-9
-            os: macOS-10.14
+          - name: macOS-latest-gcc-9
+            os: macOS-latest
             compiler: gcc
             version: "9"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,14 +409,16 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Release x64
         run: |
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       # Valgrind doesn't support the latest macOS versions.
       # `-DCMAKE_CXX_FLAGS=""` overrides CXXFLAGS (disables sanitizers).
@@ -427,7 +429,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="" -DDOCTEST_TEST_MODE=VALGRIND
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Release x64 Valgrind
         if: runner.os == 'Linux'
@@ -435,7 +438,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="" -DDOCTEST_TEST_MODE=VALGRIND
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Debug x64 Thread Sanitizers
         if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -443,7 +447,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="$TSAN_FLAGS" -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Debug x64 without RTTI
         if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -451,7 +456,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fno-rtti" -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build x64 Debug without exceptions
         if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -481,7 +487,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Release x86
         if: (runner.os == 'Windows' && matrix.compiler != 'gcc') || runner.os == 'Linux'
@@ -489,7 +496,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DDOCTEST_TEST_MODE=COMPARE
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Debug x86 Valgrind
         if: runner.os == 'Linux'
@@ -497,7 +505,8 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-m32" -DDOCTEST_TEST_MODE=VALGRIND
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest
 
       - name: Build & Test Release x86 Valgrind
         if: runner.os == 'Linux'
@@ -505,4 +514,5 @@ jobs:
           cmake -E remove_directory build
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-m32" -DDOCTEST_TEST_MODE=VALGRIND
           cmake --build build
-          cd build && ctest
+          cd build
+          ctest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
           - name: macOS-latest-xcode-11.0
             os: macOS-latest
             compiler: xcode
-            version: "11.0"
+            version: "11"
 
           - name: macOS-latest-xcode-11.3
             os: macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
           windows-2019-clang,
           windows-2019-gcc,
           macOS-latest-xcode-11.0,
+          macOS-latest-xcode-11.3,
         ]
 
         include:
@@ -175,7 +176,12 @@ jobs:
           - name: macOS-latest-xcode-11.0
             os: macOS-latest
             compiler: xcode
-            version: "11"
+            version: "11.0"
+
+          - name: macOS-latest-xcode-11.3
+            os: macOS-latest
+            compiler: xcode
+            version: "11.3"
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,6 +281,7 @@ jobs:
             echo "::set-env name=CC::gcc-${{ matrix.version }}"
             echo "::set-env name=CXX::g++-${{ matrix.version }}"
           else
+            ls -ls /Applications/
             sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
             echo "::set-env name=CC::clang"
             echo "::set-env name=CXX::clang++"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,16 +46,7 @@ jobs:
           windows-2019-clang-cl,
           windows-2019-clang,
           windows-2019-gcc,
-          macOS-latest-xcode-9.4.1,
-          macOS-latest-xcode-10.0,
-          macOS-latest-xcode-10.1,
-          macOS-latest-xcode-10.2,
-          macOS-latest-xcode-10.2.1,
-          macOS-latest-xcode-10.3,
           macOS-latest-xcode-11.0,
-          macOS-latest-gcc-7,
-          macOS-latest-gcc-8,
-          macOS-latest-gcc-9,
         ]
 
         include:
@@ -181,55 +172,10 @@ jobs:
             os: windows-2019
             compiler: gcc
 
-          - name: macOS-latest-xcode-9.4.1
-            os: macOS-latest
-            compiler: xcode
-            version: "9.4.1"
-
-          - name: macOS-latest-xcode-10.0
-            os: macOS-latest
-            compiler: xcode
-            version: "10"
-
-          - name: macOS-latest-xcode-10.1
-            os: macOS-latest
-            compiler: xcode
-            version: "10.1"
-
-          - name: macOS-latest-Xcode-10.2
-            os: macOS-latest
-            compiler: xcode
-            version: "10.2"
-
-          - name: macOS-latest-xcode-10.2.1
-            os: macOS-latest
-            compiler: xcode
-            version: "10.2.1"
-
-          - name: macOS-latest-xcode-10.3
-            os: macOS-latest
-            compiler: xcode
-            version: "10.3"
-
           - name: macOS-latest-xcode-11.0
             os: macOS-latest
             compiler: xcode
             version: "11"
-
-          - name: macOS-latest-gcc-7
-            os: macOS-latest
-            compiler: gcc
-            version: "7"
-
-          - name: macOS-latest-gcc-8
-            os: macOS-latest
-            compiler: gcc
-            version: "8"
-
-          - name: macOS-latest-gcc-9
-            os: macOS-latest
-            compiler: gcc
-            version: "9"
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
             Windows <a href="https://ci.appveyor.com/project/onqtam/doctest/branch/master"><img src="https://ci.appveyor.com/api/projects/status/j89qxtahyw1dp4gd/branch/master?svg=true"></a>
         </td>
         <td>
+            All <a href="https://github.com/onqtam/doctest/actions?query=branch%3Amaster"><img src="https://github.com/onqtam/doctest/workflows/CI/badge.svg?branch=master"></a>
+        </td>
+        <td>
             <a href="https://coveralls.io/github/onqtam/doctest?branch=master"><img src="https://coveralls.io/repos/github/onqtam/doctest/badge.svg?branch=master"></a>
         </td>
         <td>
@@ -27,6 +30,9 @@
         </td>
         <td>
             Windows <a href="https://ci.appveyor.com/project/onqtam/doctest/branch/dev"><img src="https://ci.appveyor.com/api/projects/status/j89qxtahyw1dp4gd/branch/dev?svg=true"></a>
+        </td>
+        <td>
+            All <a href="https://github.com/onqtam/doctest/actions?query=branch%3Adev"><img src="https://github.com/onqtam/doctest/workflows/CI/badge.svg?branch=dev"></a>
         </td>
         <td>
             <a href="https://coveralls.io/github/onqtam/doctest?branch=dev"><img src="https://coveralls.io/repos/github/onqtam/doctest/badge.svg?branch=dev"></a>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -2751,7 +2751,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
-#include <windows.h>
+#include <Windows.h>
 #endif
 #include <io.h>
 

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -139,7 +139,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
-#include <windows.h>
+#include <Windows.h>
 #endif
 #include <io.h>
 

--- a/examples/executable_dll_and_plugin/main.cpp
+++ b/examples/executable_dll_and_plugin/main.cpp
@@ -24,7 +24,7 @@ TEST_CASE("executable") {
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
-#include <windows.h>
+#include <Windows.h>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #ifdef _MSC_VER
 #define LoadDynamicLib(lib) LoadLibrary(lib ".dll")


### PR DESCRIPTION
## Description

Fixed the GitHub actions builds, so that any future breakages in them are easy to spot.

Changes made:

* Remove macos xcode versions that are no longer supported by GitHub
* Add xcode 11.3
* Leave in an 'ls' command to debug future xcode version changes
* Split 'cd build && ctest' which broke all Windows builds
* Add github actions build pages to README
* Fix case of `<Windows.h>` to fix clang Windows builds 

## GitHub Issues

* Replaces #335
* Should fix #334
