### PR TITLE
Add JUNIT_OUTPUT_DIR option to doctest_discover_tests

### DIFF
--- a/scripts/cmake/doctest.cmake
+++ b/scripts/cmake/doctest.cmake
@@ -33,6 +33,7 @@ same as the doctest name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
                          [TEST_SUFFIX suffix]
                          [PROPERTIES name1 value1...]
                          [TEST_LIST var]
+                         [JUNIT_OUTPUT_DIR dir]
     )
 
   ``doctest_discover_tests`` sets up a post-build command on the test executable
@@ -90,6 +91,13 @@ same as the doctest name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     executable is being used in multiple calls to ``doctest_discover_tests()``.
     Note that this variable is only available in CTest.
 
+  ``JUNIT_OUTPUT_DIR dir``
+    If specified, the parameter is passed along with ``--reporters=junit``
+    and ``--out=`` to the test executable. The actual file name is the same
+    as the test target, including prefix and suffix. This should be used
+    instead of EXTRA_ARGS to avoid race conditions writing the XML result
+    output when using parallel test execution.
+
 #]=======================================================================]
 
 #------------------------------------------------------------------------------
@@ -97,7 +105,7 @@ function(doctest_discover_tests TARGET)
   cmake_parse_arguments(
     ""
     ""
-    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST"
+    "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;JUNIT_OUTPUT_DIR"
     "TEST_SPEC;EXTRA_ARGS;PROPERTIES"
     ${ARGN}
   )
@@ -134,6 +142,7 @@ function(doctest_discover_tests TARGET)
             -D "TEST_PREFIX=${_TEST_PREFIX}"
             -D "TEST_SUFFIX=${_TEST_SUFFIX}"
             -D "TEST_LIST=${_TEST_LIST}"
+            -D "TEST_JUNIT_OUTPUT_DIR=${_JUNIT_OUTPUT_DIR}"
             -D "CTEST_FILE=${ctest_tests_file}"
             -P "${_DOCTEST_DISCOVER_TESTS_SCRIPT}"
     VERBATIM

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -6,6 +6,7 @@ set(suffix "${TEST_SUFFIX}")
 set(spec ${TEST_SPEC})
 set(extra_args ${TEST_EXTRA_ARGS})
 set(properties ${TEST_PROPERTIES})
+set(junit_output_dir "${TEST_JUNIT_OUTPUT_DIR}")
 set(script)
 set(suite)
 set(tests)
@@ -54,6 +55,13 @@ foreach(line ${output})
     continue()
   endif()
   set(test ${line})
+  if(NOT "${junit_output_dir}" STREQUAL "")
+    # turn testname into a valid filename by replacing all special characters with "-"
+    string(REGEX REPLACE "[/\\:\"|<>]" "-" test_filename "${test}")
+    set(TEST_JUNIT_OUTPUT_PARAM "--reporters=junit" "--out=${junit_output_dir}/${prefix}${test_filename}${suffix}.xml")
+  else()
+    unset(TEST_JUNIT_OUTPUT_PARAM)
+  endif()
   # use escape commas to handle properly test cases with commas inside the name
   string(REPLACE "," "\\," test_name ${test})
   # ...and add to script
@@ -62,6 +70,7 @@ foreach(line ${output})
     ${TEST_EXECUTOR}
     "${TEST_EXECUTABLE}"
     "--test-case=${test_name}"
+    "${TEST_JUNIT_OUTPUT_PARAM}"
     ${extra_args}
   )
   add_command(set_tests_properties


### PR DESCRIPTION
Adds support for generating junit-style xml output when discovering tests with `doctest_discover_tests` and running them through `ctest --parallel`. This feature has been inspired by a similar feature in [CMake's GoogleTest module](https://cmake.org/cmake/help/v3.18/module/GoogleTest.html) called `XML_OUTPUT_DIR`. In short:

```
  ``JUNIT_OUTPUT_DIR dir``
    If specified, the parameter is passed along with ``--reporters=junit``
    and ``--out=`` to the test executable. The actual file name is the same
    as the test target, including prefix and suffix. This should be used
    instead of EXTRA_ARGS to avoid race conditions writing the XML result
    output when using parallel test execution.
```

The implementation is based on [GoogleTest.cmake](https://github.com/Kitware/CMake/blob/v3.18.2/Modules/GoogleTest.cmake)  and [GoogleTestAddTests.cmake](https://github.com/Kitware/CMake/blob/v3.18.2/Modules/GoogleTestAddTests.cmake). It does not take care of creating the specified output directory.