### PR TITLE
Fix dll interface export for the filldata::fill symbol

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1192,12 +1192,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <>
     struct filldata<const void*> {
-        static void fill(std::ostream* stream, const void* in);
+        DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
     };
 
     template <>
     struct filldata<const volatile void*> {
-        static void fill(std::ostream* stream, const volatile void* in);
+        DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
     };
 
     template <typename T>

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -1001,12 +1001,12 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     template <>
     struct filldata<const void*> {
-        static void fill(std::ostream* stream, const void* in);
+        DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
     };
 
     template <>
     struct filldata<const volatile void*> {
-        static void fill(std::ostream* stream, const volatile void* in);
+        DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
     };
 
     template <typename T>


### PR DESCRIPTION
## Description

I have a link error when I use the DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL way of using doctest.

```
undefined symbol: public: static void __cdecl doctest::detail::filldata<void const *>::fill(class std::basic_ostream<char, struct std::char_traits<char>> *, void const *)
```

The template is fully specialized here, so the code will reside in the dll and the user of the code, `REQUIRE(pointer != nullptr)` will need to see the definition and know that the static function is defined in the dll.
