### PR TITLE
Fix 32bit support on macOS

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -368,7 +368,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0");

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -365,7 +365,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0");


### PR DESCRIPTION
## Description
macOS 32bit support is broken since https://github.com/onqtam/doctest/commit/3c5e0fa8d2cc7e6409de5e4e6df8e52fb9627a26.

## GitHub Issues
Reported and fixed in https://github.com/ccache/ccache/issues/731
