### PR TITLE
Fix for gcc -Wnrvo warning

### DIFF
--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1410,7 +1410,7 @@ namespace {
         auto&  translators = getExceptionTranslators();
         for(auto& curr : translators)
             if(curr->translate(res))
-                return res;
+                return String(res);
         // clang-format off
         DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
         try {


### PR DESCRIPTION
## Description
Fix to remove  -Wnrvo warning for gcc 15.
Explicitly return a `String` to help compiler know we don't want nrvo. 
Does not functionally change anything.

## GitHub Issues
#928