### PR TITLE
ci: Bump `checkout` to v5 & `codeql-action` to v4

### DIFF
--- a/.github/workflows/ci-mingw-w64.yml
+++ b/.github/workflows/ci-mingw-w64.yml
@@ -29,7 +29,7 @@ jobs:
         configuration: ["Debug", "Release"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set up MinGW-w64
         uses: egor-tensin/setup-mingw@v2

--- a/.github/workflows/ci-msvs.yml
+++ b/.github/workflows/ci-msvs.yml
@@ -31,7 +31,7 @@ jobs:
         configuration: ["Debug", "Release"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Generate
         run:

--- a/.github/workflows/ci-oneapi.yml
+++ b/.github/workflows/ci-oneapi.yml
@@ -30,7 +30,7 @@ jobs:
         compiler: ["icpc", "icx"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
             version: "12"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       # Ref: https://github.com/actions/checkout/issues/1590#issuecomment-2567109195
       - name: Prepare container (Linux, containerized)

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install
         run: sudo apt-get install -y ninja-build clang-tidy-14

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install
         run: sudo apt-get install -y ninja-build lcov

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -29,7 +29,7 @@ jobs:
         sanitizers: ["address", "thread", "undefined", "integer", "implicit-conversion", "nullability", "safe-stack"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install
         run: sudo apt-get install -y ninja-build


### PR DESCRIPTION
## Description

Both of these actions use very outdated versions on the repo, both of which produced warnings for me. No changes needed to be made elsewhere as a result of this bump