### PR TITLE
summary: align even large values #402

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5454,25 +5454,28 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
             separator_to_stream();
             s << std::dec;
 
+            auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+            auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+            auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
                                                                           Color::Green)
-              << std::setw(6) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
+              << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
               << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(6) << p.numTestCasesFailed << " failed" << Color::None << " | ";
+              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
             if(opt.no_skipped_summary == false) {
                 const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped
+                s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
                   << " skipped" << Color::None;
             }
             s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
               << p.numAsserts << " | "
               << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(6) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
+              << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
               << p.numAssertsFailed << " failed" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
               << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -2843,25 +2843,28 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
             separator_to_stream();
             s << std::dec;
 
+            auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+            auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+            auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
                                                                           Color::Green)
-              << std::setw(6) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
+              << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
               << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(6) << p.numTestCasesFailed << " failed" << Color::None << " | ";
+              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
             if(opt.no_skipped_summary == false) {
                 const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped
+                s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
                   << " skipped" << Color::None;
             }
             s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
               << p.numAsserts << " | "
               << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(6) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
+              << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
               << p.numAssertsFailed << " failed" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
               << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)

--- a/examples/all_features/test_output/abort_after.txt
+++ b/examples/all_features/test_output/abort_after.txt
@@ -13,7 +13,7 @@ coverage_maxout.cpp(0): ERROR: CHECK( str.compare("omgomgomg", false) != 0 ) is 
 
 Aborting - too many failed asserts!
 ===============================================================================
-[doctest] test cases:      1 |      0 passed |      1 failed | 
-[doctest] assertions:      7 |      5 passed |      2 failed |
+[doctest] test cases: 1 | 0 passed | 1 failed |
+[doctest] assertions: 7 | 5 passed | 2 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/all_binary.txt
+++ b/examples/all_features/test_output/all_binary.txt
@@ -76,7 +76,7 @@ assertion_macros.cpp(0): SUCCESS: REQUIRE_UNARY_FALSE( 0 ) is correct!
   values: REQUIRE_UNARY_FALSE( 0 )
 
 ===============================================================================
-[doctest] test cases:      1 |      1 passed |      0 failed | 
-[doctest] assertions:     16 |     16 passed |      0 failed |
+[doctest] test cases:  1 |  1 passed | 0 failed |
+[doctest] assertions: 16 | 16 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/alternative_macros.cpp.txt
+++ b/examples/all_features/test_output/alternative_macros.cpp.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      1 |      1 passed |      0 failed | 
-[doctest] assertions:      6 |      6 passed |      0 failed |
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 6 | 6 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/assertion_macros.cpp.txt
+++ b/examples/all_features/test_output/assertion_macros.cpp.txt
@@ -198,7 +198,7 @@ TEST CASE:  some asserts used in a function called by a test case
 assertion_macros.cpp(0): ERROR: CHECK_THROWS_WITH_AS( throw_if(true, false), "unknown exception", int ) threw a DIFFERENT exception! (contents: "unknown exception")
 
 ===============================================================================
-[doctest] test cases:     21 |      3 passed |     18 failed | 
-[doctest] assertions:     74 |     35 passed |     39 failed |
+[doctest] test cases: 21 |  3 passed | 18 failed |
+[doctest] assertions: 74 | 35 passed | 39 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/asserts_used_outside_of_tests.cpp.txt
+++ b/examples/all_features/test_output/asserts_used_outside_of_tests.cpp.txt
@@ -1,7 +1,7 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.
 asserts_used_outside_of_tests.cpp(19): ERROR: CHECK_EQ( true, false ) is NOT correct!

--- a/examples/all_features/test_output/coverage_maxout.cpp.txt
+++ b/examples/all_features/test_output/coverage_maxout.cpp.txt
@@ -55,7 +55,7 @@ TEST CASE:  will end from an unknown exception
 coverage_maxout.cpp(0): ERROR: test case THREW exception: unknown exception
 
 ===============================================================================
