### PR TITLE
chore: Extract test-suite management to doctest/parts/test_suite.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
         ${doctest_parts_folder}/private/matchers/is_nan.cpp
         ${doctest_parts_folder}/private/string.cpp
         ${doctest_parts_folder}/private/subcase.cpp
+        ${doctest_parts_folder}/private/test_suite.cpp
     )
     add_library(${PROJECT_NAME}::${PROJECT_NAME}_with_main ALIAS ${PROJECT_NAME}_with_main)
     target_compile_definitions(${PROJECT_NAME}_with_main PRIVATE

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -76,6 +76,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #include <doctest/parts/public/assert/expression.h>
 #include <doctest/parts/public/color.h>
 #include <doctest/parts/public/subcase.h>
+#include <doctest/parts/public/test_suite.h>
 
 namespace doctest {
 
@@ -122,27 +123,6 @@ namespace doctest {
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    struct DOCTEST_INTERFACE TestSuite
-    {
-        const char* m_test_suite = nullptr;
-        const char* m_description = nullptr;
-        bool        m_skip = false;
-        bool        m_no_breaks = false;
-        bool        m_no_output = false;
-        bool        m_may_fail = false;
-        bool        m_should_fail = false;
-        int         m_expected_failures = 0;
-        double      m_timeout = 0;
-
-        TestSuite& operator*(const char* in);
-
-        template <typename T>
-        TestSuite& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
-    };
-
     using funcType = void (*)();
 
     struct DOCTEST_INTERFACE TestCase : public TestCaseData
@@ -180,7 +160,6 @@ namespace detail {
 
     // forward declarations of functions used by the macros
     DOCTEST_INTERFACE int  regTest(const TestCase& tc);
-    DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
 
     template<typename T>
     int instantiationHelper(const T&) { return 0; }
@@ -334,12 +313,6 @@ int registerExceptionTranslator(String (*translateFunction)(T)) {
 }
 
 } // namespace doctest
-
-// in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
-// introduces an anonymous namespace in which getCurrentTestSuite gets overridden
-namespace doctest_detail_test_suite_ns {
-DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
-} // namespace doctest_detail_test_suite_ns
 
 namespace doctest {
 #else  // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/doctest.cpp
+++ b/doctest/parts/private/doctest.cpp
@@ -93,14 +93,6 @@ int registerReporter(const char*, int, IReporter*) { return 0; }
 } // namespace doctest
 #else // DOCTEST_CONFIG_DISABLE
 
-namespace doctest_detail_test_suite_ns {
-// holds the current test suite
-doctest::detail::TestSuite& getCurrentTestSuite() {
-    static doctest::detail::TestSuite data{};
-    return data;
-}
-} // namespace doctest_detail_test_suite_ns
-
 namespace doctest {
 namespace {
     // the int (priority) is part of the key for automatic sorting - sadly one can register a
@@ -210,11 +202,6 @@ namespace {
     }
 } // namespace
 namespace detail {
-
-    TestSuite& TestSuite::operator*(const char* in) {
-        m_test_suite = in;
-        return *this;
-    }
 
     TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
                        const String& type, int template_id) {
@@ -352,12 +339,6 @@ namespace detail {
     // used by the macros for registering tests
     int regTest(const TestCase& tc) {
         getRegisteredTests().insert(tc);
-        return 0;
-    }
-
-    // sets the current test suite
-    int setTestSuite(const TestSuite& ts) {
-        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
         return 0;
     }
 

--- a/doctest/parts/private/test_suite.cpp
+++ b/doctest/parts/private/test_suite.cpp
@@ -1,0 +1,30 @@
+#include "doctest/parts/private/prelude.h"
+
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+TestSuite& TestSuite::operator*(const char* in) {
+    m_test_suite = in;
+    return *this;
+}
+
+// sets the current test suite
+int setTestSuite(const TestSuite& ts) {
+    doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+    return 0;
+}
+
+} // namespace detail
+} // namespace doctest
+
+namespace doctest_detail_test_suite_ns {
+// holds the current test suite
+doctest::detail::TestSuite& getCurrentTestSuite() {
+    static doctest::detail::TestSuite data{};
+    return data;
+}
+} // namespace doctest_detail_test_suite_ns
+
+#endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/test_suite.h
+++ b/doctest/parts/public/test_suite.h
@@ -1,0 +1,40 @@
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+namespace detail {
+
+struct DOCTEST_INTERFACE TestSuite
+{
+    const char* m_test_suite = nullptr;
+    const char* m_description = nullptr;
+    bool        m_skip = false;
+    bool        m_no_breaks = false;
+    bool        m_no_output = false;
+    bool        m_may_fail = false;
+    bool        m_should_fail = false;
+    int         m_expected_failures = 0;
+    double      m_timeout = 0;
+
+    TestSuite& operator*(const char* in);
+
+    template <typename T>
+    TestSuite& operator*(const T& in) {
+        in.fill(*this);
+        return *this;
+    }
+};
+
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+
+} // namespace detail
+
+} // namespace doctest
+
+// in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
+// introduces an anonymous namespace in which getCurrentTestSuite gets overridden
+namespace doctest_detail_test_suite_ns {
+DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
+} // namespace doctest_detail_test_suite_ns
+
+#endif // DOCTEST_CONFIG_DISABLE


### PR DESCRIPTION
## Description

Moves `doctest::detail::TestSuite` and associated globals to `doctest/parts/test_suite.h`.

Decorators are not included since these apply to both `TestSuite` and `TestCase` objects, so will be lifted into a `decorators.h` later.

## GitHub Issues

#941