### PR TITLE
Print subcase stack upon a subcase entry

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5268,6 +5268,12 @@ namespace {
             std::lock_guard<std::mutex> lock(mutex);
             subcasesStack.push_back(subc);
             hasLoggedCurrentTestStart = false;
+
+            s << Color::Cyan << "[doctest] SUBCASE" << Color::None << "\n";
+            for(auto& curr : subcasesStack)
+                if(curr.m_name[0] != '\0')
+                    s << " - " << Color::LightGrey << curr.m_name << Color::None << " (" << curr.m_file << ":" << curr.m_line << ")\n";
+            s << "\n";
         }
 
         void subcase_end() override {

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -2656,6 +2656,12 @@ namespace {
             std::lock_guard<std::mutex> lock(mutex);
             subcasesStack.push_back(subc);
             hasLoggedCurrentTestStart = false;
+
+            s << Color::Cyan << "[doctest] SUBCASE" << Color::None << "\n";
+            for(auto& curr : subcasesStack)
+                if(curr.m_name[0] != '\0')
+                    s << " - " << Color::LightGrey << curr.m_name << Color::None << " (" << curr.m_file << ":" << curr.m_line << ")\n";
+            s << "\n";
         }
 
         void subcase_end() override {


### PR DESCRIPTION
This is largely a hack to give us at least *something* for data driven testing (#215). In that pattern, it's common to structure code in a way that first "generates the data", and only then executes the actual test. It can look like this:

```c++
  TEST_CASE("parsing stuff") {
    std::string input;
    Something expected;

    DOCTEST_SUBCASE("single-line") {
      DOCTEST_SUBCASE("empty") {}
      DOCTEST_SUBCASE("trivial") {
        input = "create foo";
	expected = {OP_CREATE, {"foo",}};
      }
      DOCTEST_SUBCASE("two args") {
        input = "create blah bar";
	expected = {OP_CREATE, {"blah", "bar",}};
      }
    }
    DOCTEST_SUBCASE("multi-line") {
      DOCTEST_SUBCASE("trailing whitespace") {
        input = "create foo\n\n";
	expected = {OP_CREATE, {"foo,}};
      }
      DOCTEST_SUBCASE("one word per line, two words") {
        input = "create\nfoo";
	expected = {OP_CREATE, {"foo",}};
      }
    }

    REQUIRE(parse(input) == expected);
  }
```

The important part is that once we're executing actual tests, the subsections will have been exited already, so the usual ways of showing the subcase stack can be no longer applied.

In Catch2, there was a patch which tried to track the deepest subcase stack so far. Let's try to implement something very simple, just printing the current state of the stack once it is entered. It does not tie into any error handling, so the output will be always there, and it also probably does not support any fancy filtering when skipping subcases. However, it's something which at least shows what is going on when an error gets reported.

Cc: https://github.com/onqtam/doctest/issues/215
Cc: https://github.com/onqtam/doctest/issues/125
Cc: @syyyr