### PR TITLE
Enforce POSIX newlines & UTF-8 encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -120,7 +120,8 @@ def main(args):
         ),
     )
 
-    output.write_text(result)
+    with open(output, "w", encoding="utf-8", newline="\n") as out:
+        out.write(result)
     sys.exit(0)
 
 

--- a/scripts/bench/bench.py
+++ b/scripts/bench/bench.py
@@ -113,7 +113,7 @@ if args.catch:
 
 # make the source files
 for i in range(0, args.files):
-    f = open(str(i) + '.cpp', 'w')
+    f = open(str(i) + '.cpp', 'w', encoding="utf-8", newline="\n")
     if args.runtime or args.header:
         f.write(defines)
         f.write(include)
@@ -136,7 +136,7 @@ for i in range(0, args.files):
     f.close()
 
 # the main file
-f = open('main.cpp', 'w')
+f = open('main.cpp', 'w', encoding="utf-8", newline="\n")
 if args.runtime or args.implement or args.header:
     f.write(defines)
     f.write(define_implement)
@@ -153,7 +153,7 @@ f.write('    return res;\n}\n')
 f.close()
 
 # the cmake file
-f = open('CMakeLists.txt', 'w')
+f = open('CMakeLists.txt', 'w', encoding="utf-8", newline="\n")
 f.write('cmake_minimum_required(VERSION 2.8)\n\n')
 f.write('project(bench)\n\n')
 f.write('if(NOT MSVC)\n')

--- a/scripts/bench/run_all.py
+++ b/scripts/bench/run_all.py
@@ -27,7 +27,7 @@ if os.name == "nt":
     call = 'python bench.py'
     the_os = 'windows'
 
-f = open('results.txt', 'w')
+f = open('results.txt', 'w', encoding="utf-8", newline="\n")
 for test in ['header', 'asserts', 'runtime']:
     print(  '\n************** ' + test + '\n')
     f.write('\n************** ' + test + '\n')

--- a/scripts/update_stuff.py
+++ b/scripts/update_stuff.py
@@ -26,7 +26,7 @@ for line in fileinput.input(["../doctest/parts/version.h"]):
     else:
         doctest_contents += line
 
-readme = open("../doctest/parts/version.h", "w")
+readme = open("../doctest/parts/version.h", "w", encoding="utf-8", newline="\n")
 readme.write(doctest_contents)
 readme.close()
 
@@ -39,6 +39,6 @@ for line in fileinput.input(["../meson.build"]):
     else:
         meson_contents += line
 
-meson = open("../meson.build", "w")
+meson = open("../meson.build", "w", encoding="utf-8", newline="\n")
 meson.write(meson_contents)
 meson.close()


### PR DESCRIPTION
## Description
Explicitly specifies newlines as POSIX and encoding as UTF-8 in more locations, particularly in generation scripts. I develop on a Windows machine, and I kept getting false-positive changes for `doctest.h` because of newlines being converted to `CRLF`.