### PR TITLE
Add a note that doctest can be installed through Homebrew

### DIFF
--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -74,6 +74,7 @@ target_link_libraries(my_tests doctest)
 - conan
     - https://bintray.com/bincrafters/public-conan/doctest:bincrafters
     - https://bintray.com/mmha/conan/doctest%3Ammha
+- Homebrew (`brew install doctest`)
 
 ---
 


### PR DESCRIPTION
A Homebrew package was added recently (https://github.com/Homebrew/homebrew-core/pull/56464).
