### PR TITLE
remove unused bla2 from stringification example

### DIFF
--- a/examples/all_features/stringification.cpp
+++ b/examples/all_features/stringification.cpp
@@ -103,9 +103,6 @@ TEST_CASE("all asserts should fail and show how the objects get stringified") {
     MyTypeInherited<int> bla1;
     bla1.one = 5;
     bla1.two = 4u;
-    MyTypeInherited<int> bla2;
-    bla2.one = 5;
-    bla2.two = 6u;
 
     Bar::Foo f1;
     Bar::Foo f2;


### PR DESCRIPTION
## Description
2.4.6 cannot be packaged for Fedora due to a `-Werror` break:
```cpp
/builddir/build/BUILD/doctest-2.4.6/examples/all_features/stringification.cpp:106:26: error: variable 'bla2' set but not used [-Werror=unused-but-set-variable]
  106 |     MyTypeInherited<int> bla2;
      |                          ^~~~
```

This removes the unused variable.