### PR TITLE
Xcode 11.3 with macos 10.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
             compiler: gcc
 
           - name: macOS-latest-xcode-11.3
-            os: macOS-latest
+            os: macOS-10.15
             compiler: xcode
             version: "11.3"
 


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->
CI is currently broken for macOS because `macos-latest` moved from macOS 10.15 to macOS 11 and no longer has Xcode 11.3.

Some coverage (pinning macos-10.15) is better than no coverage and an ❌ .

Changes CI to use macOS 10.15.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #547 