### PR TITLE
Set variable to 0 if not set

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -12,6 +12,10 @@ set(script)
 set(suite)
 set(tests)
 
+if(NOT DEFINED ${add_labels})
+    set(add_labels 0)
+endif()
+
 function(add_command NAME)
   set(_args "")
   foreach(_arg ${ARGN})


### PR DESCRIPTION
## Description
Set a variable in the CMake to zero if it is not defined.

## GitHub Issues
Closes #489 
