### PR TITLE
Fixed intel compiler parser bug. Should fix #502

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1079,7 +1079,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
-#define SFINAE_OP(ret,op) decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),static_cast<ret>(0))
+#define SFINAE_OP(ret,op) decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),ret{})
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
@@ -1108,6 +1108,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
         bool   m_passed;
         String m_decomp;
 
+        Result() = default;
         Result(bool passed, const String& decomposition = String());
 
         // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1076,7 +1076,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // If not it doesn't find the operator or if the operator at global scope is defined after
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
-#define SFINAE_OP(ret,op) decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),static_cast<ret>(0))
+#define SFINAE_OP(ret,op) decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),ret{})
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
@@ -1105,6 +1105,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
         bool   m_passed;
         String m_decomp;
 
+        Result() = default;
         Result(bool passed, const String& decomposition = String());
 
         // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence


### PR DESCRIPTION
## Description
Related to #502
The intel compiler has a funky parser that does not handle well some complex C++ expressions. This is the case for 

```
decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),static_cast<ret>(0))
```

where the combination of `doctest::detail::declval<L>()`, a comma, and then the `static_cast` triggers a parser error in the compiler.

The proposed way to correct it is to replace it by the simpler (from icpc point of view) :

```
decltype(doctest::detail::declval<L>() op doctest::detail::declval<R>(),ret{})
```

From my understanding it does the same (I might be wrong though), except that `ret` has to be default constructible. So the default ctor has also been added.
Of course, `doctest::detail::declval<ret>()` could have also been a replacement, but it also breaks intel.

Side note : The intel compiler is not in the CI, do any of you know if this is possible ? From https://github.com/nemequ/icc-travis it seems that it is, but not sure how to do it though...

## GitHub Issues
Should fix #502
