### PR TITLE
ci: Simplify conditional job configuration to support internal PRs

### DIFF
--- a/.github/workflows/ci-mingw-w64.yml
+++ b/.github/workflows/ci-mingw-w64.yml
@@ -2,11 +2,13 @@ name: CI MinGW-w64
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   ci-mingw-w64:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-latest
 
     strategy:

--- a/.github/workflows/ci-msvs.yml
+++ b/.github/workflows/ci-msvs.yml
@@ -2,11 +2,13 @@ name: CI MSVS
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   ci-msvs:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on:  "windows-2025"
 
     strategy:

--- a/.github/workflows/ci-oneapi.yml
+++ b/.github/workflows/ci-oneapi.yml
@@ -2,11 +2,13 @@ name: CI OneAPI
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   ci-oneapi:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   ci:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,11 +2,13 @@ name: Clang-Tidy
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   clang-tidy:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,11 +2,13 @@ name: Coverage
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -2,11 +2,13 @@ name: Sanitizers
 
 on:
   push:
+    branches: [dev, master]
     paths-ignore:
       - "doc/**"
       - "scripts/**"
       - "LICENSE.txt"
       - "README.md"
+
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -20,7 +22,6 @@ env:
 
 jobs:
   sanitizers:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
 
     strategy:


### PR DESCRIPTION
## Description

Resolving an issue that occurs when developing directly on `doctest/doctest`. When pushing a branch, we trigger the `on:push` rule, which is not restricted to any branches. When a pull-request is created, it also creates jobs but all of these are skipped. This results in a weird summary on pull-requests:

<img width="311" height="63" alt="image" src="https://github.com/user-attachments/assets/0e4ae5d0-b9a5-4c37-b47b-d1a5dceda4f6" />

To resolve this, I updated the CI/CD config to use `on:push:branches` to restrict job creation to only `dev` and `master`, and removed the `if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository` snippet entirely. This _should_ have the effect of running jobs when...

1. We push to `dev` / `master`, i.e. after a pull-request is accepted
2. We create or update a pull-request, even from an internal branch

Behaviour was confirmed by checking that no actions were created upon initial push of this branch, but were created after the pull-request was created. This is in contrast to #971 where the actions were created upon push, then _again_ on pull-request creation (even though they were all skipped).

## GitHub Issues

N/A