### PR TITLE
Enum support (fix for Issue #121)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -769,6 +769,13 @@ namespace detail {
 
     template<class T> struct remove_const          { typedef T type; };
     template<class T> struct remove_const<const T> { typedef T type; };
+
+    template<bool T, class Ty1, class Ty2> struct conditional { typedef Ty1 type; };
+    template<class Ty1, class Ty2> struct conditional<false, Ty1, Ty2> { typedef Ty2 type; };
+
+    // Use compiler intrinsics
+    template<class T> struct is_enum { constexpr static bool value = __is_enum(T); };
+    template<class T> struct underlying_type { typedef __underlying_type(T) type; };
     // clang-format on
 
     template <typename T>
@@ -783,12 +790,12 @@ namespace detail {
 
         template<class, class = void>
         struct check {
-            static constexpr auto value = false;
+            static constexpr bool value = false;
         };
 
         template<class T>
         struct check<T, decltype(os() << val<T>(), void())> {
-            static constexpr auto value = true;
+            static constexpr bool value = true;
         };
     } // namespace has_insertion_operator_impl
 
@@ -819,6 +826,76 @@ namespace detail {
         }
     };
 
+    template <class UT>
+    struct EnumStringMakerBase
+    {
+        template <class E>
+        static String convert(const DOCTEST_REF_WRAP(E) in) {
+            static_assert(is_enum<E>::value);
+            *getTlsOss() << static_cast<UT>(in);
+            return getTlsOssResult();
+        };
+    };
+    template <>
+    struct EnumStringMakerBase<char>
+    {
+        template <class E>
+        static String convert(const DOCTEST_REF_WRAP(E) in) {
+            static_assert(is_enum<E>::value);
+            signed char c = static_cast<signed char>(static_cast<char>(in));
+            if (c >= 32 && c < 127) // ASCII Printable
+            {
+                *getTlsOss() << "'" << c << "'";
+            }
+            else
+            {
+                *getTlsOss() << static_cast<int>(c);
+            }
+            return getTlsOssResult();
+        }
+    };
+    template <>
+    struct EnumStringMakerBase<signed char>
+    {
+        template <class E>
+        static String convert(const DOCTEST_REF_WRAP(E) in) {
+            static_assert(is_enum<E>::value);
+            signed char c = static_cast<signed char>(in);
+            if (c >= 32 && c < 127) // ASCII Printable
+            {
+                *getTlsOss() << "'" << c << "'";
+            }
+            else
+            {
+                *getTlsOss() << static_cast<int>(c);
+            }
+            return getTlsOssResult();
+        }
+    };
+    template <>
+    struct EnumStringMakerBase<unsigned char>
+    {
+        template <class E>
+        static String convert(const DOCTEST_REF_WRAP(E) in) {
+            static_assert(is_enum<E>::value);
+            unsigned char c = static_cast<unsigned char>(in);
+            if (c >= 32 && c < 127) // ASCII Printable
+            {
+                *getTlsOss() << "'" << c << "'";
+            }
+            else
+            {
+                *getTlsOss() << static_cast<unsigned>(c);
+            }
+            return getTlsOssResult();
+        }
+    };
+
+    template<class T>
+    struct EnumStringMaker : EnumStringMakerBase<typename underlying_type<T>::type> {
+        static_assert(is_enum<T>::value);
+    };
+
     DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
 
     template <typename T>
@@ -833,7 +910,7 @@ namespace detail {
 } // namespace detail
 
 template <typename T>
-struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value>
+struct StringMaker : public detail::conditional<detail::is_enum<T>::value, detail::EnumStringMaker<T>, detail::StringMakerBase<detail::has_insertion_operator<T>::value>>::type
 {};
 
 template <typename T>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -387,6 +387,9 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_IOSFWD
 
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+#ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <iosfwd>
 #include <cstddef>
 #include <ostream>
