### PR TITLE
Fix bug in automatic testcase labelling of tests with commas in their names

### DIFF
--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -56,12 +56,14 @@ foreach(line ${output})
   if("${line}" STREQUAL "===============================================================================" OR "${line}" MATCHES [==[^\[doctest\] ]==])
     continue()
   endif()
-  set(test ${line})
+  set(unescaped_test ${line})
+  # use escape commas to handle properly test cases with commas inside the name
+  string(REPLACE "," "\\," escaped_test ${unescaped_test})
   set(labels "")
   if(${add_labels})
     # get test suite that test belongs to
     execute_process(
-      COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites
+      COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${escaped_test} --list-test-suites
       OUTPUT_VARIABLE labeloutput
       RESULT_VARIABLE labelresult
       WORKING_DIRECTORY "${TEST_WORKING_DIR}"
@@ -85,24 +87,22 @@ foreach(line ${output})
 
   if(NOT "${junit_output_dir}" STREQUAL "")
     # turn testname into a valid filename by replacing all special characters with "-"
-    string(REGEX REPLACE "[/\\:\"|<>]" "-" test_filename "${test}")
+    string(REGEX REPLACE "[/\\:\"|<>]" "-" test_filename "${unescaped_test}")
     set(TEST_JUNIT_OUTPUT_PARAM "--reporters=junit" "--out=${junit_output_dir}/${prefix}${test_filename}${suffix}.xml")
   else()
     unset(TEST_JUNIT_OUTPUT_PARAM)
   endif()
-  # use escape commas to handle properly test cases with commas inside the name
-  string(REPLACE "," "\\," test_name ${test})
   # ...and add to script
   add_command(add_test
-    "${prefix}${test}${suffix}"
+    "${prefix}${unescaped_test}${suffix}"
     ${TEST_EXECUTOR}
     "${TEST_EXECUTABLE}"
-    "--test-case=${test_name}"
+    "--test-case=${escaped_test}"
     "${TEST_JUNIT_OUTPUT_PARAM}"
     ${extra_args}
   )
   add_command(set_tests_properties
-    "${prefix}${test}${suffix}"
+    "${prefix}${unescaped_test}${suffix}"
     PROPERTIES
     WORKING_DIRECTORY "${TEST_WORKING_DIR}"
     ${properties}


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

Currently the `ADD_LABELS` functionality of the cmake integration fails to find the tests suites for test cases with commas in their names (due to #398). This PR modifies the cmake script to escape the commas following #493. 

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
