### PR TITLE
chore: Extract subcase management to doctest/parts/subcase.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
         ${doctest_parts_folder}/private/matchers/contains.cpp
         ${doctest_parts_folder}/private/matchers/is_nan.cpp
         ${doctest_parts_folder}/private/string.cpp
+        ${doctest_parts_folder}/private/subcase.cpp
     )
     add_library(${PROJECT_NAME}::${PROJECT_NAME}_with_main ALIAS ${PROJECT_NAME}_with_main)
     target_compile_definitions(${PROJECT_NAME}_with_main PRIVATE

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1664,6 +1664,41 @@ namespace Color {
     DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
 } // namespace Color
 }
+namespace doctest {
+
+struct DOCTEST_INTERFACE SubcaseSignature
+{
+    String      m_name;
+    const char* m_file;
+    int         m_line;
+
+    bool operator==(const SubcaseSignature& other) const;
+    bool operator<(const SubcaseSignature& other) const;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+struct DOCTEST_INTERFACE Subcase
+{
+    SubcaseSignature m_signature;
+    bool             m_entered = false;
+
+    Subcase(const String& name, const char* file, int line);
+    Subcase(const Subcase&) = delete;
+    Subcase(Subcase&&) = delete;
+    Subcase& operator=(const Subcase&) = delete;
+    Subcase& operator=(Subcase&&) = delete;
+    ~Subcase();
+
+    operator bool() const;
+
+    private:
+        bool checkFilters();
+};
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest
 
 namespace doctest {
 
@@ -1693,16 +1728,6 @@ struct DOCTEST_INTERFACE MessageData
     const char*      m_file;
     int              m_line;
     assertType::Enum m_severity;
-};
-
-struct DOCTEST_INTERFACE SubcaseSignature
-{
-    String      m_name;
-    const char* m_file;
-    int         m_line;
-
-    bool operator==(const SubcaseSignature& other) const;
-    bool operator<(const SubcaseSignature& other) const;
 };
 
 struct DOCTEST_INTERFACE IContextScope
@@ -1810,24 +1835,6 @@ namespace detail {
 namespace doctest {
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-
-    struct DOCTEST_INTERFACE Subcase
-    {
-        SubcaseSignature m_signature;
-        bool             m_entered = false;
-
-        Subcase(const String& name, const char* file, int line);
-        Subcase(const Subcase&) = delete;
-        Subcase(Subcase&&) = delete;
-        Subcase& operator=(const Subcase&) = delete;
-        Subcase& operator=(Subcase&&) = delete;
-        ~Subcase();
-
-        operator bool() const;
-
-        private:
-            bool checkFilters();
-    };
 
     struct DOCTEST_INTERFACE TestSuite
     {
@@ -4056,20 +4063,6 @@ const char* skipPathFromFilename(const char* file) {
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-    return m_line == other.m_line
-        && std::strcmp(m_file, other.m_file) == 0
-        && m_name == other.m_name;
-}
-
-bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    if(std::strcmp(m_file, other.m_file) != 0)
-        return std::strcmp(m_file, other.m_file) < 0;
-    return m_name.compare(other.m_name) < 0;
-}
-
 DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 } // namespace doctest
@@ -4217,89 +4210,6 @@ namespace {
     }
 } // namespace
 namespace detail {
-    bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
-                return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
-                return true;
-        }
-        return false;
-    }
-
-    Subcase::Subcase(const String& name, const char* file, int line)
-            : m_signature({name, file, line}) {
-        if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
-                // Going down.
-                if (checkFilters()) { return; }
-
-                g_cs->subcaseStack.push_back(m_signature);
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            }
-        } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
-                // This subcase is reentered via control flow.
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
-                // This subcase is part of the one to be executed next.
-                g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
-                g_cs->nextSubcaseStack.push_back(m_signature);
-            }
-        }
-    }
-
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
-    Subcase::~Subcase() {
-        if (m_entered) {
-            g_cs->currentSubcaseDepth--;
-
-            if (!g_cs->reachedLeaf) {
-                // Leaf.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-                g_cs->nextSubcaseStack.clear();
-                g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
-                // All children are finished.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-            }
-
-#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-            if(std::uncaught_exceptions() > 0
-#else
-            if(std::uncaught_exception()
-#endif
-                && g_cs->shouldLogCurrentException) {
-                DOCTEST_ITERATE_THROUGH_REPORTERS(
-                        test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
-                g_cs->shouldLogCurrentException = false;
-            }
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
-    }
-
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-    Subcase::operator bool() const { return m_entered; }
 
     TestSuite& TestSuite::operator*(const char* in) {
         m_test_suite = in;
@@ -7340,6 +7250,114 @@ String toString(long in) { return toStreamLit(in); }
 String toString(long unsigned in) { return toStreamLit(in); }
 String toString(long long in) { return toStreamLit(in); }
 String toString(long long unsigned in) { return toStreamLit(in); }
+
+} // namespace doctest
+
+namespace doctest {
+
+    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+        return m_line == other.m_line
+            && std::strcmp(m_file, other.m_file) == 0
+            && m_name == other.m_name;
+    }
+
+    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        if(std::strcmp(m_file, other.m_file) != 0)
+            return std::strcmp(m_file, other.m_file) < 0;
+        return m_name.compare(other.m_name) < 0;
+    }
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+    bool Subcase::checkFilters() {
+        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+                return true;
+            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+                return true;
+        }
+        return false;
+    }
+
+    Subcase::Subcase(const String& name, const char* file, int line)
+            : m_signature({name, file, line}) {
+        if (!g_cs->reachedLeaf) {
+            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
+                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+                // Going down.
+                if (checkFilters()) { return; }
+
+                g_cs->subcaseStack.push_back(m_signature);
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            }
+        } else {
+            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+                // This subcase is reentered via control flow.
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
+                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
+                    == g_cs->fullyTraversedSubcases.end()) {
+                if (checkFilters()) { return; }
+                // This subcase is part of the one to be executed next.
+                g_cs->nextSubcaseStack.clear();
+                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
+                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+                g_cs->nextSubcaseStack.push_back(m_signature);
+            }
+        }
+    }
+
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+    Subcase::~Subcase() {
+        if (m_entered) {
+            g_cs->currentSubcaseDepth--;
+
+            if (!g_cs->reachedLeaf) {
+                // Leaf.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+                g_cs->nextSubcaseStack.clear();
+                g_cs->reachedLeaf = true;
+            } else if (g_cs->nextSubcaseStack.empty()) {
+                // All children are finished.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+            }
+
+    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+            if(std::uncaught_exceptions() > 0
+    #else
+            if(std::uncaught_exception()
+    #endif
+                && g_cs->shouldLogCurrentException) {
+                DOCTEST_ITERATE_THROUGH_REPORTERS(
+                        test_case_exception, {"exception thrown in subcase - will translate later "
+                                                "when the whole test case has been exited (cannot "
+                                                "translate while there is an active exception)",
+                                                false});
+                g_cs->shouldLogCurrentException = false;
+            }
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+        }
+    }
+
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    Subcase::operator bool() const { return m_entered; }
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
 
 } // namespace doctest
 

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -75,6 +75,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #include <doctest/parts/public/assert/result.h>
 #include <doctest/parts/public/assert/expression.h>
 #include <doctest/parts/public/color.h>
+#include <doctest/parts/public/subcase.h>
 
 namespace doctest {
 
@@ -106,16 +107,6 @@ struct DOCTEST_INTERFACE MessageData
     assertType::Enum m_severity;
 };
 
-struct DOCTEST_INTERFACE SubcaseSignature
-{
-    String      m_name;
-    const char* m_file;
-    int         m_line;
-
-    bool operator==(const SubcaseSignature& other) const;
-    bool operator<(const SubcaseSignature& other) const;
-};
-
 struct DOCTEST_INTERFACE IContextScope
 {
     DOCTEST_DECLARE_INTERFACE(IContextScope)
@@ -130,24 +121,6 @@ struct DOCTEST_INTERFACE IContextScope
 namespace doctest {
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-
-    struct DOCTEST_INTERFACE Subcase
-    {
-        SubcaseSignature m_signature;
-        bool             m_entered = false;
-
-        Subcase(const String& name, const char* file, int line);
-        Subcase(const Subcase&) = delete;
-        Subcase(Subcase&&) = delete;
-        Subcase& operator=(const Subcase&) = delete;
-        Subcase& operator=(Subcase&&) = delete;
-        ~Subcase();
-
-        operator bool() const;
-
-        private:
-            bool checkFilters();
-    };
 
     struct DOCTEST_INTERFACE TestSuite
     {

--- a/doctest/parts/private/doctest.cpp
+++ b/doctest/parts/private/doctest.cpp
@@ -63,20 +63,6 @@ const char* skipPathFromFilename(const char* file) {
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-    return m_line == other.m_line
-        && std::strcmp(m_file, other.m_file) == 0
-        && m_name == other.m_name;
-}
-
-bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    if(std::strcmp(m_file, other.m_file) != 0)
-        return std::strcmp(m_file, other.m_file) < 0;
-    return m_name.compare(other.m_name) < 0;
-}
-
 DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 } // namespace doctest
@@ -224,89 +210,6 @@ namespace {
     }
 } // namespace
 namespace detail {
-    bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
-                return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
-                return true;
-        }
-        return false;
-    }
-
-    Subcase::Subcase(const String& name, const char* file, int line)
-            : m_signature({name, file, line}) {
-        if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
-                // Going down.
-                if (checkFilters()) { return; }
-
-                g_cs->subcaseStack.push_back(m_signature);
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            }
-        } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
-                // This subcase is reentered via control flow.
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
-                // This subcase is part of the one to be executed next.
-                g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
-                g_cs->nextSubcaseStack.push_back(m_signature);
-            }
-        }
-    }
-
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
-    Subcase::~Subcase() {
-        if (m_entered) {
-            g_cs->currentSubcaseDepth--;
-
-            if (!g_cs->reachedLeaf) {
-                // Leaf.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-                g_cs->nextSubcaseStack.clear();
-                g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
-                // All children are finished.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-            }
-
-#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-            if(std::uncaught_exceptions() > 0
-#else
-            if(std::uncaught_exception()
-#endif
-                && g_cs->shouldLogCurrentException) {
-                DOCTEST_ITERATE_THROUGH_REPORTERS(
-                        test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
-                g_cs->shouldLogCurrentException = false;
-            }
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
-    }
-
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-    Subcase::operator bool() const { return m_entered; }
 
     TestSuite& TestSuite::operator*(const char* in) {
         m_test_suite = in;

--- a/doctest/parts/private/subcase.cpp
+++ b/doctest/parts/private/subcase.cpp
@@ -1,0 +1,110 @@
+#include "doctest/parts/private/prelude.h"
+#include "doctest/parts/private/context_state.h"
+
+namespace doctest {
+
+    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+        return m_line == other.m_line
+            && std::strcmp(m_file, other.m_file) == 0
+            && m_name == other.m_name;
+    }
+
+    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        if(std::strcmp(m_file, other.m_file) != 0)
+            return std::strcmp(m_file, other.m_file) < 0;
+        return m_name.compare(other.m_name) < 0;
+    }
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+
+    bool Subcase::checkFilters() {
+        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+                return true;
+            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+                return true;
+        }
+        return false;
+    }
+
+    Subcase::Subcase(const String& name, const char* file, int line)
+            : m_signature({name, file, line}) {
+        if (!g_cs->reachedLeaf) {
+            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
+                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+                // Going down.
+                if (checkFilters()) { return; }
+
+                g_cs->subcaseStack.push_back(m_signature);
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            }
+        } else {
+            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+                // This subcase is reentered via control flow.
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
+                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
+                    == g_cs->fullyTraversedSubcases.end()) {
+                if (checkFilters()) { return; }
+                // This subcase is part of the one to be executed next.
+                g_cs->nextSubcaseStack.clear();
+                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
+                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+                g_cs->nextSubcaseStack.push_back(m_signature);
+            }
+        }
+    }
+
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+    Subcase::~Subcase() {
+        if (m_entered) {
+            g_cs->currentSubcaseDepth--;
+
+            if (!g_cs->reachedLeaf) {
+                // Leaf.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+                g_cs->nextSubcaseStack.clear();
+                g_cs->reachedLeaf = true;
+            } else if (g_cs->nextSubcaseStack.empty()) {
+                // All children are finished.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+            }
+
+    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+            if(std::uncaught_exceptions() > 0
+    #else
+            if(std::uncaught_exception()
+    #endif
+                && g_cs->shouldLogCurrentException) {
+                DOCTEST_ITERATE_THROUGH_REPORTERS(
+                        test_case_exception, {"exception thrown in subcase - will translate later "
+                                                "when the whole test case has been exited (cannot "
+                                                "translate while there is an active exception)",
+                                                false});
+                g_cs->shouldLogCurrentException = false;
+            }
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+        }
+    }
+
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    Subcase::operator bool() const { return m_entered; }
+
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest

--- a/doctest/parts/public/subcase.h
+++ b/doctest/parts/public/subcase.h
@@ -1,0 +1,35 @@
+namespace doctest {
+
+struct DOCTEST_INTERFACE SubcaseSignature
+{
+    String      m_name;
+    const char* m_file;
+    int         m_line;
+
+    bool operator==(const SubcaseSignature& other) const;
+    bool operator<(const SubcaseSignature& other) const;
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+namespace detail {
+struct DOCTEST_INTERFACE Subcase
+{
+    SubcaseSignature m_signature;
+    bool             m_entered = false;
+
+    Subcase(const String& name, const char* file, int line);
+    Subcase(const Subcase&) = delete;
+    Subcase(Subcase&&) = delete;
+    Subcase& operator=(const Subcase&) = delete;
+    Subcase& operator=(Subcase&&) = delete;
+    ~Subcase();
+
+    operator bool() const;
+
+    private:
+        bool checkFilters();
+};
+} // namespace detail
+#endif // DOCTEST_CONFIG_DISABLE
+
+} // namespace doctest


### PR DESCRIPTION
## Description

Extracts both `SubcaseSignature` and `detail::Subcase` into `doctest/parts/subcase.h`

These can be kept together as we don't need any extra types introduced _between_ them, and most consumers would be happy with one or the other.

## GitHub Issues

#941