@@ -767,10 +770,14 @@ namespace detail {
 
     template<class T> struct remove_const          { typedef T type; };
     template<class T> struct remove_const<const T> { typedef T type; };
-
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template<class T> struct is_enum : public std::is_enum<T> {};
+    template<class T> struct underlying_type : public std::underlying_type<T> {};
+#else
     // Use compiler intrinsics
     template<class T> struct is_enum { constexpr static bool value = __is_enum(T); };
     template<class T> struct underlying_type { typedef __underlying_type(T) type; };
+#endif
     // clang-format on
 
     template <typename T>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -752,7 +752,6 @@ struct ContextOptions //!OCLINT too many fields
 };
 
 namespace detail {
-#if defined(DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || defined(DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS)
     template <bool CONDITION, typename TYPE = void>
     struct enable_if
     {};
@@ -760,7 +759,6 @@ namespace detail {
     template <typename TYPE>
     struct enable_if<true, TYPE>
     { typedef TYPE type; };
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format off
     template<class T> struct remove_reference      { typedef T type; };
@@ -769,11 +767,6 @@ namespace detail {
 
     template<class T> struct remove_const          { typedef T type; };
     template<class T> struct remove_const<const T> { typedef T type; };
-
-    template<bool T, class Ty1, class Ty2> struct conditional { typedef Ty1 type; };
-    template<class Ty1, class Ty2> struct conditional<false, Ty1, Ty2> { typedef Ty2 type; };
-
-    template<class T> struct is_signed { constexpr static bool value = T(-1) < T(0); };
 
     // Use compiler intrinsics
     template<class T> struct is_enum { constexpr static bool value = __is_enum(T); };
@@ -809,79 +802,25 @@ namespace detail {
     DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
     DOCTEST_INTERFACE String getTlsOssResult();
 
-    template <typename T, bool C = has_insertion_operator<T>::value>
+    template <bool C>
     struct StringMakerBase
     {
-        template <typename U>
-        static String convert(const DOCTEST_REF_WRAP(U)) {
+        template <typename T>
+        static String convert(const DOCTEST_REF_WRAP(T)) {
             return "{?}";
         }
     };
 
-    template <typename T>
-    struct StringMakerBase<T, true>
+    template <>
+    struct StringMakerBase<true>
     {
-        template <typename U>
-        static String convert(const DOCTEST_REF_WRAP(U) in) {
+        template <typename T>
+        static String convert(const DOCTEST_REF_WRAP(T) in) {
             *getTlsOss() << in;
             return getTlsOssResult();
         }
     };
 
-#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
-    template <>
-    struct StringMakerBase<char, true>
-    {
-        static String convert(char c) {
-            if (c >= 32 && c < 127) // ASCII printable
-            {
-                *detail::getTlsOss() << '\'' << c << '\'';
-                return detail::getTlsOssResult();
-            }
-            // char can be either signed or unsigned, so delegate based on which it is
-            typedef typename detail::conditional<detail::is_signed<char>::value, int, unsigned int>::type IntType;
-            return StringMakerBase<IntType, true>::convert(static_cast<IntType>(c));
-        }
-    };
-
-    template <>
-    struct StringMakerBase<signed char, true>
-    {
-        static String convert(signed char c) {
-            if (c >= 32 && c < 127) // ASCII printable
-            {
-                *detail::getTlsOss() << '\'' << c << '\'';
-                return detail::getTlsOssResult();
-            }
-            return StringMakerBase<int, true>::convert(static_cast<int>(c));
-        }
-    };
-
-    template <>
-    struct StringMakerBase<unsigned char, true>
-    {
-        static String convert(unsigned char c) {
-            if (c >= 32 && c < 127) // ASCII printable
-            {
-                *detail::getTlsOss() << '\'' << c << '\'';
-                return detail::getTlsOssResult();
-            }
-            return StringMakerBase<unsigned int, true>::convert(static_cast<unsigned int>(c));
-        }  
-    };
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#endif
-
-    template <typename T>
-    struct EnumStringMakerBase : public StringMakerBase<typename underlying_type<T>::type>
-    {
-        template <typename U>
-        static String convert(const DOCTEST_REF_WRAP(U) in) {
-            typedef typename underlying_type<T>::type UT;
-            return StringMakerBase<UT>::convert(static_cast<UT>(in));
-        }
-    };
     DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
 
     template <typename T>
@@ -896,10 +835,7 @@ namespace detail {
 } // namespace detail
 
 template <typename T>
-struct StringMaker;
-
-template <typename T>
-struct StringMaker : public detail::conditional<detail::is_enum<T>::value, detail::EnumStringMakerBase<T>, detail::StringMakerBase<T>>::type
+struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value>
 {};
 
 template <typename T>
@@ -923,7 +859,7 @@ struct StringMaker<R C::*>
     }
 };
 
-template <typename T>
+template <typename T, typename detail::enable_if<!detail::is_enum<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
@@ -949,6 +885,12 @@ DOCTEST_INTERFACE String toString(int long unsigned in);
 DOCTEST_INTERFACE String toString(int long long in);
 DOCTEST_INTERFACE String toString(int long long unsigned in);
 DOCTEST_INTERFACE String toString(std::nullptr_t in);
+
+template <typename T, typename detail::enable_if<detail::is_enum<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    typedef typename detail::underlying_type<T>::type UT;
+    return toString(static_cast<UT>(value));
+}
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -414,6 +414,12 @@ struct char_traits<char>;
 template <class charT, class traits>
 class basic_ostream;
 typedef basic_ostream<char, char_traits<char>> ostream;
+template <class charT, class traits>
+basic_ostream<charT, traits>& operator <<(basic_ostream<charT, traits>& os, charT ch);
+template <class charT, class traits>
+basic_ostream<charT, traits>& operator <<(basic_ostream<charT, traits>& os, char ch);
+template <class traits>
+basic_ostream<char, traits>& operator <<(basic_ostream<char, traits>& os, char ch);
 template <class... Types>
 class tuple;
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -776,6 +776,8 @@ namespace detail {
     template<bool T, class Ty1, class Ty2> struct conditional { typedef Ty1 type; };
     template<class Ty1, class Ty2> struct conditional<false, Ty1, Ty2> { typedef Ty2 type; };
 
+    template<class T> struct is_signed { constexpr static bool value = T(-1) < T(0); };
+
     // Use compiler intrinsics
     template<class T> struct is_enum { constexpr static bool value = __is_enum(T); };
     template<class T> struct underlying_type { typedef __underlying_type(T) type; };
@@ -855,7 +857,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
             }
             else
             {
-                *getTlsOss() << static_cast<int>(c);
+                return EnumStringMakerBase<conditional<is_signed<char>::value, int, unsigned int>::type>::convert(in);
             }
             return getTlsOssResult();
         }
@@ -873,7 +875,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
             }
             else
             {
-                *getTlsOss() << static_cast<int>(c);
+                return EnumStringMakerBase<int>::convert(in);
             }
             return getTlsOssResult();
         }
