### PR TITLE
REQUIRE does not compile when operator== in different namespace #443 .

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -443,9 +443,15 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#include<utility>
+
+
 
 namespace doctest {
+template<typename T, typename U = T&&> U declval(int); 
+
+template<typename T> T declval(long); 
+
+template<typename T> auto declval() noexcept -> decltype(declval<T>(0)) ;
 
 DOCTEST_INTERFACE extern bool is_running_in_test;
 
@@ -1053,7 +1059,7 @@ namespace detail {
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
-#define SFINAE_OP(ret,op) decltype(std::declval<const L&>() op std::declval<const R&>(),static_cast<ret>(0))
+#define SFINAE_OP(ret,op) decltype(doctest::declval<const L&>() op doctest::declval<const R&>(),static_cast<ret>(0))
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -440,9 +440,15 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#include<utility>
+
+
 
 namespace doctest {
+template<typename T, typename U = T&&> U declval(int); 
+
+template<typename T> T declval(long); 
+
+template<typename T> auto declval() noexcept -> decltype(declval<T>(0)) ;
 
 DOCTEST_INTERFACE extern bool is_running_in_test;
 
@@ -1050,7 +1056,7 @@ namespace detail {
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
-#define SFINAE_OP(ret,op) decltype(std::declval<const L&>() op std::declval<const R&>(),static_cast<ret>(0))
+#define SFINAE_OP(ret,op) decltype(doctest::declval<const L&>() op doctest::declval<const R&>(),static_cast<ret>(0))
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -440,6 +440,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#include<utility>
 
 namespace doctest {
 
@@ -1045,9 +1046,15 @@ namespace detail {
         return toString(lhs) + op + toString(rhs);
     }
 
+// This will check if there is any way it could find a operator like member or friend and uses it.
+// If not it doesn't find the operator or if the operator at global scope is defined after
+// this template, the template won't be instantiated due to SFINAE. Once the template is not
+// instantiated it can look for global operator using normal conversions.
+#define SFINAE_OP(ret,op) decltype(std::declval<const L&>() op std::declval<const R&>(),static_cast<ret>(0))
+
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
+    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(const DOCTEST_REF_WRAP(R) rhs) {             \
         bool res = op_macro(lhs, rhs);                                                             \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
@@ -1189,6 +1196,9 @@ namespace detail {
                 return Result(res, toString(lhs));
             return Result(res);
         }
+
+	/* This is required for user-defined conversions from Expression_lhs to L */
+	operator L() const { return lhs; }
 
         // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -450,6 +450,27 @@ template<typename T> T declval(long);
 
 template<typename T> auto declval() noexcept -> decltype(declval<T>(0)) ;
 
+template< class T > struct remove_reference      {typedef T type;};
+template< class T > struct remove_reference<T&>  {typedef T type;};
+template< class T > struct remove_reference<T&&> {typedef T type;};
+
+template<class T> struct is_lvalue_reference { const static bool value=false; };
+template<class T> struct is_lvalue_reference<T&> { const static bool value=true; };
+
+template <class T>
+inline T&& forward(typename remove_reference<T>::type& t) noexcept
+{
+	return static_cast<T&&>(t);
+}
+
+template <class T>
+inline T&& forward(typename remove_reference<T>::type&& t) noexcept
+{
+    static_assert(!is_lvalue_reference<T>::value,
+                     "Can not forward an rvalue as an lvalue.");
+    return static_cast<T&&>(t);
+}
+
 DOCTEST_INTERFACE extern bool is_running_in_test;
 
 // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
@@ -1056,12 +1077,12 @@ namespace detail {
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
-#define SFINAE_OP(ret,op) decltype(doctest::declval<const L&>() op doctest::declval<const R&>(),static_cast<ret>(0))
+#define SFINAE_OP(ret,op) decltype(doctest::declval<L>() op doctest::declval<R>(),static_cast<ret>(0))
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(const DOCTEST_REF_WRAP(R) rhs) {             \
-        bool res = op_macro(lhs, rhs);                                                             \
+    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {             \
+	    bool res = op_macro(doctest::forward<L>(lhs), doctest::forward<R>(rhs));                                                             \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
         if(!res || doctest::getContextOptions()->success)                                          \
@@ -1189,8 +1210,8 @@ namespace detail {
         L                lhs;
         assertType::Enum m_at;
 
-        explicit Expression_lhs(L in, assertType::Enum at)
-                : lhs(in)
+        explicit Expression_lhs(L&& in, assertType::Enum at)
+                : lhs(doctest::forward<L>(in))
                 , m_at(at) {}
 
         DOCTEST_NOINLINE operator Result() {
@@ -1204,6 +1225,7 @@ namespace detail {
         }
 
 	/* This is required for user-defined conversions from Expression_lhs to L */
+	//operator L() const { return lhs; }
 	operator L() const { return lhs; }
 
         // clang-format off
@@ -1257,8 +1279,8 @@ namespace detail {
         // https://github.com/catchorg/Catch2/issues/870
         // https://github.com/catchorg/Catch2/issues/565
         template <typename L>
-        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
-            return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_at);
+	Expression_lhs<L> operator<<(L &&operand) {
+            return Expression_lhs<L>(doctest::forward<L>(operand), m_at);
         }
     };
 

--- a/examples/all_features/CMakeLists.txt
+++ b/examples/all_features/CMakeLists.txt
@@ -22,6 +22,15 @@ set(files_all
     ${files_with_output}
     concurrency.cpp
     ../../scripts/coverage_maxout.cpp
+    namespace1.cpp
+    namespace2.cpp
+    namespace3.cpp
+    namespace4.cpp
+    namespace5.cpp
+    namespace6.cpp
+    namespace7.cpp
+    namespace8.cpp
+    namespace9.cpp
 )
 
 # add the executable
@@ -48,6 +57,16 @@ endforeach()
 if(NOT MINGW AND NOT DEFINED DOCTEST_THREAD_LOCAL)
     doctest_add_test(NO_OUTPUT NAME concurrency.cpp ${common_args} -sf=*concurrency.cpp -d) # duration: there is no output anyway
 endif()
+
+doctest_add_test(NO_OUTPUT NAME namespace1.cpp ${common_args} -sf=*namespace1.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace2.cpp ${common_args} -sf=*namespace2.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace3.cpp ${common_args} -sf=*namespace3.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace4.cpp ${common_args} -sf=*namespace4.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace5.cpp ${common_args} -sf=*namespace5.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace6.cpp ${common_args} -sf=*namespace6.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace7.cpp ${common_args} -sf=*namespace7.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace8.cpp ${common_args} -sf=*namespace8.cpp )
+doctest_add_test(NO_OUTPUT NAME namespace9.cpp ${common_args} -sf=*namespace9.cpp )
 
 # add this separately since the file has a non-straightforward path
 doctest_add_test(NAME coverage_maxout.cpp ${common_args} -sf=*coverage_maxout.cpp)

--- a/examples/all_features/namespace1.cpp
+++ b/examples/all_features/namespace1.cpp
@@ -1,0 +1,27 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user1 {
+struct label
+{
+    label()
+            : i(0) {}
+    int i;
+};
+} // namespace user1
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+bool operator==(const user1::label& lhs, const user1::label& rhs) { return lhs.i == rhs.i; }
+
+
+TEST_CASE("namespace 1 global operator") {
+    user1::label a;
+    user1::label b;
+    CHECK(a == b);
+}

--- a/examples/all_features/namespace2.cpp
+++ b/examples/all_features/namespace2.cpp
@@ -1,0 +1,24 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user2 {
+struct label
+{
+    label()
+            : i(0) {}
+    int         i;
+    friend bool operator==(const user2::label& lhs, const user2::label& rhs) {
+        return lhs.i == rhs.i;
+    }
+};
+} // namespace user2
+
+TEST_CASE("namespace 2 friend operator") {
+    user2::label a;
+    user2::label b;
+    REQUIRE(a == b);
+}

--- a/examples/all_features/namespace3.cpp
+++ b/examples/all_features/namespace3.cpp
@@ -1,0 +1,22 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user3 {
+struct label
+{
+    label()
+            : i(0) {}
+    int  i;
+    bool operator==(const user3::label& rhs) const { return i == rhs.i; }
+};
+} // namespace user3
+
+TEST_CASE("namespace 3 member operator") {
+    user3::label a;
+    user3::label b;
+    REQUIRE(a == b);
+}

--- a/examples/all_features/namespace4.cpp
+++ b/examples/all_features/namespace4.cpp
@@ -1,0 +1,37 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user4 {
+struct label
+{
+    label()
+            : i(0) {}
+    int  i;
+    bool operator==(const user4::label& rhs) const { return i == rhs.i; }
+};
+} // namespace user4
+
+namespace user5 {
+struct label
+{
+    label()
+            : i(0) {}
+    int  i;
+    bool operator==(const user5::label& rhs) const { return i == rhs.i; }
+};
+} // namespace user5
+
+TEST_CASE("namespace 4 member vs member") {
+    user4::label a4;
+    user4::label b4;
+
+    user5::label a5;
+    user5::label b5;
+
+    REQUIRE(a4 == b4);
+    REQUIRE(a5 == b5);
+}

--- a/examples/all_features/namespace5.cpp
+++ b/examples/all_features/namespace5.cpp
@@ -1,0 +1,39 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user6 {
+struct label
+{
+    label()
+            : i(0) {}
+    int  i;
+    bool operator==(const user6::label& rhs) const { return i == rhs.i; }
+};
+} // namespace user6
+
+namespace user7 {
+struct label
+{
+    label()
+            : i(0) {}
+    int         i;
+    friend bool operator==(const user7::label& lhs, const user7::label& rhs) {
+        return lhs.i == rhs.i;
+    }
+};
+} // namespace user7
+
+TEST_CASE("namespace 5 member vs friend") {
+    user6::label a6;
+    user6::label b6;
+
+    user7::label a7;
+    user7::label b7;
+
+    REQUIRE(a6 == b6);
+    REQUIRE(a7 == b7);
+}

--- a/examples/all_features/namespace6.cpp
+++ b/examples/all_features/namespace6.cpp
@@ -1,0 +1,41 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user6 {
+struct label
+{
+    label()
+            : i(0) {}
+    int         i;
+    friend bool operator==(const user6::label& lhs, const user6::label& rhs) {
+        return lhs.i == rhs.i;
+    }
+};
+} // namespace user6
+
+namespace user7 {
+struct label
+{
+    label()
+            : i(0) {}
+    int         i;
+    friend bool operator==(const user7::label& lhs, const user7::label& rhs) {
+        return lhs.i == rhs.i;
+    }
+};
+} // namespace user7
+
+TEST_CASE("namespace 6 friend vs friend") {
+    user6::label a6;
+    user6::label b6;
+
+    user7::label a7;
+    user7::label b7;
+
+    REQUIRE(a6 == b6);
+    REQUIRE(a7 == b7);
+}

--- a/examples/all_features/namespace7.cpp
+++ b/examples/all_features/namespace7.cpp
@@ -1,0 +1,41 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user6 {
+struct label
+{
+    label()
+            : i(0) {}
+    int  i;
+    bool operator==(const user6::label& rhs) const { return i == rhs.i; }
+};
+} // namespace user6
+
+namespace user7 {
+struct label
+{
+    label()
+            : i(0) {}
+    int i;
+};
+} // namespace user7
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+bool operator==(const user7::label& lhs, const user7::label& rhs) { return lhs.i == rhs.i; }
+
+TEST_CASE("namespace 7 member vs global") {
+    user6::label a6;
+    user6::label b6;
+
+    user7::label a7;
+    user7::label b7;
+
+    REQUIRE(a6 == b6);
+    REQUIRE(a7 == b7);
+}

--- a/examples/all_features/namespace8.cpp
+++ b/examples/all_features/namespace8.cpp
@@ -1,0 +1,45 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user6 {
+struct label
+{
+    label()
+            : i(0) {}
+    int         i;
+    friend bool operator==(const user6::label& lhs, const user6::label& rhs) {
+        return lhs.i == rhs.i;
+    }
+};
+} // namespace user6
+
+namespace user8 {
+struct label
+{
+    label()
+            : i(0) {}
+    int i;
+};
+} // namespace user8
+
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+bool operator==(const user8::label& lhs, const user8::label& rhs) { return lhs.i == rhs.i; }
+
+
+TEST_CASE("namespace 8 friend vs global") {
+    user6::label a6;
+    user6::label b6;
+
+    user8::label a8;
+    user8::label b8;
+
+    REQUIRE(a6 == b6);
+    REQUIRE(a8 == b8);
+}

--- a/examples/all_features/namespace9.cpp
+++ b/examples/all_features/namespace9.cpp
@@ -1,0 +1,44 @@
+#include <doctest/doctest.h>
+
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstdint>
+#include <sstream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+
+namespace user9a {
+struct label
+{
+    label()
+            : i(0) {}
+    int i;
+};
+} // namespace user9a
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+bool operator==(const user9a::label& lhs, const user9a::label& rhs) { return lhs.i == rhs.i; }
+
+namespace user9b {
+struct label
+{
+    label()
+            : i(0) {}
+    int i;
+};
+} // namespace user9b
+
+DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
+
+bool operator==(const user9b::label& lhs, const user9b::label& rhs) { return lhs.i == rhs.i; }
+
+TEST_CASE("namespace 9 both global") {
+    user9a::label a1;
+    user9a::label a2;
+
+    user9b::label b1;
+    user9b::label b2;
+
+    REQUIRE(a1 == a2);
+    REQUIRE(b1 == b2);
+}

--- a/examples/all_features/test_output/filter_2.txt
+++ b/examples/all_features/test_output/filter_2.txt
@@ -1,6 +1,6 @@
 [doctest] run with "--help" for options
 ===============================================================================
-[doctest] test cases: 0 | 0 passed | 0 failed | 81 skipped
+[doctest] test cases: 0 | 0 passed | 0 failed | 90 skipped
 [doctest] assertions: 0 | 0 passed | 0 failed |
 [doctest] Status: SUCCESS!
 Program code.

--- a/examples/all_features/test_output/filter_2_xml.txt
+++ b/examples/all_features/test_output/filter_2_xml.txt
@@ -75,6 +75,15 @@
     <TestCase name="multiple types&lt;>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
     <TestCase name="multiple types&lt;>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
     <TestCase name="multiple types&lt;>" filename="templated_test_cases.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 1 global operator" filename="namespace1.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 2 friend operator" filename="namespace2.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 3 member operator" filename="namespace3.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 4 member vs member" filename="namespace4.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 5 member vs friend" filename="namespace5.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 6 friend vs friend" filename="namespace6.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 7 member vs global" filename="namespace7.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 8 friend vs global" filename="namespace8.cpp" line="0" skipped="true"/>
+    <TestCase name="namespace 9 both global" filename="namespace9.cpp" line="0" skipped="true"/>
     <TestCase name="normal macros" filename="assertion_macros.cpp" line="0" skipped="true"/>
   </TestSuite>
   <TestSuite name="ts1">
@@ -119,6 +128,6 @@
     <TestCase name="will end from an unknown exception" filename="coverage_maxout.cpp" line="0" skipped="true"/>
   </TestSuite>
   <OverallResultsAsserts successes="0" failures="0"/>
-  <OverallResultsTestCases successes="0" failures="0" skipped="81"/>
+  <OverallResultsTestCases successes="0" failures="0" skipped="90"/>
 </doctest>
 Program code.


### PR DESCRIPTION

## Description

- This was a valid test case when you have global operator the comparision succeeds but doctest fails.
- This is due to forced instantiation of template member function `Expression_lhs.operator==(const R& rhs).`
- The template member function contains `lhs  == rhs` for equality operator. This comparison fails since the global operator is defined after the template and it doesn't take part in lookup.
-  In that case the function itself is not instantiated due to sfinae and the global operator is visible and due to user defined conversion the operator succeeds.


## GitHub Issues
Closes #443 

