### PR TITLE
Convert to bool by casting, rather than double negation

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1184,7 +1184,7 @@ namespace detail {
                 , m_at(at) {}
 
         DOCTEST_NOINLINE operator Result() {
-            bool res = !!lhs;
+            bool res = static_cast<bool>(lhs);
             if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
                 res = !res;
 
@@ -6088,7 +6088,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
     if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-        p->var = !!intRes;                                                                         \
+        p->var = static_cast<bool>(intRes);                                                        \
     else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
         p->var = true;                                                                             \

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3421,7 +3421,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
     if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-        p->var = !!intRes;                                                                         \
+        p->var = static_cast<bool>(intRes);                                                        \
     else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
         p->var = true;                                                                             \

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1181,7 +1181,7 @@ namespace detail {
                 , m_at(at) {}
 
         DOCTEST_NOINLINE operator Result() {
-            bool res = !!lhs;
+            bool res = static_cast<bool>(lhs);
             if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
                 res = !res;
 


### PR DESCRIPTION
## Description

doctest allows asserting the validity of objects that are convertible to `bool`, this works for things like pointers, `optional<T>`, etc., which define an `explicit operator bool() const;`

this is done by `!!arg` which works for that purpose. but doesn't do the right thing in some other cases. for example, bool-like objects that are known at compile time can be implemented like this

```cpp
template <bool B>
struct constant_bool {
  constexpr constant_bool<!B> operator!() const noexcept { return {}; }
  explicit constexpr operator bool() const noexcept { return B; }
};
```

given some `constant_bool<true> b;`, `!b` has type `constant_bool<false>`, and `!!b` again has type `constant_bool<true>`.  
so `bool x = !!b;` doesn't work since the conversion operator is explicit