@@ -891,7 +893,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
             }
             else
             {
-                *getTlsOss() << static_cast<unsigned int>(c);
+                return EnumStringMakerBase<unsigned int>::convert(in);
             }
             return getTlsOssResult();
         }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -414,12 +414,12 @@ struct char_traits<char>;
 template <class charT, class traits>
 class basic_ostream;
 typedef basic_ostream<char, char_traits<char>> ostream;
-template <class charT, class traits>
-basic_ostream<charT, traits>& operator <<(basic_ostream<charT, traits>& os, charT ch);
-template <class charT, class traits>
-basic_ostream<charT, traits>& operator <<(basic_ostream<charT, traits>& os, char ch);
 template <class traits>
-basic_ostream<char, traits>& operator <<(basic_ostream<char, traits>& os, char ch);
+basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& os, char ch);
+template <class traits>
+basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& os, signed char ch);
+template <class traits>
+basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& os, unsigned char ch);
 template <class... Types>
 class tuple;
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
@@ -812,101 +812,79 @@ namespace detail {
     DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
     DOCTEST_INTERFACE String getTlsOssResult();
 
-    template <bool C>
+    template <typename T, bool C = has_insertion_operator<T>::value>
     struct StringMakerBase
     {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
+        template <typename U>
+        static String convert(const DOCTEST_REF_WRAP(U)) {
             return "{?}";
         }
     };
 
-    template <>
-    struct StringMakerBase<true>
+    template <typename T>
+    struct StringMakerBase<T, true>
     {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
+        template <typename U>
+        static String convert(const DOCTEST_REF_WRAP(U) in) {
             *getTlsOss() << in;
             return getTlsOssResult();
         }
     };
 
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
-    template <class UT>
-    struct EnumStringMakerBase
-    {
-        template <class E>
-        static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value, "");
-            *getTlsOss() << static_cast<UT>(in);
-            return getTlsOssResult();
-        }
-    };
+#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
     template <>
-    struct EnumStringMakerBase<char>
+    struct StringMakerBase<char, true>
     {
-        template <class E>
-        static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value, "");
-            char c = static_cast<char>(in);
-            if (c >= 32 && c < 127) // ASCII Printable
+        static String convert(char c) {
+            if (c >= 32 && c < 127) // ASCII printable
             {
-                *getTlsOss() << "'" << c << "'";
+                *detail::getTlsOss() << '\'' << c << '\'';
+                return detail::getTlsOssResult();
             }
-            else
-            {
-                return EnumStringMakerBase<conditional<is_signed<char>::value, int, unsigned int>::type>::convert(in);
-            }
-            return getTlsOssResult();
+            // char can be either signed or unsigned, so delegate based on which it is
+            typedef typename detail::conditional<detail::is_signed<char>::value, int, unsigned int>::type IntType;
+            return StringMakerBase<IntType, true>::convert(static_cast<IntType>(c));
         }
-    };
-    template <>
-    struct EnumStringMakerBase<signed char>
-    {
-        template <class E>
-        static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value, "");
-            signed char c = static_cast<signed char>(in);
-            if (c >= 32 && c < 127) // ASCII Printable
-            {
-                *getTlsOss() << "'" << c << "'";
-            }
-            else
-            {
-                return EnumStringMakerBase<int>::convert(in);
-            }
-            return getTlsOssResult();
-        }
-    };
-    template <>
-    struct EnumStringMakerBase<unsigned char>
-    {
-        template <class E>
-        static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value, "");
-            unsigned char c = static_cast<unsigned char>(in);
-            if (c >= 32 && c < 127) // ASCII Printable
-            {
-                *getTlsOss() << "'" << c << "'";
-            }
-            else
-            {
-                return EnumStringMakerBase<unsigned int>::convert(in);
-            }
-            return getTlsOssResult();
-        }
-    };
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-
-    template<class T>
-    struct EnumStringMaker : EnumStringMakerBase<typename underlying_type<T>::type> {
-        static_assert(is_enum<T>::value, "");
     };
 
