### PR TITLE
switch from using operator<< to the comma operator for logging

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1547,6 +1547,8 @@ namespace detail {
             return *this;
         }
 
+        MessageBuilder& write(const char* data, unsigned size);
+
         bool log();
         void react();
     };
@@ -4268,6 +4270,11 @@ namespace detail {
 
     IExceptionTranslator::IExceptionTranslator()  = default;
     IExceptionTranslator::~IExceptionTranslator() = default;
+
+    MessageBuilder& MessageBuilder::write(const char* data, unsigned size) {
+        m_stream->write(data, std::streamsize(size));
+        return *this;
+    }
 
     bool MessageBuilder::log() {
         m_string = getTlsOssResult();

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1627,6 +1627,11 @@ namespace detail {
     IExceptionTranslator::IExceptionTranslator()  = default;
     IExceptionTranslator::~IExceptionTranslator() = default;
 
+    MessageBuilder& MessageBuilder::write(const char* data, unsigned size) {
+        m_stream->write(data, std::streamsize(size));
+        return *this;
+    }
+
     bool MessageBuilder::log() {
         m_string = getTlsOssResult();
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1544,6 +1544,8 @@ namespace detail {
             return *this;
         }
 
+        MessageBuilder& write(const char* data, unsigned size);
+
         bool log();
         void react();
     };

--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -75,6 +75,33 @@ struct Foo
     friend bool operator==(const Foo&, const Foo&) { return false; }
 };
 
+struct MyStringType
+{
+    std::string s;
+    template <size_t N> MyStringType(const char (&in)[N]) : s(in, in+N) {}
+    friend bool operator==(const MyStringType &lhs, const MyStringType &rhs) { return lhs.s == rhs.s; }
+};
+
+template <typename T, typename K>
+std::ostream& operator<<(std::ostream& stream, const MyType<T, K>& in) {
+    stream << "[" << in.one << ", " << in.two << "]";
+    return stream;
+}
+
+// you can use the stream.write() method to write blocks of characters, and
+// you also can use a template operator<< if your code does not use
+// std::ostream and you'd like to avoid the include
+template <class OStream>
+OStream& operator<<(OStream& stream, const MyStringType &in) {
+    // the terminating \0 character may be present in size()
+    auto size = in.s.size() > 0u ? in.s.size() - 1u : 0u;
+    constexpr const char quote = '\'';
+    stream.write(&quote, 1u);
+    stream.write(in.s.data(), static_cast<unsigned>(size));
+    stream.write(&quote, 1u);
+    return stream;
+}
+
 // as a third option you may provide an overload of toString()
 inline doctest::String toString(const Foo&) { return "Foo{}"; }
 } // namespace Bar
@@ -126,6 +153,18 @@ TEST_CASE("all asserts should fail and show how the objects get stringified") {
     lst_2.push_back(666);
 
     CHECK(lst_1 == lst_2);
+
+    {
+        // use of ostream::write() is possible:
+        Bar::MyStringType s1 = "some";
+        Bar::MyStringType s2 = "contents";
+
+        // also inside the message builder
+        INFO("s1=" << s1 << " s2=" << s2);
+
+        CHECK(s1 == s2);
+        CHECK_MESSAGE(s1 == s2, s1 << " is not really " << s2);
+    }
 
     // lets see if this exception gets translated
     throw_if(true, bla1);

--- a/examples/all_features/test_output/stringification.cpp.txt
+++ b/examples/all_features/test_output/stringification.cpp.txt
@@ -15,6 +15,15 @@ stringification.cpp(0): ERROR: CHECK( vec1 == vec2 ) is NOT correct!
 stringification.cpp(0): ERROR: CHECK( lst_1 == lst_2 ) is NOT correct!
   values: CHECK( [1, 42, 3, ] == [1, 2, 666, ] )
 
+stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
+  values: CHECK( 'some' == 'contents' )
+  logged: s1='some' s2='contents'
+
+stringification.cpp(0): ERROR: CHECK( s1 == s2 ) is NOT correct!
+  values: CHECK( 'some' == 'contents' )
+  logged: s1='some' s2='contents'
+          'some' is not really 'contents'
+
 stringification.cpp(0): ERROR: test case THREW exception: MyTypeInherited<int>(5, 4)
 
 ===============================================================================
@@ -25,6 +34,6 @@ stringification.cpp(0): ERROR: test case THREW exception: 5
 
 ===============================================================================
 [doctest] test cases: 2 | 0 passed | 2 failed |
-[doctest] assertions: 4 | 0 passed | 4 failed |
+[doctest] assertions: 6 | 0 passed | 6 failed |
 [doctest] Status: FAILURE!
 Program code.

--- a/examples/all_features/test_output/stringification.cpp_junit.txt
+++ b/examples/all_features/test_output/stringification.cpp_junit.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="all_features" errors="2" failures="4" tests="4">
+  <testsuite name="all_features" errors="2" failures="6" tests="6">
     <testcase classname="stringification.cpp" name="all asserts should fail and show how the objects get stringified" status="run">
       <failure message="Foo{} == Foo{}" type="CHECK">
 stringification.cpp(0):
@@ -24,6 +24,18 @@ CHECK( vec1 == vec2 ) is NOT correct!
 stringification.cpp(0):
 CHECK( lst_1 == lst_2 ) is NOT correct!
   values: CHECK( [1, 42, 3, ] == [1, 2, 666, ] )
+
+      </failure>
+      <failure message="'some' == 'contents'" type="CHECK">
+stringification.cpp(0):
+CHECK( s1 == s2 ) is NOT correct!
+  values: CHECK( 'some' == 'contents' )
+
+      </failure>
+      <failure message="'some' == 'contents'" type="CHECK">
+stringification.cpp(0):
+CHECK( s1 == s2 ) is NOT correct!
+  values: CHECK( 'some' == 'contents' )
 
       </failure>
       <error message="exception">

--- a/examples/all_features/test_output/stringification.cpp_xml.txt
+++ b/examples/all_features/test_output/stringification.cpp_xml.txt
@@ -35,10 +35,35 @@
           [1, 42, 3, ] == [1, 2, 666, ]
         </Expanded>
       </Expression>
+      <Expression success="false" type="CHECK" filename="stringification.cpp" line="0">
+        <Original>
+          s1 == s2
+        </Original>
+        <Expanded>
+          'some' == 'contents'
+        </Expanded>
+        <Info>
+          s1='some' s2='contents'
+        </Info>
+      </Expression>
+      <Expression success="false" type="CHECK" filename="stringification.cpp" line="0">
+        <Original>
+          s1 == s2
+        </Original>
+        <Expanded>
+          'some' == 'contents'
+        </Expanded>
+        <Info>
+          s1='some' s2='contents'
+        </Info>
+        <Info>
+          'some' is not really 'contents'
+        </Info>
+      </Expression>
       <Exception crash="false">
         MyTypeInherited&lt;int>(5, 4)
       </Exception>
-      <OverallResultsAsserts successes="0" failures="4"/>
+      <OverallResultsAsserts successes="0" failures="6"/>
     </TestCase>
     <TestCase name="a test case that registers an exception translator for int and then throws one" filename="stringification.cpp" line="0">
       <Exception crash="false">
@@ -47,7 +72,7 @@
       <OverallResultsAsserts successes="0" failures="0"/>
     </TestCase>
   </TestSuite>
-  <OverallResultsAsserts successes="0" failures="4"/>
+  <OverallResultsAsserts successes="0" failures="6"/>
   <OverallResultsTestCases successes="0" failures="2"/>
 </doctest>
 Program code.


### PR DESCRIPTION
In the `operator<<(stream, T)` calls from doctest, using `stream.write()` was possible from the CHECK() macros, but not from INFO() and CHECK_MESSAGE(). This PR addresses that.

An example of the use case can be seen in the added test in stringification.cpp. I've updated the test result files.

I do have a doubt about the size passed into `write()`. The correct type would be `std::streamsize` but the standard only specifies that it is a `typedef`, and nothing regarding the particular type, so it is difficult or impossible to provide a safe forward declaration. So I've went with `unsigned`, as `size_t` would require `#include <cstdint>`.
