### PR TITLE
fix executable_dll_and_plugin test on cygwin

### DIFF
--- a/examples/executable_dll_and_plugin/main.cpp
+++ b/examples/executable_dll_and_plugin/main.cpp
@@ -36,6 +36,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #include <dlfcn.h>
 #ifdef __APPLE__
 #define LoadDynamicLib(lib) dlopen("lib" lib ".dylib", RTLD_NOW)
+#elif defined(__CYGWIN__)
+#define LoadDynamicLib(lib) dlopen("cyg" lib ".dll", RTLD_NOW)
 #else // __APPLE__
 #define LoadDynamicLib(lib) dlopen("lib" lib ".so", RTLD_NOW)
 #endif // __APPLE__


### PR DESCRIPTION
<!--
Make sure the PR is against the dev branch and not master which contains
the latest stable release. Also make sure to have read CONTRIBUTING.md.
Please do not submit pull requests changing the single-include `doctest.h`
file, it is generated from the 2 files in the doctest/parts/ folder.
-->


## Description

I've been bringing up cygwin support in nixpkgs, and found that this particular test failed due to the incorrect shared lib path.  With this change, the whole test suite passes.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