+    template <>
+    struct StringMakerBase<signed char, true>
+    {
+        static String convert(signed char c) {
+            if (c >= 32 && c < 127) // ASCII printable
+            {
+                *detail::getTlsOss() << '\'' << c << '\'';
+                return detail::getTlsOssResult();
+            }
+            return StringMakerBase<int, true>::convert(static_cast<int>(c));
+        }
+    };
+
+    template <>
+    struct StringMakerBase<unsigned char, true>
+    {
+        static String convert(unsigned char c) {
+            if (c >= 32 && c < 127) // ASCII printable
+            {
+                *detail::getTlsOss() << '\'' << c << '\'';
+                return detail::getTlsOssResult();
+            }
+            return StringMakerBase<unsigned int, true>::convert(static_cast<unsigned int>(c));
+        }  
+    };
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#endif
+
+    template <typename T>
+    struct EnumStringMakerBase : public StringMakerBase<typename underlying_type<T>::type>
+    {
+        template <typename U>
+        static String convert(const DOCTEST_REF_WRAP(U) in) {
+            typedef typename underlying_type<T>::type UT;
+            return StringMakerBase<UT>::convert(static_cast<UT>(in));
+        }
+    };
     DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
 
     template <typename T>
@@ -921,7 +899,10 @@ DOCTEST_CLANG_SUPPRESS_WARNING_POP
 } // namespace detail
 
 template <typename T>
-struct StringMaker : public detail::conditional<detail::is_enum<T>::value, detail::EnumStringMaker<T>, detail::StringMakerBase<detail::has_insertion_operator<T>::value>>::type
+struct StringMaker;
+
+template <typename T>
+struct StringMaker : public detail::conditional<detail::is_enum<T>::value, detail::EnumStringMakerBase<T>, detail::StringMakerBase<T>>::type
 {};
 
 template <typename T>

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -384,6 +384,9 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_IOSFWD
 
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+#ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <iosfwd>
 #include <cstddef>
 #include <ostream>
@@ -764,10 +767,14 @@ namespace detail {
 
     template<class T> struct remove_const          { typedef T type; };
     template<class T> struct remove_const<const T> { typedef T type; };
-
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    template<class T> struct is_enum : public std::is_enum<T> {};
+    template<class T> struct underlying_type : public std::underlying_type<T> {};
+#else
     // Use compiler intrinsics
     template<class T> struct is_enum { constexpr static bool value = __is_enum(T); };
     template<class T> struct underlying_type { typedef __underlying_type(T) type; };
+#endif
     // clang-format on
 
     template <typename T>

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -867,7 +867,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
             signed char c = static_cast<signed char>(in);
             if (c >= 32 && c < 127) // ASCII Printable
             {
-                *getTlsOss() << "'" << static_cast<char>(c) << "'";
+                *getTlsOss() << "'" << c << "'";
             }
             else
             {
@@ -885,11 +885,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
             unsigned char c = static_cast<unsigned char>(in);
             if (c >= 32 && c < 127) // ASCII Printable
             {
-                *getTlsOss() << "'" << static_cast<char>(c) << "'";
+                *getTlsOss() << "'" << c << "'";
             }
             else
             {
-                *getTlsOss() << static_cast<unsigned>(c);
+                *getTlsOss() << static_cast<unsigned int>(c);
             }
             return getTlsOssResult();
         }

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -823,6 +823,7 @@ namespace detail {
         }
     };
 
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
     template <class UT>
     struct EnumStringMakerBase
     {
@@ -887,6 +888,7 @@ namespace detail {
             return getTlsOssResult();
         }
     };
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template<class T>
     struct EnumStringMaker : EnumStringMakerBase<typename underlying_type<T>::type> {

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -830,6 +830,8 @@ namespace detail {
     };
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wsign-conversion")
     template <class UT>
     struct EnumStringMakerBase
     {
@@ -895,6 +897,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5045) // Spectre mitigation
         }
     };
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
     template<class T>
     struct EnumStringMaker : EnumStringMakerBase<typename underlying_type<T>::type> {

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -828,18 +828,18 @@ namespace detail {
     {
         template <class E>
         static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value);
+            static_assert(is_enum<E>::value, "");
             *getTlsOss() << static_cast<UT>(in);
             return getTlsOssResult();
-        };
+        }
     };
     template <>
     struct EnumStringMakerBase<char>
     {
         template <class E>
         static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value);
