### PR TITLE
Fix build with GCC 11

### DIFF
--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -103,9 +103,6 @@ TEST_CASE("all asserts should fail and show how the objects get stringified") {
     MyTypeInherited<int> bla1;
     bla1.one = 5;
     bla1.two = 4u;
-    MyTypeInherited<int> bla2;
-    bla2.one = 5;
-    bla2.two = 6u;
 
     Bar::Foo f1;
     Bar::Foo f2;


### PR DESCRIPTION
GCC 11 started warning about unused-but-set variables. Here's how it
fails:
```
 examples/all_features/stringification.cpp: In function ‘void _DOCTEST_ANON_FUNC_20()’:
 examples/all_features/stringification.cpp:106:26: error: variable ‘bla2’ set but not used [-Werror=unused-but-set-variable]
   106 |     MyTypeInherited<int> bla2;
       |                          ^~~~
```
I don't think that that assignment is actually doing anything; in fact,
there's that other variable which is assigned in a similar manner, but
that one is also used for an assert.