### PR TITLE
Add MAIN_PROJECT check for test option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,12 @@ endif()
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.txt ver)
 project(doctest VERSION ${ver} LANGUAGES CXX)
 
-option(DOCTEST_WITH_TESTS               "Build tests/examples" ON)
+set(MAIN_PROJECT OFF)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(MAIN_PROJECT ON)
+endif()
+
+option(DOCTEST_WITH_TESTS               "Build tests/examples" ${MAIN_PROJECT})
 option(DOCTEST_WITH_MAIN_IN_STATIC_LIB  "Build a static lib (cmake target) with a default main entry point" ON)
 option(DOCTEST_NO_INSTALL  "Skip the installation process" OFF)
 option(DOCTEST_USE_STD_HEADERS  "Use std headers" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,10 @@ endif()
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.txt ver)
 project(doctest VERSION ${ver} LANGUAGES CXX)
 
+# Determine if doctest is built as a subproject (using add_subdirectory) or if it is the main project.
 set(MAIN_PROJECT OFF)
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-  set(MAIN_PROJECT ON)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(MAIN_PROJECT ON)
 endif()
 
 option(DOCTEST_WITH_TESTS               "Build tests/examples" ${MAIN_PROJECT})
@@ -31,7 +32,7 @@ endif()
 set(doctest_parts_folder "${CMAKE_CURRENT_SOURCE_DIR}/doctest/parts")
 set(doctest_folder "${CMAKE_CURRENT_SOURCE_DIR}/") # in order to have the mpi extension files, not included into the doctest.h single header
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(MAIN_PROJECT)
     # use a special hidden version of the header which directly includes the 2 parts - proper reporting of file/line locations during dev
     target_include_directories(${PROJECT_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/scripts/development_only/>
@@ -74,7 +75,7 @@ if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
     target_link_libraries(${PROJECT_NAME}_with_main PUBLIC ${PROJECT_NAME})
 endif()
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND DOCTEST_WITH_TESTS)
+if(MAIN_PROJECT AND DOCTEST_WITH_TESTS)
     include(scripts/cmake/common.cmake)
 
     add_subdirectory(examples/all_features)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
When adding `doctest` to a **CMake** project using **FetchContent**, testing has to be explicitly disabled.
This check only enables testing, if `doctest` is the main project being built.

This change enables the cleaner usage of `doctest` with **FetchContent**.

#### Before
```cmake
FetchContent_Declare(
  onqtam_doctest
  GIT_REPOSITORY https://github.com/onqtam/doctest.git
  GIT_TAG dev)
set(DOCTEST_WITH_TESTS OFF)
FetchContent_MakeAvailable(onqtam_doctest)
```

#### After
```cmake
FetchContent_Declare(
  onqtam_doctest
  GIT_REPOSITORY https://github.com/onqtam/doctest.git
  GIT_TAG dev)
FetchContent_MakeAvailable(onqtam_doctest)
```

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
none