-            signed char c = static_cast<signed char>(static_cast<char>(in));
+            static_assert(is_enum<E>::value, "");
+            char c = static_cast<char>(in);
             if (c >= 32 && c < 127) // ASCII Printable
             {
                 *getTlsOss() << "'" << c << "'";
@@ -856,11 +856,11 @@ namespace detail {
     {
         template <class E>
         static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value);
+            static_assert(is_enum<E>::value, "");
             signed char c = static_cast<signed char>(in);
             if (c >= 32 && c < 127) // ASCII Printable
             {
-                *getTlsOss() << "'" << c << "'";
+                *getTlsOss() << "'" << static_cast<char>(c) << "'";
             }
             else
             {
@@ -874,11 +874,11 @@ namespace detail {
     {
         template <class E>
         static String convert(const DOCTEST_REF_WRAP(E) in) {
-            static_assert(is_enum<E>::value);
+            static_assert(is_enum<E>::value, "");
             unsigned char c = static_cast<unsigned char>(in);
             if (c >= 32 && c < 127) // ASCII Printable
             {
-                *getTlsOss() << "'" << c << "'";
+                *getTlsOss() << "'" << static_cast<char>(c) << "'";
             }
             else
             {
@@ -890,7 +890,7 @@ namespace detail {
 
     template<class T>
     struct EnumStringMaker : EnumStringMakerBase<typename underlying_type<T>::type> {
-        static_assert(is_enum<T>::value);
+        static_assert(is_enum<T>::value, "");
     };
 
     DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -15,6 +15,7 @@ set(files_with_output
     templated_test_cases.cpp
     test_cases_and_suites.cpp
     asserts_used_outside_of_tests.cpp
+    enums.cpp
 )
 
 set(files_all

--- a/examples/all_features/enums.cpp
+++ b/examples/all_features/enums.cpp
@@ -5,7 +5,7 @@
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <cstdint>
 #include <sstream>
-// using namespace std;
+#include <type_traits>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 namespace
@@ -53,7 +53,7 @@ enum class EnumClassU8 : uint8_t
     Two,
 };
 
-template<class E, class T = std::underlying_type<E>::type>
+template<class E, class T = typename std::underlying_type<E>::type>
 T printable(E val)
 {
     return T(val);

--- a/examples/all_features/enums.cpp
+++ b/examples/all_features/enums.cpp
@@ -1,3 +1,4 @@
+#define DOCTEST_CONFIG_USE_STD_HEADERS
 #include <doctest/doctest.h>
 
 #include "header.h"

--- a/examples/all_features/enums.cpp
+++ b/examples/all_features/enums.cpp
@@ -1,0 +1,110 @@
+#include <doctest/doctest.h>
+
+#include "header.h"
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+// using namespace std;
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace
+{
+
+enum StandardEnum
+{
+    Zero,
+    One,
+    Two,
+};
+
+enum TypedEnum : int64_t
+{
+    TypedZero,
+    TypedOne,
+    TypedTwo,
+};
+
+enum class EnumClassC : char
+{
+    Zero = '0',
+    One = '1',
+    Two = '2',
+};
+
+enum class EnumClassSC : signed char
+{
+    Zero = '0',
+    One = '1',
+    Two = '2',
+};
+
+enum class EnumClassUC : unsigned char
+{
+    Zero = '0',
+    One = '1',
+    Two = '2',
+};
+
+enum class EnumClassU8 : uint8_t
+{
+    Zero,
+    One,
+    Two,
+};
+
+template<class E, class T = std::underlying_type<E>::type>
+T printable(E val)
+{
+    return T(val);
+}
+
+}
+
+TEST_CASE("enum 1")
+{
+    std::ostringstream ostr;
+    ostr << Zero << One << Two;
+    ostr << TypedZero << TypedOne << TypedTwo;
+    static_assert(std::is_enum<EnumClassSC>::value, "");
+    ostr << printable(EnumClassSC::Zero) << printable(EnumClassSC::One) << printable(EnumClassSC::Two);
+
+    CHECK_EQ(Zero, 0);
+    CHECK_EQ(One, 1);
+    CHECK_EQ(Two, 2);
+
+    CHECK_EQ(TypedZero, 0);
+    CHECK_EQ(TypedOne, 1);
+    CHECK_EQ(TypedTwo, 2);
+
+    CHECK_EQ(EnumClassSC::Zero, EnumClassSC::Zero);
+    CHECK_EQ(EnumClassSC::One, EnumClassSC::One);
+    CHECK_EQ(EnumClassSC::Two, EnumClassSC::Two);
+}
+
+TEST_CASE("enum 2" * doctest::should_fail())
+{
+    CHECK_EQ(Zero, 1);
+    CHECK_EQ(One, 2);
+    CHECK_EQ(Two, 3);
+
+    CHECK_EQ(TypedZero, 1);
+    CHECK_EQ(TypedOne, 2);
+    CHECK_EQ(TypedTwo, 3);
+
+    CHECK_EQ(EnumClassC::Zero, EnumClassC::One);
+    CHECK_EQ(EnumClassC::One, EnumClassC::Two);
+    CHECK_EQ(EnumClassC::Two, EnumClassC::Zero);
+
+    CHECK_EQ(EnumClassSC::Zero, EnumClassSC::One);
+    CHECK_EQ(EnumClassSC::One, EnumClassSC::Two);
+    CHECK_EQ(EnumClassSC::Two, EnumClassSC::Zero);
+
+    CHECK_EQ(EnumClassUC::Zero, EnumClassUC::One);
+    CHECK_EQ(EnumClassUC::One, EnumClassUC::Two);
+    CHECK_EQ(EnumClassUC::Two, EnumClassUC::Zero);
+
+    CHECK_EQ(EnumClassU8::Zero, EnumClassU8::One);
+    CHECK_EQ(EnumClassU8::One, EnumClassU8::Two);
+    CHECK_EQ(EnumClassU8::Two, EnumClassU8::Zero);
+}

--- a/examples/all_features/enums.cpp
+++ b/examples/all_features/enums.cpp
@@ -1,4 +1,3 @@
-#define DOCTEST_CONFIG_USE_STD_HEADERS
 #include <doctest/doctest.h>
 
 #include "header.h"
@@ -6,7 +5,6 @@
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <cstdint>
 #include <sstream>
-#include <type_traits>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 namespace

--- a/examples/all_features/test_output/enums.cpp.txt
+++ b/examples/all_features/test_output/enums.cpp.txt
@@ -1,0 +1,65 @@
+[doctest] run with "--help" for options
+===============================================================================
+enums.cpp(0):
+TEST CASE:  enum 2
+
+enums.cpp(0): ERROR: CHECK_EQ( Zero, 1 ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+enums.cpp(0): ERROR: CHECK_EQ( One, 2 ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+enums.cpp(0): ERROR: CHECK_EQ( Two, 3 ) is NOT correct!
+  values: CHECK_EQ( 2, 3 )
+
+enums.cpp(0): ERROR: CHECK_EQ( TypedZero, 1 ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+enums.cpp(0): ERROR: CHECK_EQ( TypedOne, 2 ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+enums.cpp(0): ERROR: CHECK_EQ( TypedTwo, 3 ) is NOT correct!
+  values: CHECK_EQ( 2, 3 )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::Zero, EnumClassC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::One, EnumClassC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::Two, EnumClassC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::Zero, EnumClassSC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::One, EnumClassSC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::Two, EnumClassSC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::Zero, EnumClassUC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::One, EnumClassUC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::Two, EnumClassUC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassU8::Zero, EnumClassU8::One ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassU8::One, EnumClassU8::Two ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+enums.cpp(0): ERROR: CHECK_EQ( EnumClassU8::Two, EnumClassU8::Zero ) is NOT correct!
+  values: CHECK_EQ( 2, 0 )
+
+Failed as expected so marking it as not failed
+===============================================================================
+[doctest] test cases:  2 | 2 passed |  0 failed |
+[doctest] assertions: 27 | 9 passed | 18 failed |
+[doctest] Status: SUCCESS!
+Program code.

--- a/examples/all_features/test_output/enums.cpp.txt
+++ b/examples/all_features/test_output/enums.cpp.txt
@@ -22,31 +22,31 @@ enums.cpp(0): ERROR: CHECK_EQ( TypedTwo, 3 ) is NOT correct!
   values: CHECK_EQ( 2, 3 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::Zero, EnumClassC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::One, EnumClassC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassC::Two, EnumClassC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::Zero, EnumClassSC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::One, EnumClassSC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassSC::Two, EnumClassSC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::Zero, EnumClassUC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::One, EnumClassUC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassUC::Two, EnumClassUC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
 enums.cpp(0): ERROR: CHECK_EQ( EnumClassU8::Zero, EnumClassU8::One ) is NOT correct!
   values: CHECK_EQ( 0, 1 )

--- a/examples/all_features/test_output/enums.cpp_junit.txt
+++ b/examples/all_features/test_output/enums.cpp_junit.txt
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="all_features" errors="0" failures="18" tests="27">
+    <testcase classname="enums.cpp" name="enum 1" status="run"/>
+    <testcase classname="enums.cpp" name="enum 2" status="run">
+      <failure message="0, 1" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( Zero, 1 ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+      </failure>
+      <failure message="1, 2" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( One, 2 ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+      </failure>
+      <failure message="2, 3" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( Two, 3 ) is NOT correct!
+  values: CHECK_EQ( 2, 3 )
+
+      </failure>
+      <failure message="0, 1" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( TypedZero, 1 ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+      </failure>
+      <failure message="1, 2" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( TypedOne, 2 ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+      </failure>
+      <failure message="2, 3" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( TypedTwo, 3 ) is NOT correct!
+  values: CHECK_EQ( 2, 3 )
+
+      </failure>
+      <failure message="'0', '1'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassC::Zero, EnumClassC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+      </failure>
+      <failure message="'1', '2'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassC::One, EnumClassC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+      </failure>
+      <failure message="'2', '0'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassC::Two, EnumClassC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+      </failure>
+      <failure message="'0', '1'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassSC::Zero, EnumClassSC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+      </failure>
+      <failure message="'1', '2'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassSC::One, EnumClassSC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+      </failure>
+      <failure message="'2', '0'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassSC::Two, EnumClassSC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+      </failure>
+      <failure message="'0', '1'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassUC::Zero, EnumClassUC::One ) is NOT correct!
+  values: CHECK_EQ( '0', '1' )
+
+      </failure>
+      <failure message="'1', '2'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassUC::One, EnumClassUC::Two ) is NOT correct!
+  values: CHECK_EQ( '1', '2' )
+
+      </failure>
+      <failure message="'2', '0'" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassUC::Two, EnumClassUC::Zero ) is NOT correct!
+  values: CHECK_EQ( '2', '0' )
+
+      </failure>
+      <failure message="0, 1" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassU8::Zero, EnumClassU8::One ) is NOT correct!
+  values: CHECK_EQ( 0, 1 )
+
+      </failure>
+      <failure message="1, 2" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassU8::One, EnumClassU8::Two ) is NOT correct!
+  values: CHECK_EQ( 1, 2 )
+
+      </failure>
+      <failure message="2, 0" type="CHECK_EQ">
+enums.cpp(0):
+CHECK_EQ( EnumClassU8::Two, EnumClassU8::Zero ) is NOT correct!
+  values: CHECK_EQ( 2, 0 )
+
+      </failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+Program code.

--- a/examples/all_features/test_output/enums.cpp_junit.txt
+++ b/examples/all_features/test_output/enums.cpp_junit.txt
@@ -39,58 +39,58 @@ CHECK_EQ( TypedTwo, 3 ) is NOT correct!
   values: CHECK_EQ( 2, 3 )
 
       </failure>
-      <failure message="'0', '1'" type="CHECK_EQ">
+      <failure message="48, 49" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassC::Zero, EnumClassC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
       </failure>
-      <failure message="'1', '2'" type="CHECK_EQ">
+      <failure message="49, 50" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassC::One, EnumClassC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
       </failure>
-      <failure message="'2', '0'" type="CHECK_EQ">
+      <failure message="50, 48" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassC::Two, EnumClassC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
       </failure>
-      <failure message="'0', '1'" type="CHECK_EQ">
+      <failure message="48, 49" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassSC::Zero, EnumClassSC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
       </failure>
-      <failure message="'1', '2'" type="CHECK_EQ">
+      <failure message="49, 50" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassSC::One, EnumClassSC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
       </failure>
-      <failure message="'2', '0'" type="CHECK_EQ">
+      <failure message="50, 48" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassSC::Two, EnumClassSC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
       </failure>
-      <failure message="'0', '1'" type="CHECK_EQ">
+      <failure message="48, 49" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassUC::Zero, EnumClassUC::One ) is NOT correct!
-  values: CHECK_EQ( '0', '1' )
+  values: CHECK_EQ( 48, 49 )
 
       </failure>
-      <failure message="'1', '2'" type="CHECK_EQ">
+      <failure message="49, 50" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassUC::One, EnumClassUC::Two ) is NOT correct!
-  values: CHECK_EQ( '1', '2' )
+  values: CHECK_EQ( 49, 50 )
 
       </failure>
-      <failure message="'2', '0'" type="CHECK_EQ">
+      <failure message="50, 48" type="CHECK_EQ">
 enums.cpp(0):
 CHECK_EQ( EnumClassUC::Two, EnumClassUC::Zero ) is NOT correct!
-  values: CHECK_EQ( '2', '0' )
+  values: CHECK_EQ( 50, 48 )
 
       </failure>
       <failure message="0, 1" type="CHECK_EQ">

--- a/examples/all_features/test_output/enums.cpp_xml.txt
+++ b/examples/all_features/test_output/enums.cpp_xml.txt
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctest binary="all_features">
+  <Options order_by="file" rand_seed="324" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+  <TestSuite>
+    <TestCase name="enum 1" filename="enums.cpp" line="0">
+      <OverallResultsAsserts successes="9" failures="0"/>
+    </TestCase>
+    <TestCase name="enum 2" filename="enums.cpp" line="0" should_fail="true">
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          Zero, 1
+        </Original>
+        <Expanded>
+          0, 1
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          One, 2
+        </Original>
+        <Expanded>
+          1, 2
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          Two, 3
+        </Original>
+        <Expanded>
+          2, 3
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          TypedZero, 1
+        </Original>
+        <Expanded>
+          0, 1
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          TypedOne, 2
+        </Original>
+        <Expanded>
+          1, 2
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          TypedTwo, 3
+        </Original>
+        <Expanded>
+          2, 3
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassC::Zero, EnumClassC::One
+        </Original>
+        <Expanded>
+          '0', '1'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassC::One, EnumClassC::Two
+        </Original>
+        <Expanded>
+          '1', '2'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassC::Two, EnumClassC::Zero
+        </Original>
+        <Expanded>
+          '2', '0'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassSC::Zero, EnumClassSC::One
+        </Original>
+        <Expanded>
+          '0', '1'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassSC::One, EnumClassSC::Two
+        </Original>
+        <Expanded>
+          '1', '2'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassSC::Two, EnumClassSC::Zero
+        </Original>
+        <Expanded>
+          '2', '0'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassUC::Zero, EnumClassUC::One
+        </Original>
+        <Expanded>
+          '0', '1'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassUC::One, EnumClassUC::Two
+        </Original>
+        <Expanded>
+          '1', '2'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassUC::Two, EnumClassUC::Zero
+        </Original>
+        <Expanded>
+          '2', '0'
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassU8::Zero, EnumClassU8::One
+        </Original>
+        <Expanded>
+          0, 1
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassU8::One, EnumClassU8::Two
+        </Original>
+        <Expanded>
+          1, 2
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
+        <Original>
+          EnumClassU8::Two, EnumClassU8::Zero
+        </Original>
+        <Expanded>
+          2, 0
+        </Expanded>
+      </Expression>
+      <OverallResultsAsserts successes="0" failures="18"/>
+    </TestCase>
+  </TestSuite>
+  <OverallResultsAsserts successes="9" failures="18"/>
+  <OverallResultsTestCases successes="2" failures="0"/>
+</doctest>
+Program code.

--- a/examples/all_features/test_output/enums.cpp_xml.txt
+++ b/examples/all_features/test_output/enums.cpp_xml.txt
@@ -59,7 +59,7 @@
           EnumClassC::Zero, EnumClassC::One
         </Original>
         <Expanded>
-          '0', '1'
+          48, 49
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -67,7 +67,7 @@
           EnumClassC::One, EnumClassC::Two
         </Original>
         <Expanded>
-          '1', '2'
+          49, 50
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -75,7 +75,7 @@
           EnumClassC::Two, EnumClassC::Zero
         </Original>
         <Expanded>
-          '2', '0'
+          50, 48
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -83,7 +83,7 @@
           EnumClassSC::Zero, EnumClassSC::One
         </Original>
         <Expanded>
-          '0', '1'
+          48, 49
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -91,7 +91,7 @@
           EnumClassSC::One, EnumClassSC::Two
         </Original>
         <Expanded>
-          '1', '2'
+          49, 50
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -99,7 +99,7 @@
           EnumClassSC::Two, EnumClassSC::Zero
         </Original>
         <Expanded>
-          '2', '0'
+          50, 48
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -107,7 +107,7 @@
           EnumClassUC::Zero, EnumClassUC::One
         </Original>
         <Expanded>
-          '0', '1'
+          48, 49
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -115,7 +115,7 @@
           EnumClassUC::One, EnumClassUC::Two
         </Original>
         <Expanded>
-          '1', '2'
+          49, 50
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">
@@ -123,7 +123,7 @@
           EnumClassUC::Two, EnumClassUC::Zero
         </Original>
         <Expanded>
-          '2', '0'
+          50, 48
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK_EQ" filename="enums.cpp" line="0">

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 78 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 80 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -42,6 +42,8 @@
     <TestCase name="doesn't fail which is fine" filename="test_cases_and_suites.cpp" line="0" description="regarding failures" may_fail="true" skipped="true"/>
   </TestSuite>
   <TestSuite>
+    <TestCase name="enum 1" filename="enums.cpp" line="0" skipped="true"/>
+    <TestCase name="enum 2" filename="enums.cpp" line="0" should_fail="true" skipped="true"/>
     <TestCase name="exceptions-related macros" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="exceptions-related macros for std::exception" filename="assertion_macros.cpp" line="0" skipped="true"/>
     <TestCase name="exercising tricky code paths of doctest" filename="coverage_maxout.cpp" line="0" skipped="true"/>
@@ -116,6 +118,6 @@
     <TestCase name="will end from an unknown exception" filename="coverage_maxout.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="78"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="80"/>
 </doctest>
 Program code.


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 headers in the doctest/parts/ folder.
-->


## Description
When a `CHECK` fails and the decomposed expression includes an enum, the values are not printed but instead `{?}` is printed. This resolves that.

## GitHub Issues
Closes #121 
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