-[doctest] test cases:      4 |      0 passed |      4 failed | 
-[doctest] assertions:     31 |     22 passed |      9 failed |
+[doctest] test cases:  4 |  0 passed | 4 failed |
+[doctest] assertions: 31 | 22 passed | 9 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/doctest_proxy.h.txt
+++ b/examples/all_features/test_output/doctest_proxy.h.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_1.txt
+++ b/examples/all_features/test_output/filter_1.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed |     78 skipped
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed | 78 skipped
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_3.txt
+++ b/examples/all_features/test_output/filter_3.txt
@@ -27,7 +27,7 @@ DEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):
 subcases.cpp(0): MESSAGE: lala
 
 ===============================================================================
-[doctest] test cases:      7 |      7 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 7 | 7 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/first_last.txt
+++ b/examples/all_features/test_output/first_last.txt
@@ -21,7 +21,7 @@ TEST CASE:  will end from an unknown exception
 coverage_maxout.cpp(0): ERROR: test case THREW exception: unknown exception
 
 ===============================================================================
-[doctest] test cases:      4 |      1 passed |      3 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 4 | 1 passed | 3 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/header.h.txt
+++ b/examples/all_features/test_output/header.h.txt
@@ -19,7 +19,7 @@ TEST CASE:  template 2<doctest::String>
 header.h(0): FATAL ERROR: 
 
 ===============================================================================
-[doctest] test cases:      4 |      1 passed |      3 failed | 
-[doctest] assertions:      4 |      1 passed |      3 failed |
+[doctest] test cases: 4 | 1 passed | 3 failed |
+[doctest] assertions: 4 | 1 passed | 3 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/logging.cpp.txt
+++ b/examples/all_features/test_output/logging.cpp.txt
@@ -77,7 +77,7 @@ TEST CASE:  explicit failures 2
 logging.cpp(0): FATAL ERROR: fail the test case and also end it
 
 ===============================================================================
-[doctest] test cases:      6 |      0 passed |      6 failed | 
-[doctest] assertions:     11 |      0 passed |     11 failed |
+[doctest] test cases:  6 | 0 passed |  6 failed |
+[doctest] assertions: 11 | 0 passed | 11 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/main.cpp.txt
+++ b/examples/all_features/test_output/main.cpp.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      1 |      1 passed |      0 failed | 
-[doctest] assertions:      1 |      1 passed |      0 failed |
+[doctest] test cases: 1 | 1 passed | 0 failed |
+[doctest] assertions: 1 | 1 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/order_1.txt
+++ b/examples/all_features/test_output/order_1.txt
@@ -102,7 +102,7 @@ test_cases_and_suites.cpp(0): MESSAGE: failing because of the timeout decorator!
 
 Test case exceeded time limit of 0.000001!
 ===============================================================================
-[doctest] test cases:     15 |      5 passed |     10 failed | 
-[doctest] assertions:     12 |      1 passed |     11 failed |
+[doctest] test cases: 15 | 5 passed | 10 failed |
+[doctest] assertions: 12 | 1 passed | 11 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/order_2.txt
+++ b/examples/all_features/test_output/order_2.txt
@@ -95,7 +95,7 @@ TEST CASE:  unskipped
 test_cases_and_suites.cpp(0): FATAL ERROR: 
 
 ===============================================================================
-[doctest] test cases:     14 |      5 passed |      9 failed | 
-[doctest] assertions:     11 |      1 passed |     10 failed |
+[doctest] test cases: 14 | 5 passed |  9 failed |
+[doctest] assertions: 11 | 1 passed | 10 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/order_3.txt
+++ b/examples/all_features/test_output/order_3.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/reporters_and_listeners.cpp.txt
+++ b/examples/all_features/test_output/reporters_and_listeners.cpp.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases:      0 |      0 passed |      0 failed | 
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 0 | 0 passed | 0 failed |
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -24,7 +24,7 @@ TEST CASE:  a test case that registers an exception translator for int and then 
 stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
-[doctest] test cases:      2 |      0 passed |      2 failed | 
-[doctest] assertions:      4 |      0 passed |      4 failed |
+[doctest] test cases: 2 | 0 passed | 2 failed |
+[doctest] assertions: 4 | 0 passed | 4 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/subcases.cpp.txt
+++ b/examples/all_features/test_output/subcases.cpp.txt
@@ -194,7 +194,7 @@ TEST CASE:  subcases with changing names
 subcases.cpp(0): MESSAGE: separate msg!
 
 ===============================================================================
