### PR TITLE
Fix compile error when targeting macOS version earlier and macOS 10.12

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1062,7 +1062,7 @@ namespace detail {
                 g_cs->subcasesPassed.insert(g_cs->subcasesStack);
             g_cs->subcasesStack.pop_back();
 
-#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
             if(std::uncaught_exceptions() > 0
 #else
             if(std::uncaught_exception()
@@ -1435,7 +1435,7 @@ namespace detail {
     // ContextScope has been destroyed (base class destructors run after derived class destructors).
     // Instead, ContextScope calls this method directly from its destructor.
     void ContextScopeBase::destroy() {
-#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
         if(std::uncaught_exceptions() > 0) {
 #else
         if(std::uncaught_exception()) {


### PR DESCRIPTION
## Description
Doctest does not compile if you are targeting a macOS version earlier than 10.12. This patch fixes that.

std::uncaught_exceptions only available on 10.12 and above (despite it being in the standard library). It results in the compiler sending an error. Targeting an earlier version of macOS is done with the flag -mmacosx-version-min=x, where x is something like 10.9.

When you use the -mmacosx-version-min flag, a define is set: __MAC_OS_X_VERSION_MIN_REQUIRED. The patch checks against this number.

## GitHub Issues
Closes #466
