### PR TITLE
Add NOLINT for String::copy

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -533,7 +533,7 @@ void String::copy(const String& other) {
     } else {
         memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 String::String() noexcept {
     buf[0] = '\0';


### PR DESCRIPTION
## Description
This PR adds the `NOLINT` comment for the `String::copy` function to instruct `clang-tidy` not to diagnose this function.  More specifically, it instructs `clang-tidy` only not to report the `clang-analyzer-cplusplus.NewDeleteLeaks` warning. 
This fix was made to conclude the issue https://github.com/doctest/doctest/issues/484 together with https://github.com/doctest/doctest/pull/659.

## GitHub Issues
Closes #484