### PR TITLE
Fix build with -Wunused-but-set-variable

### DIFF
--- a/examples/all_features/test_cases_and_suites.cpp
+++ b/examples/all_features/test_cases_and_suites.cpp
@@ -2,13 +2,15 @@
 
 #include "header.h"
 
-static void doStuff() {
+static int doStuff() {
     int a = 5;
     a += 2;
     // asserts and other doctest functionality can be used in user code if checked for a testing context
     // AND they can also be used without such checks - see "asserts_used_outside_of_tests.cpp"
     if(doctest::is_running_in_test)
         CHECK(a == 7);
+
+    return a;
 }
 
 TEST_CASE("an empty test that will succeed - not part of a test suite") {}


### PR DESCRIPTION
Some compilers (hi clang 14) warn about variables which are written to but not used -- and that's what happens when doctest is disabled by a compiler macro in the `disabled` tests.

Fix by simply returning the result from that function. That's less invasive than printing to `stdout` which would break the testsuite.