### PR TITLE
Fixing issue with doctestAddTests.cmake

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -57,7 +57,7 @@ foreach(line ${output})
   endif()
   set(test ${line})
   set(labels "")
-  if(${add_labels} EQUAL 1)
+  if(${add_labels})
     # get test suite that test belongs to
     execute_process(
       COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites


### PR DESCRIPTION
Newer versions of CMake won't work with line 60: `if(${add_labels} EQUAL 1)`, changed it to simply `if (${add_labels})`

<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Builds using the CMake `doctest_discover_tests` function are failing due to a syntax error. This is likely due to newer versions of CMake syntax. This fixes those issues by updating the syntax.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Addresses #524 