### PR TITLE
fix: Use new `version.h` location in `update_stuff.py`

### DIFF
--- a/scripts/update_stuff.py
+++ b/scripts/update_stuff.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python3
 
-import os
 import fileinput
 
 # the version of the release
@@ -16,7 +15,7 @@ version_patch = str(getVersionTuple(version)[2])
 # update version in the header file
 print("updating the version in the header file")
 doctest_contents = ""
-for line in fileinput.input(["../doctest/parts/version.h"]):
+for line in fileinput.input(["../doctest/parts/public/version.h"]):
     if line.startswith("#define DOCTEST_VERSION_MAJOR "):
         doctest_contents += "#define DOCTEST_VERSION_MAJOR " + version_major + "\n"
     elif line.startswith("#define DOCTEST_VERSION_MINOR "):
@@ -26,7 +25,7 @@ for line in fileinput.input(["../doctest/parts/version.h"]):
     else:
         doctest_contents += line
 
-readme = open("../doctest/parts/version.h", "w", encoding="utf-8", newline="\n")
+readme = open("../doctest/parts/public/version.h", "w", encoding="utf-8", newline="\n")
 readme.write(doctest_contents)
 readme.close()
 


### PR DESCRIPTION
Ensures that `update_stuff.py` will work as intended with `version.h` changing locations in #973. Also adjusts the SHA to use Python 3 (no functional changes required), and removes an unnecessary `os` include