### PR TITLE
Automatically add TEST_SUITE labels to discovered tests

### DIFF
--- a/scripts/cmake/doctest.cmake
+++ b/scripts/cmake/doctest.cmake
@@ -32,6 +32,7 @@ same as the doctest name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
                          [TEST_PREFIX prefix]
                          [TEST_SUFFIX suffix]
                          [PROPERTIES name1 value1...]
+                         [ADD_LABELS value]
                          [TEST_LIST var]
                          [JUNIT_OUTPUT_DIR dir]
     )
@@ -85,6 +86,9 @@ same as the doctest name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     Specifies additional properties to be set on all tests discovered by this
     invocation of ``doctest_discover_tests``.
 
+  ``ADD_LABELS value``
+    Specifies if the test labels should be set automatically.
+
   ``TEST_LIST var``
     Make the list of tests available in the variable ``var``, rather than the
     default ``<target>_TESTS``.  This can be useful when the same test
@@ -106,7 +110,7 @@ function(doctest_discover_tests TARGET)
     ""
     ""
     "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;JUNIT_OUTPUT_DIR"
-    "TEST_SPEC;EXTRA_ARGS;PROPERTIES"
+    "TEST_SPEC;EXTRA_ARGS;PROPERTIES;ADD_LABELS"
     ${ARGN}
   )
 
@@ -139,6 +143,7 @@ function(doctest_discover_tests TARGET)
             -D "TEST_SPEC=${_TEST_SPEC}"
             -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
             -D "TEST_PROPERTIES=${_PROPERTIES}"
+            -D "TEST_ADD_LABELS=${_ADD_LABELS}"
             -D "TEST_PREFIX=${_TEST_PREFIX}"
             -D "TEST_SUFFIX=${_TEST_SUFFIX}"
             -D "TEST_LIST=${_TEST_LIST}"

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -55,27 +55,30 @@ foreach(line ${output})
     continue()
   endif()
   set(test ${line})
-  # get test suite that test belongs to
-  execute_process(
-    COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites
-    OUTPUT_VARIABLE labeloutput
-    RESULT_VARIABLE labelresult
-  )
-  if(NOT ${labelresult} EQUAL 0)
-    message(FATAL_ERROR
-      "Error running test executable '${TEST_EXECUTABLE}':\n"
-      "  Result: ${labelresult}\n"
-      "  Output: ${labeloutput}\n"
+  set(labels "")
+  if(DOCTEST_LABEL_TESTS)
+    # get test suite that test belongs to
+    execute_process(
+      COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites
+      OUTPUT_VARIABLE labeloutput
+      RESULT_VARIABLE labelresult
     )
-  endif()
-
-  string(REPLACE "\n" ";" labeloutput "${labeloutput}")
-  foreach(labelline ${labeloutput})
-    if("${labelline}" STREQUAL "===============================================================================" OR "${labelline}" MATCHES [==[^\[doctest\] ]==])
-      continue()
+    if(NOT ${labelresult} EQUAL 0)
+      message(FATAL_ERROR
+        "Error running test executable '${TEST_EXECUTABLE}':\n"
+        "  Result: ${labelresult}\n"
+        "  Output: ${labeloutput}\n"
+      )
     endif()
-    list(APPEND labels ${labelline})
-  endforeach()
+
+    string(REPLACE "\n" ";" labeloutput "${labeloutput}")
+    foreach(labelline ${labeloutput})
+      if("${labelline}" STREQUAL "===============================================================================" OR "${labelline}" MATCHES [==[^\[doctest\] ]==])
+        continue()
+      endif()
+      list(APPEND labels ${labelline})
+    endforeach()
+  endif()
 
   if(NOT "${junit_output_dir}" STREQUAL "")
     # turn testname into a valid filename by replacing all special characters with "-"

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -6,6 +6,7 @@ set(suffix "${TEST_SUFFIX}")
 set(spec ${TEST_SPEC})
 set(extra_args ${TEST_EXTRA_ARGS})
 set(properties ${TEST_PROPERTIES})
+set(add_labels ${TEST_ADD_LABELS})
 set(junit_output_dir "${TEST_JUNIT_OUTPUT_DIR}")
 set(script)
 set(suite)
@@ -56,7 +57,7 @@ foreach(line ${output})
   endif()
   set(test ${line})
   set(labels "")
-  if(DOCTEST_LABEL_TESTS)
+  if(${add_labels} EQUAL 1)
     # get test suite that test belongs to
     execute_process(
       COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -55,6 +55,28 @@ foreach(line ${output})
     continue()
   endif()
   set(test ${line})
+  # get test suite that test belongs to
+  execute_process(
+    COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites
+    OUTPUT_VARIABLE labeloutput
+    RESULT_VARIABLE labelresult
+  )
+  if(NOT ${labelresult} EQUAL 0)
+    message(FATAL_ERROR
+      "Error running test executable '${TEST_EXECUTABLE}':\n"
+      "  Result: ${labelresult}\n"
+      "  Output: ${labeloutput}\n"
+    )
+  endif()
+
+  string(REPLACE "\n" ";" labeloutput "${labeloutput}")
+  foreach(labelline ${labeloutput})
+    if("${labelline}" STREQUAL "===============================================================================" OR "${labelline}" MATCHES [==[^\[doctest\] ]==])
+      continue()
+    endif()
+    list(APPEND labels ${labelline})
+  endforeach()
+
   if(NOT "${junit_output_dir}" STREQUAL "")
     # turn testname into a valid filename by replacing all special characters with "-"
     string(REGEX REPLACE "[/\\:\"|<>]" "-" test_filename "${test}")
@@ -77,8 +99,10 @@ foreach(line ${output})
     "${prefix}${test}${suffix}"
     PROPERTIES
     WORKING_DIRECTORY "${TEST_WORKING_DIR}"
+    LABELS ${labels}
     ${properties}
   )
+  unset(labels)
   list(APPEND tests "${prefix}${test}${suffix}")
 endforeach()
 


### PR DESCRIPTION
The PR is against dev, and I have read the `CONTRIBUTING.md`. I understand that usually a issue is opened for discussion, but I figured the draft PR would illustrate the changes better.

## Description
What:
When using `doctest_discover_tests`, the `LABELS` property is set for the generated test based on the `TEST_SUITE`.

Why:
In a downstream project using CMake, I found it useful to group each `TEST_CASE` in a `TEST_SUITE`. I found myself wanting to selectively run tests based on what `TEST_SUITE` they belong to, e.g, `ctest -L TEST_SUITE_NAME`. The test discovery returns the list of test, but modifying each one would be tedious.

## GitHub Issues
#302 is related, but the discussion doesn't seem to indicate that this is the desired solution.
