### PR TITLE
ci: Add task to check for stale doctest.h files

### DIFF
--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -1,0 +1,35 @@
+name: Code Generation
+
+on:
+  push:
+    branches: [dev, master]
+    paths-ignore:
+      - "doc/**"
+      - "LICENSE.txt"
+      - "README.md"
+
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "LICENSE.txt"
+      - "README.md"
+
+jobs:
+  check-generated-header:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Generate Single-Header File
+        run: python scripts/assemble.py
+
+      - name: Check Diff
+        run: |
+          if ! git diff --exit-code doctest/doctest.h; then
+            echo "::error file=doctest/doctest.h title=doctest.h out-of-date::doctest.h differs when regenerated"
+            echo "Ensure you have only changed files in the doctest/parts/* directory"
+            echo "and either build via CMake, or run the scripts/assemble.py script directly"
+            echo "to assemble the single-header include form of doctest"
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Adds `.github/workflows/code-generation.yml` which provides a `check-generated-header` job. The intent of this job is to check whether the `doctest.h` file would change if re-generated. This aims to catch pull-requests which have directly modified the `doctest.h` header without actually updating the constituent `parts/*` files.

## GitHub Issues

N/A