### PR TITLE
fix lvalue member not convertible to rvalue

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1533,7 +1533,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
         }
 
         /* This is required for user-defined conversions from Expression_lhs to L */
-        operator L() const { return lhs; }
+        operator L() const { return static_cast<L&&>(lhs); }
 
         // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1342,7 +1342,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
         }
 
         /* This is required for user-defined conversions from Expression_lhs to L */
-        operator L() const { return lhs; }
+        operator L() const { return static_cast<L&&>(lhs); }
 
         // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional


### PR DESCRIPTION
Fixes the following error
```
In file included from /home/peter/vuk/tests/03_commands.cpp:4:
/home/peter/vuk/build/_deps/doctest-src/doctest/doctest.h:1525:37: error: rvalue reference to type 'const span<...>' cannot bind to lvalue of type 'const span<...>'
 1525 |         operator L() const { return lhs; }
      |                                     ^~~
/home/peter/vuk/tests/03_commands.cpp:13:2: note: in instantiation of member function 'doctest::detail::Expression_lhs<const std::span<unsigned int> &&>::operator const std::span<unsigned int> &&' requested here
   13 |         CHECK(std::span((uint32_t*)res->mapped_ptr, 3) == std::span(data));
      |         ^
/home/peter/vuk/build/_deps/doctest-src/doctest/doctest.h:2970:20: note: expanded from macro 'CHECK'
 2970 | #define CHECK(...) DOCTEST_CHECK(__VA_ARGS__)
      |                    ^
/home/peter/vuk/build/_deps/doctest-src/doctest/doctest.h:2441:28: note: expanded from macro 'DOCTEST_CHECK'
 2441 | #define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_CHECK, __VA_ARGS__)
      |                            ^
/home/peter/vuk/build/_deps/doctest-src/doctest/doctest.h:2397:9: note: expanded from macro 'DOCTEST_ASSERT_IMPLEMENT_1'
 2397 |         DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
      |         ^
/home/peter/vuk/build/_deps/doctest-src/doctest/doctest.h:2390:13: note: expanded from macro 'DOCTEST_ASSERT_IMPLEMENT_2'
 2390 |             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
      |             ^
```
