### PR TITLE
specifying working directory for execute_process in doctest_discover_tests

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -39,6 +39,7 @@ execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-cases
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
 if(NOT ${result} EQUAL 0)
   message(FATAL_ERROR
@@ -63,6 +64,7 @@ foreach(line ${output})
       COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites
       OUTPUT_VARIABLE labeloutput
       RESULT_VARIABLE labelresult
+      WORKING_DIRECTORY "${TEST_WORKING_DIR}"
     )
     if(NOT ${labelresult} EQUAL 0)
       message(FATAL_ERROR


### PR DESCRIPTION
## Description
quoting from https://github.com/catchorg/Catch2/pull/2039 :

> In a CMake project, when using `catch_discover_tests(WORKING_DIRECTORY [...])` it usually means that the test binary needs resources that are relative to said working directory. This could lead to UB or a crash when running `--list-test-names-only` or `--list-reporters` on the produced test binary i.e when a .dll is not lazy loaded and not available in the current PATH.
> This commit simply forwards the `WORKING_DIRECTORY` argument to the `execute_process()` calls.
> 
> This also remove the need of using CMake's own magic with `CMAKE_MSVCIDE_RUN_PATH` and the like...


## GitHub Issues
See https://github.com/catchorg/Catch2/pull/2039
