### PR TITLE
allow specifying separate outputs for reporters

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -414,6 +414,7 @@ using ticks_t = timer_large_integer::type;
         MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
         std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+        std::map<String, String> out;                                    // map of filters to output filenames
 
         std::vector<IReporter*> reporters_currently_used;
 
@@ -1055,6 +1056,16 @@ namespace {
             if (wildcmp(name, curr.c_str(), caseSensitive))
                 return true;
         return false;
+    }
+
+    // checks if the name matches any of the filters, and returns the matching output stream
+    std::fstream* matchesAny(const char* name,
+        std::map<String, std::fstream>& output_filters,
+        bool caseSensitive) {
+        for (auto& curr : output_filters)
+            if (wildcmp(name, curr.first.c_str(), caseSensitive))
+                return &curr.second;
+        return nullptr;
     }
 
     unsigned long long hash(unsigned long long a, unsigned long long b) {
@@ -2315,9 +2326,10 @@ namespace {
         const ContextOptions& opt;
         const TestCaseData*   tc = nullptr;
 
-        XmlReporter(const ContextOptions& co)
-                : xml(*co.cout)
+        XmlReporter(const ContextOptions& co, std::ostream* ostr = nullptr)
+                : xml(ostr ? *ostr : std::cout)
                 , opt(co) {}
+
 
         void log_contexts() {
             int num_contexts = get_num_active_contexts();
@@ -2689,8 +2701,8 @@ namespace {
         const ContextOptions& opt;
         const TestCaseData*   tc = nullptr;
 
-        JUnitReporter(const ContextOptions& co)
-                : xml(*co.cout)
+        JUnitReporter(const ContextOptions& co, std::ostream* ostr = nullptr)
+                : xml(ostr ? *ostr : std::cout)
                 , opt(co) {}
 
         unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
@@ -2846,12 +2858,8 @@ namespace {
         const ContextOptions& opt;
         const TestCaseData*   tc;
 
-        ConsoleReporter(const ContextOptions& co)
-                : s(*co.cout)
-                , opt(co) {}
-
-        ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-                : s(ostr)
+        ConsoleReporter(const ContextOptions& co, std::ostream* ostr = nullptr)
+                : s(ostr ? *ostr : std::cout)
                 , opt(co) {}
 
         // =========================================================================================
@@ -3007,8 +3015,8 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "filters OUT subcases by their name\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "r,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "reporters=<filters>           "
               << Whitespace(sizePrefixDisplay*1) << "reporters to use (console is default)\n";
-            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
-              << Whitespace(sizePrefixDisplay*1) << "output filename\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<filter>[<string>]...     "
+              << Whitespace(sizePrefixDisplay*1) << "output filenames for reporters\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
               << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
             s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
@@ -3295,7 +3303,7 @@ namespace {
         DOCTEST_THREAD_LOCAL static std::ostringstream oss;
 
         DebugOutputWindowReporter(const ContextOptions& co)
-                : ConsoleReporter(co, oss) {}
+                : ConsoleReporter(co, &oss) {}
 
 #define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                    \
     void func(type arg) override {                                                                 \
@@ -3424,6 +3432,42 @@ namespace {
         return false;
     }
 
+    bool parseCommaSepArgsTwoPart(int argc, const char* const* argv,
+                                  const char* pattern,
+                                  std::map<String, String>& res) {
+        std::vector<String> args;
+        if (!parseCommaSepArgs(argc, argv, pattern, args)) {
+            return false;
+        }
+
+        for (auto& str : args) {
+            if (str.size() == 0)
+                return false;
+
+            const auto close = str.rfind(']');
+            if (close == str.size()-1) {
+                const auto open = str.rfind('[', close);
+                if (open != str.npos) {
+                    auto filter = str.substr(0, open);
+                    auto filename = str.substr(open+1, close-open-1);
+                    auto where_inserted = res.emplace(filter, filename);
+                    // already have an output for this filter
+                    if (!where_inserted.second)
+                        return false;
+                } else {
+                    return false;
+                }
+            } else {
+                auto where_inserted = res.emplace("*", str);
+                // already have an output for the '*' filter
+                if (!where_inserted.second)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
     enum optionType
     {
         option_bool,
@@ -3508,6 +3552,8 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
+    parseCommaSepArgsTwoPart(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "out=",                p->out);
+    parseCommaSepArgsTwoPart(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "o=",                  p->out);
     // clang-format on
 
     int    intRes = 0;
@@ -3537,7 +3583,6 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     p->var = strRes
 
     // clang-format off
-    DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
     DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
     DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
 
@@ -3644,8 +3689,6 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
-void Context::setCout(std::ostream* out) { p->cout = out; }
-
 static class DiscardOStream : public std::ostream
 {
 private:
@@ -3682,18 +3725,11 @@ int Context::run() {
     g_no_colors = p->no_colors;
     p->resetRunData();
 
-    std::fstream fstr;
-    if(p->cout == nullptr) {
-        if(p->quiet) {
-            p->cout = &discardOut;
-        } else if(p->out.size()) {
-            // to a file if specified
-            fstr.open(p->out.c_str(), std::fstream::out);
-            p->cout = &fstr;
-        } else {
-            // stdout by default
-            p->cout = &std::cout;
-        }
+    std::map<String, std::fstream> reporter_streams;
+    for (const auto& filter_output : p->out) {
+        const auto& filter = filter_output.first;
+        const auto& output = filter_output.second;
+        reporter_streams.emplace(filter, std::fstream(output.c_str(), std::fstream::out));
     }
 
     FatalConditionHandler::allocateAltStackMem();
@@ -3701,8 +3737,9 @@ int Context::run() {
     auto cleanup_and_return = [&]() {
         FatalConditionHandler::freeAltStackMem();
 
-        if(fstr.is_open())
-            fstr.close();
+        for (auto& fstr : reporter_streams)
+            if(fstr.second.is_open())
+                fstr.second.close();
 
         // restore context
         g_cs               = old_cs;
@@ -3724,15 +3761,25 @@ int Context::run() {
 
     // check to see if any of the registered reporters has been selected
     for(auto& curr : getReporters()) {
-        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-            p->reporters_currently_used.push_back(curr.second(*g_cs));
+        // stdout by default
+        std::ostream* cout = &std::cout;
+        if (p->quiet) {
+            cout = &discardOut;
+        }
+        else if(std::ostream* out = matchesAny(curr.first.second.c_str(), reporter_streams, p->case_sensitive)) {
+            cout = out;
+        }
+
+        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive)) {
+            p->reporters_currently_used.push_back(curr.second(*g_cs, cout));
+        }
     }
 
     // TODO: check if there is nothing in reporters_currently_used
 
     // prepend all listeners
     for(auto& curr : getListeners())
-        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs, nullptr));
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
     if(isDebuggerActive() && p->no_debug_output == false)

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -64,6 +64,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <math.h>
 #endif // __BORLANDC__
 #include <new>
+#include <memory>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -267,7 +268,7 @@ namespace detail {
 
 namespace timer_large_integer
 {
-    
+
 #if defined(DOCTEST_PLATFORM_WINDOWS)
     using type = ULONGLONG;
 #else // DOCTEST_PLATFORM_WINDOWS
@@ -1060,11 +1061,11 @@ namespace {
 
     // checks if the name matches any of the filters, and returns the matching output stream
     std::fstream* matchesAny(const char* name,
-        std::map<String, std::fstream>& output_filters,
+        std::map<String, std::unique_ptr<std::fstream>>& output_filters,
         bool caseSensitive) {
         for (auto& curr : output_filters)
             if (wildcmp(name, curr.first.c_str(), caseSensitive))
-                return &curr.second;
+                return curr.second.get();
         return nullptr;
     }
 
@@ -1912,7 +1913,7 @@ namespace detail {
             m_string = tlssPop();
             logged = true;
         }
-        
+
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
 
         const bool isWarn = m_severity & assertType::is_warn;
@@ -2464,7 +2465,7 @@ namespace {
             test_case_start_impl(in);
             xml.ensureTagClosed();
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
@@ -3182,7 +3183,7 @@ namespace {
             subcasesStack.clear();
             currentSubcaseLevel = 0;
         }
-        
+
         void test_case_reenter(const TestCaseData&) override {
             subcasesStack.clear();
         }
@@ -3725,11 +3726,11 @@ int Context::run() {
     g_no_colors = p->no_colors;
     p->resetRunData();
 
-    std::map<String, std::fstream> reporter_streams;
+    std::map<String, std::unique_ptr<std::fstream>> reporter_streams;
     for (const auto& filter_output : p->out) {
         const auto& filter = filter_output.first;
         const auto& output = filter_output.second;
-        reporter_streams.emplace(filter, std::fstream(output.c_str(), std::fstream::out));
+        reporter_streams[filter].reset(new std::fstream(output.c_str(), std::fstream::out));
     }
 
     FatalConditionHandler::allocateAltStackMem();
@@ -3738,8 +3739,8 @@ int Context::run() {
         FatalConditionHandler::freeAltStackMem();
 
         for (auto& fstr : reporter_streams)
-            if(fstr.second.is_open())
-                fstr.second.close();
+            if(fstr.second->is_open())
+                fstr.second->close();
 
         // restore context
         g_cs               = old_cs;
@@ -3904,7 +3905,7 @@ int Context::run() {
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
             p->timer.start();
-            
+
             bool run_test = true;
 
             do {
@@ -3945,7 +3946,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
                     run_test = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
-                
+
                 if(!p->nextSubcaseStack.empty() && run_test)
                     DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
                 if(p->nextSubcaseStack.empty())

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -866,13 +866,11 @@ namespace detail {
 
 struct ContextOptions //!OCLINT too many fields
 {
-    std::ostream* cout = nullptr; // stdout stream
     String        binary_name;    // the test binary name
 
     const detail::TestCase* currentTest = nullptr;
 
     // == parameters from the command line
-    String   out;       // output filename
     String   order_by;  // how tests should be ordered
     unsigned rand_seed; // the seed for rand ordering
 
@@ -2051,13 +2049,13 @@ struct DOCTEST_INTERFACE IReporter
 };
 
 namespace detail {
-    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
+    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&, std::ostream*);
 
     DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
 
     template <typename Reporter>
-    IReporter* reporterCreator(const ContextOptions& o) {
-        return new Reporter(o);
+    IReporter* reporterCreator(const ContextOptions& o, std::ostream* ostr) {
+        return new Reporter(o, ostr);
     }
 } // namespace detail
 

--- a/examples/all_features/reporters_and_listeners.cpp
+++ b/examples/all_features/reporters_and_listeners.cpp
@@ -3,6 +3,7 @@
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <vector>
 #include <mutex>
+#include <iostream>
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")
@@ -25,9 +26,8 @@ struct MyXmlReporter : public IReporter
     const TestCaseData*   tc;
     std::mutex            mutex;
 
-    // constructor has to accept the ContextOptions by ref as a single argument
-    MyXmlReporter(const ContextOptions& in)
-            : stdout_stream(*in.cout)
+    MyXmlReporter(const ContextOptions& in, std::ostream* ostr)
+            : stdout_stream(ostr ? *ostr : std::cout)
             , opt(in)
             , tc(nullptr) {}
 

--- a/examples/all_features/test_output/help.txt
+++ b/examples/all_features/test_output/help.txt
@@ -27,7 +27,7 @@
  -sc,  --subcase=<filters>             filters     subcases by their name
  -sce, --subcase-exclude=<filters>     filters OUT subcases by their name
  -r,   --reporters=<filters>           reporters to use (console is default)
- -o,   --out=<string>                  output filename
+ -o,   --out=<filter>[<string>]...     output filenames for reporters
  -ob,  --order-by=<string>             how the tests should be ordered
                                        <string> - [file/suite/name/rand/none]
  -rs,  --rand-seed=<int>               seed for random ordering


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
Extends the command-line arguments to allow specifying a filter of reporters
to which the output filename applies: `--out=junit[junit-report.xml],xml[report.xml],console[log.txt]`
The old syntax `--out=filename` still works, being treated like `--out=*[filename]`.
This allows sending for example JUnit output to a file, and still having the console reporter output to the console: `-r=junit,console -o=junit[report.xml]` (since no output file has a matcher that matches the `console` reporter, it uses its default, stdout).

(Should there be an explicit way to specify stdout as well? Possibly using `-` as the filename, like many *nix tools do?)


TODO:  
- [ ] update documentation
- [ ] API for setting these from `main`
- [ ] tests, coverage

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
See #627
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