-[doctest] test cases:      7 |      3 passed |      4 failed | 
-[doctest] assertions:     25 |     19 passed |      6 failed |
+[doctest] test cases:  7 |  3 passed | 4 failed |
+[doctest] assertions: 25 | 19 passed | 6 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/templated_test_cases.cpp.txt
+++ b/examples/all_features/test_output/templated_test_cases.cpp.txt
@@ -35,7 +35,7 @@ templated_test_cases.cpp(0): ERROR: CHECK( t2 != T2() ) is NOT correct!
   values: CHECK( 0 != 0 )
 
 ===============================================================================
-[doctest] test cases:     15 |     10 passed |      5 failed | 
-[doctest] assertions:     19 |     14 passed |      5 failed |
+[doctest] test cases: 15 | 10 passed | 5 failed |
+[doctest] assertions: 19 | 14 passed | 5 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/test_cases_and_suites.cpp.txt
+++ b/examples/all_features/test_output/test_cases_and_suites.cpp.txt
@@ -95,7 +95,7 @@ test_cases_and_suites.cpp(0): ERROR:
 
 Didn't fail exactly 1 times so marking it as failed!
 ===============================================================================
-[doctest] test cases:     14 |      5 passed |      9 failed | 
-[doctest] assertions:     11 |      1 passed |     10 failed |
+[doctest] test cases: 14 | 5 passed |  9 failed |
+[doctest] assertions: 11 | 1 passed | 10 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/exe_with_static_libs/test_output/exe_with_static_libs.txt
+++ b/examples/exe_with_static_libs/test_output/exe_with_static_libs.txt
@@ -4,6 +4,6 @@ hello from <lib_1_src2.cpp>
 hello from <lib_2_src.cpp>
 hello from <main.cpp>
 ===============================================================================
-[doctest] test cases:      4 |      4 passed |      0 failed |      0 skipped
-[doctest] assertions:      0 |      0 passed |      0 failed |
+[doctest] test cases: 4 | 4 passed | 0 failed | 0 skipped
+[doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!

--- a/examples/executable_dll_and_plugin/test_output/executable_dll_and_plugin.txt
+++ b/examples/executable_dll_and_plugin/test_output/executable_dll_and_plugin.txt
@@ -26,6 +26,6 @@ plugin.cpp(0): FATAL ERROR: certain death!
   logged: some info
 
 ===============================================================================
-[doctest] test cases:      5 |      3 passed |      2 failed |      0 skipped
-[doctest] assertions:      2 |      0 passed |      2 failed |
+[doctest] test cases: 5 | 3 passed | 2 failed | 0 skipped
+[doctest] assertions: 2 | 0 passed | 2 failed |
 [doctest] Status: FAILURE!


### PR DESCRIPTION
As requested by the issue template, I have not changed `doctest/doctest.h` directly, but instead only `doctest/doctest.cpp` from which it is said to be generated (btw, the issue template refers to "two headers in `doctest/parts`", but only one of these has a `.h` extension. Perhaps "two files"?).

## Description
When there are one million or more tests/asserts, the summary output gets out of wack (see #402). This fixes it in my tests. In addition, the output now uses only the necessary space for the total/passed/failed columns. If this last is undesirable, just add a ', 6' to the various `std::max()` parameters (or request that I do so).

before:

```
===============================================================================
[doctest] test cases:     36 |     36 passed |      0 failed |      1 skipped
[doctest] assertions: 8509223 | 8509223 passed |      0 failed |
[doctest] Status: SUCCESS!
```

after:

```
[schwarzgerat](0) $ ./notcurses-tester -p ../data/
Running with TERM=vte-256color
[doctest] doctest version is "2.4.0"
[doctest] run with "--help" for options
DirectMode *italic*!
DirectMode *bold*!
DirectMode *underline*!
===============================================================================
[doctest] test cases:      36 |      36 passed | 0 failed |      1 skipped
[doctest] assertions: 8509223 | 8509223 passed | 0 failed |
[doctest] Status: SUCCESS!
[schwarzgerat](0) $ 
```

## GitHub Issues
Closes #402.