### PR TITLE
build(meson): use `override_dependency` if supported

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,2 +1,7 @@
-project('doctest', ['cpp'], version: '2.4.6', meson_version:'>=0.50')
+project('doctest', 'cpp', version: '2.4.6')
+
 doctest_dep = declare_dependency(include_directories: include_directories('doctest'))
+
+if meson.version().version_compare('>=0.54.0')
+    meson.override_dependency('doctest', doctest_dep)
+endif


### PR DESCRIPTION
This improves user experience when using doctest as a Meson subproject.

With this change users will be able to simply call `dependency('doctest')` and have Meson automatically resolve the dependency from the subproject if it is not found on the system.

Without this, users always have to explicitly call `dependency('doctest', fallback: ['doctest', 'doctest_dep'])`

I also removed the minimum required Meson version, that was mistakenly re-added in 77af20093f9c2ce11e46374224c86e1f82d30cdc

<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->