### PR TITLE
ci: Bump macos-14 from gcc-12 to gcc-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
           - os: macos-14
             compiler: gcc
-            version: "12"
+            version: "13"
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Description

Updates (macos-14, gcc, 12) to (macos-14, gcc, 13), as `gcc-12` is no longer available on this runner.

## GitHub Issues

Announced in https://github.com/actions/runner-images/pull/13257