### PR TITLE
Replace gendered pronouns

### DIFF
--- a/doc/html_generated/configuration.html
+++ b/doc/html_generated/configuration.html
@@ -50,7 +50,7 @@ This should be defined only in the source file where the library is implemented.
 
 ### **```DOCTEST_CONFIG_IMPLEMENT```**
 
-If the client wants to [**supply the ```main()``` function**](main.html) (either to set an option with some value from the code or to integrate the framework into his existing project codebase) this identifier should be used.
+If the client wants to [**supply the ```main()``` function**](main.html) (either to set an option with some value from the code or to integrate the framework into their existing project codebase) this identifier should be used.
 
 This should be defined only in the source file where the library is implemented.
 

--- a/doc/html_generated/faq.html
+++ b/doc/html_generated/faq.html
@@ -151,10 +151,10 @@ A compiler-specific solution for MSVC is to use the [```/OPT:NOREF```](https://m
 
 There are 2 options:
 
-- just include the doctest header in your headers and write the tests - the doctest header should be shipped with your headers and the user will have to implement the doctest runner in one of his source files.
-- don't include the doctest header and guard your test cases with ```#ifdef DOCTEST_LIBRARY_INCLUDED``` and ```#endif``` - that way your tests will be compiled and registered if the user includes the doctest header before your headers (and he will also have to implement the test runner somewhere).
+- just include the doctest header in your headers and write the tests - the doctest header should be shipped with your headers and the user will have to implement the doctest runner in one of their source files.
+- don't include the doctest header and guard your test cases with ```#ifdef DOCTEST_LIBRARY_INCLUDED``` and ```#endif``` - that way your tests will be compiled and registered if the user includes the doctest header before your headers (and they will also have to implement the test runner somewhere).
 
-Also note that it would be a good idea to add a tag in your test case names (like this: ```TEST_CASE("[the_lib] testing foo")```) so the user can easily filter them out with ```--test-case-exclude=*the_lib*``` if he wishes to.
+Also note that it would be a good idea to add a tag in your test case names (like this: ```TEST_CASE("[the_lib] testing foo")```) so the user can easily filter them out with ```--test-case-exclude=*the_lib*``` if they wish to.
 
 ### Does the framework use exceptions?
 

--- a/doc/html_generated/parameterized-tests.html
+++ b/doc/html_generated/parameterized-tests.html
@@ -31,7 +31,7 @@ There will be proper support for this in the future. For now there are 2 ways of
     This has several drawbacks:
     - in case of an exception (or a ```REQUIRE``` assert failing) the entire test case ends and the checks are not done for the rest of the input data
     - the user has to manually log the data with calls to ```CAPTURE()``` ( or ```INFO()```)
-    - more boilerplate - doctest should supply primitives for generating data but currently doesnt - so the user has to write his own data generation
+    - more boilerplate - doctest should supply primitives for generating data but currently doesnt - so the user has to write their own data generation
 
 - using subcases to initialize data differently:
 
@@ -127,7 +127,7 @@ There are 2 ways to do it:
 
     TEST_CASE_TEMPLATE_APPLY(test_id, std::tuple<float, double>);
     ```
-    If you are designing an interface or concept, you can define a suite of type-parameterized tests to verify properties that any valid implementation of the interface/concept should have. Then, the author of each implementation can just instantiate the test suite with his type to verify that it conforms to the requirements, without having to write similar tests repeatedly.
+    If you are designing an interface or concept, you can define a suite of type-parameterized tests to verify properties that any valid implementation of the interface/concept should have. Then, the author of each implementation can just instantiate the test suite with their type to verify that it conforms to the requirements, without having to write similar tests repeatedly.
 
 
 A test case named ```signed integers stuff``` instantiated for type ```int``` will yield the following test case name:

--- a/doc/html_generated/testcases.html
+++ b/doc/html_generated/testcases.html
@@ -128,7 +128,7 @@ Multiple decorators can be used at the same time. These are the currently suppor
 - **```no_breaks(bool = true)```** - no breaking into the debugger for asserts in the test case - useful in combination with `may_fail`/`should_fail`/`expected_failures`
 - **```no_output(bool = true)```** - no output from asserts in the test case - useful in combination with `may_fail`/`should_fail`/`expected_failures`
 - **```may_fail(bool = true)```** - doesn't fail the test if any given assertion fails (but still reports it) - this can be useful to flag a work-in-progress, or a known issue that you don't want to immediately fix but still want to track in the your tests
-- **```should_fail(bool = true)```** - like **```may_fail()```** but fails the test if it passes - his can be useful if you want to be notified of accidental, or third-party, fixes
+- **```should_fail(bool = true)```** - like **```may_fail()```** but fails the test if it passes - this can be useful if you want to be notified of accidental, or third-party, fixes
 - **```expected_failures(int)```** - defines the number of assertions that are expected to fail within the test case - reported as failure when the number of failed assertions is different than the declared expected number of failures
 - **```timeout(double)```** - fails the test case if its execution exceeds this limit (in seconds) - but doesn't terminate it - that would require subprocess support
 - **```test_suite("name")```** - can be used on test cases to override (or just set) the test suite they are in

--- a/doc/markdown/configuration.md
+++ b/doc/markdown/configuration.md
@@ -45,7 +45,7 @@ This should be defined only in the source file where the library is implemented.
 
 ### **```DOCTEST_CONFIG_IMPLEMENT```**
 
-If the client wants to [**supply the ```main()``` function**](main.md) (either to set an option with some value from the code or to integrate the framework into his existing project codebase) this identifier should be used.
+If the client wants to [**supply the ```main()``` function**](main.md) (either to set an option with some value from the code or to integrate the framework into their existing project codebase) this identifier should be used.
 
 This should be defined only in the source file where the library is implemented.
 
@@ -69,7 +69,7 @@ This should be defined only in the source file where the library is implemented 
 
 ### **```DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES```**
 
-This will remove all macros from **doctest** that don't have the **```DOCTEST_```** prefix - like **```CHECK```**, **```TEST_CASE```** and **```SUBCASE```**. Then only the full macro names will be available - **```DOCTEST_CHECK```**, **```DOCTEST_TEST_CASE```** and **```DOCTEST_SUBCASE```**. The user is free to make his own short versions of these macros - [**example**](../../examples/all_features/alternative_macros.cpp).
+This will remove all macros from **doctest** that don't have the **```DOCTEST_```** prefix - like **```CHECK```**, **```TEST_CASE```** and **```SUBCASE```**. Then only the full macro names will be available - **```DOCTEST_CHECK```**, **```DOCTEST_TEST_CASE```** and **```DOCTEST_SUBCASE```**. The user is free to make their own short versions of these macros - [**example**](../../examples/all_features/alternative_macros.cpp).
 
 This can be defined both globally and in specific source files only.
 

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -146,10 +146,10 @@ A compiler-specific solution for MSVC is to use the [```/OPT:NOREF```](https://m
 
 There are 2 options:
 
-- just include the doctest header in your headers and write the tests - the doctest header should be shipped with your headers and the user will have to implement the doctest runner in one of his source files.
-- don't include the doctest header and guard your test cases with ```#ifdef DOCTEST_LIBRARY_INCLUDED``` and ```#endif``` - that way your tests will be compiled and registered if the user includes the doctest header before your headers (and he will also have to implement the test runner somewhere).
+- just include the doctest header in your headers and write the tests - the doctest header should be shipped with your headers and the user will have to implement the doctest runner in one of their source files.
+- don't include the doctest header and guard your test cases with ```#ifdef DOCTEST_LIBRARY_INCLUDED``` and ```#endif``` - that way your tests will be compiled and registered if the user includes the doctest header before your headers (and they will also have to implement the test runner somewhere).
 
-Also note that it would be a good idea to add a tag in your test case names (like this: ```TEST_CASE("[the_lib] testing foo")```) so the user can easily filter them out with ```--test-case-exclude=*the_lib*``` if he wishes to.
+Also note that it would be a good idea to add a tag in your test case names (like this: ```TEST_CASE("[the_lib] testing foo")```) so the user can easily filter them out with ```--test-case-exclude=*the_lib*``` if they wish to.
 
 ### Does the framework use exceptions?
 

--- a/doc/markdown/parameterized-tests.md
+++ b/doc/markdown/parameterized-tests.md
@@ -15,7 +15,7 @@ There will be proper support for this in the future. For now there are 2 ways of
 
     TEST_CASE("test name") {
         std::vector<int> data {1, 2, 3, 4, 5, 6};
-        
+
         for(auto& i : data) {
             CAPTURE(i); // log the current input data
             doChecks(i);
@@ -26,7 +26,7 @@ There will be proper support for this in the future. For now there are 2 ways of
     This has several drawbacks:
     - in case of an exception (or a ```REQUIRE``` assert failing) the entire test case ends and the checks are not done for the rest of the input data
     - the user has to manually log the data with calls to ```CAPTURE()``` ( or ```INFO()```)
-    - more boilerplate - doctest should supply primitives for generating data but currently doesnt - so the user has to write his own data generation
+    - more boilerplate - doctest should supply primitives for generating data but currently doesnt - so the user has to write their own data generation
 
 - using subcases to initialize data differently:
 
@@ -35,9 +35,9 @@ There will be proper support for this in the future. For now there are 2 ways of
         int data;
         SUBCASE("") { data = 1; }
         SUBCASE("") { data = 2; }
-        
+
         CAPTURE(data);
-        
+
         // do asserts with data
     }
     ```
@@ -45,11 +45,11 @@ There will be proper support for this in the future. For now there are 2 ways of
     This has the following drawbacks:
     - doesn't scale well - it is very impractical to write such code for more than a few different inputs
     - the user has to manually log the data with calls to ```CAPTURE()``` (or ```INFO()```)
-    
+
     --------------------------------
-    
+
     There is however an easy way to encapsulate this into a macro (written with C++14 for simplicity):
-    
+
     ```c++
     #include <algorithm>
     #include <string>
@@ -62,22 +62,22 @@ There will be proper support for this in the future. For now there are 2 ways of
         });                                                                                         \
         _doctest_subcase_idx = 0
     ```
-    
+
     and now this can be used as follows:
-    
+
     ```c++
     TEST_CASE("test name") {
         int data;
         std::list<int> data_container = {1, 2, 3, 4}; // must be iterable - std::vector<> would work as well
 
         DOCTEST_VALUE_PARAMETERIZED_DATA(data, data_container);
-        
+
         printf("%d\n", data);
     }
     ```
-    
+
     and will print the 4 numbers by re-entering the test case 3 times (after the first entry) - just like subcases work:
-    
+
     ```
     1
     2
