### PR TITLE
fix google's death test URI in roadmap

### DIFF
--- a/doc/markdown/roadmap.md
+++ b/doc/markdown/roadmap.md
@@ -95,7 +95,7 @@ Planned features for future releases - order changes constantly... Also look thr
 - support for LibIdentify
 - add CHECKED_IF & friends: https://github.com/catchorg/Catch2/issues/1278
 - support for running tests in parallel in multiple threads
-- death tests - as in [google test](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#death-tests)
+- death tests - as in [google test](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests)
 - config options
     - test case name uniqueness - reject the ones with identical names
 - command line options


### PR DESCRIPTION
Old URI became 404 not found.