### PR TITLE
Fix issue template to mention doctest instead of Catch

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -13,7 +13,7 @@ want it.
 This is only relevant for bug reports, but if you do have one,
 please provide a minimal set of steps to reproduce the problem.
 
-Usually this means providing a small and self-contained code using Catch
+Usually this means providing a small and self-contained code using doctest
 and specifying compiler flags/tools used if relevant.
 -->
 


### PR DESCRIPTION
Should this go to master or dev branch?

This only changes the issue template, not the repo. Also Github complains about the issue template:

> You are using an old version of issue templates. Please update to the new issue template workflow. [Learn more](https://help.github.com/articles/about-issue-and-pull-request-templates)