@@ -122,7 +122,7 @@ There are 2 ways to do it:
 
     TEST_CASE_TEMPLATE_APPLY(test_id, std::tuple<float, double>);
     ```
-    If you are designing an interface or concept, you can define a suite of type-parameterized tests to verify properties that any valid implementation of the interface/concept should have. Then, the author of each implementation can just instantiate the test suite with his type to verify that it conforms to the requirements, without having to write similar tests repeatedly.
+    If you are designing an interface or concept, you can define a suite of type-parameterized tests to verify properties that any valid implementation of the interface/concept should have. Then, the author of each implementation can just instantiate the test suite with their type to verify that it conforms to the requirements, without having to write similar tests repeatedly.
 
 
 A test case named ```signed integers stuff``` instantiated for type ```int``` will yield the following test case name:

--- a/doc/markdown/testcases.md
+++ b/doc/markdown/testcases.md
@@ -123,7 +123,7 @@ Multiple decorators can be used at the same time. These are the currently suppor
 - **```no_breaks(bool = true)```** - no breaking into the debugger for asserts in the test case - useful in combination with `may_fail`/`should_fail`/`expected_failures`
 - **```no_output(bool = true)```** - no output from asserts in the test case - useful in combination with `may_fail`/`should_fail`/`expected_failures`
 - **```may_fail(bool = true)```** - doesn't fail the test if any given assertion fails (but still reports it) - this can be useful to flag a work-in-progress, or a known issue that you don't want to immediately fix but still want to track in the your tests
-- **```should_fail(bool = true)```** - like **```may_fail()```** but fails the test if it passes - his can be useful if you want to be notified of accidental, or third-party, fixes
+- **```should_fail(bool = true)```** - like **```may_fail()```** but fails the test if it passes - this can be useful if you want to be notified of accidental, or third-party, fixes
 - **```expected_failures(int)```** - defines the number of assertions that are expected to fail within the test case - reported as failure when the number of failed assertions is different than the declared expected number of failures
 - **```timeout(double)```** - fails the test case if its execution exceeds this limit (in seconds) - but doesn't terminate it - that would require subprocess support
 - **```test_suite("name")```** - can be used on test cases to override (or just set) the test suite they are in


### PR DESCRIPTION
## Description

Just a small doc update to replace some masculine pronouns with neutral equivalents. A spelling fix and some trailing whitespace fixes made it in as well.