### PR TITLE
Improve speed with attached debugger (Windows)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5900,8 +5900,10 @@ namespace {
         bool with_col = g_no_colors;                                                               \
         g_no_colors   = false;                                                                     \
         ConsoleReporter::func(arg);                                                                \
-        DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                            \
-        oss.str("");                                                                               \
+        if(oss.tellp() != std::streampos{}) {                                                      \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
+            oss.str("");                                                                           \
+        }                                                                                          \
         g_no_colors = with_col;                                                                    \
     }
 

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -3233,8 +3233,10 @@ namespace {
         bool with_col = g_no_colors;                                                               \
         g_no_colors   = false;                                                                     \
         ConsoleReporter::func(arg);                                                                \
-        DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                            \
-        oss.str("");                                                                               \
+        if(oss.tellp() != std::streampos{}) {                                                      \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
+            oss.str("");                                                                           \
+        }                                                                                          \
         g_no_colors = with_col;                                                                    \
     }
 


### PR DESCRIPTION
## Description

**What**: Only call `OutputDebugStringA` if there's actually something to print.

**Why**: This speeds up execution with a debugger attached dramatically.

## GitHub Issues

Closes #481
