### PR TITLE
ci: Fix macOS jobs failing due to -Wpoison-system-directories

### DIFF
--- a/.github/workflows/build_and_test.py
+++ b/.github/workflows/build_and_test.py
@@ -71,6 +71,10 @@ elif _os == "macOS" and _compiler == "gcc":
 if _os == "Linux" and _compiler == "gcc":
     flags += " -static-libasan"
 
+warnings = ""
+if _os == "macOS" and _compiler == "xcode":
+    warnings = " -Wno-poison-system-directories"
+
 tsan_flags = "-fsanitize=thread -pie -fPIE"
 if _os == "Windows":
     tsan_flags = ""
@@ -91,16 +95,16 @@ if _os == "Linux" and _compiler == "gcc":
 x86_flag = " -m32" if _arch == "x86" and _compiler != "cl" else ""
 
 for configuration in ["Debug", "Release"]:
-    run_test(configuration, "COMPARE", flags + x86_flag)
+    run_test(configuration, "COMPARE", flags + x86_flag + warnings)
     if tsan_flags != "":
-        run_test(configuration, "COMPARE", tsan_flags)
+        run_test(configuration, "COMPARE", tsan_flags + warnings)
     if _os != "Windows":
         run_test(
             configuration,
             "COMPARE",
-            "-fno-exceptions -D DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS",
+            "-fno-exceptions -D DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS " + warnings,
             test=False,
         )
-        run_test(configuration, "COMPARE", "-fno-rtti")
+        run_test(configuration, "COMPARE", "-fno-rtti" + warnings)
     if _os == "Linux":
-        run_test(configuration, "VALGRIND", x86_flag)
+        run_test(configuration, "VALGRIND", x86_flag + warnings)


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description

Adds `-Wno-poison-system-directories` to macOS CI jobs.

It's unclear why this failure suddenly started, but presumably GitHub bumped the Mac OS on us, hence upgraded to a higher version of `clang`.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues

N/A

<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
