### PR TITLE
chore: Extract test decorators to doctest/parts/decorators.h

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -1802,6 +1802,33 @@ namespace detail {
 #endif // DOCTEST_CONFIG_DISABLE
 
 } // namespace doctest
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
+    struct name                                                                                    \
+    {                                                                                              \
+        type data;                                                                                 \
+        name(type in = def)                                                                        \
+                : data(in) {}                                                                      \
+        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
+        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
+    }
+
+DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
+DOCTEST_DEFINE_DECORATOR(description, const char*, "");
+DOCTEST_DEFINE_DECORATOR(skip, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
+DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
+DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
+
+} // namespace
+
+#endif // DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
 
@@ -2043,26 +2070,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
         return ContextScope<L>(lambda);
     }
 } // namespace detail
-
-#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
-    struct name                                                                                    \
-    {                                                                                              \
-        type data;                                                                                 \
-        name(type in = def)                                                                        \
-                : data(in) {}                                                                      \
-        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
-        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
-    }
-
-DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
-DOCTEST_DEFINE_DECORATOR(description, const char*, "");
-DOCTEST_DEFINE_DECORATOR(skip, bool, true);
-DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
-DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
-DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
-DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
-DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
-DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
 template <typename T>
 int registerExceptionTranslator(String (*translateFunction)(T)) {

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -78,6 +78,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #include <doctest/parts/public/subcase.h>
 #include <doctest/parts/public/test_suite.h>
 #include <doctest/parts/public/test_case.h>
+#include <doctest/parts/public/decorators.h>
 
 namespace doctest {
 
@@ -228,26 +229,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
         return ContextScope<L>(lambda);
     }
 } // namespace detail
-
-#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
-    struct name                                                                                    \
-    {                                                                                              \
-        type data;                                                                                 \
-        name(type in = def)                                                                        \
-                : data(in) {}                                                                      \
-        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
-        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
-    }
-
-DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
-DOCTEST_DEFINE_DECORATOR(description, const char*, "");
-DOCTEST_DEFINE_DECORATOR(skip, bool, true);
-DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
-DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
-DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
-DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
-DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
-DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
 template <typename T>
 int registerExceptionTranslator(String (*translateFunction)(T)) {

--- a/doctest/parts/public/decorators.h
+++ b/doctest/parts/public/decorators.h
@@ -1,0 +1,27 @@
+#ifndef DOCTEST_CONFIG_DISABLE
+
+namespace doctest {
+
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
+    struct name                                                                                    \
+    {                                                                                              \
+        type data;                                                                                 \
+        name(type in = def)                                                                        \
+                : data(in) {}                                                                      \
+        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
+        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
+    }
+
+DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
+DOCTEST_DEFINE_DECORATOR(description, const char*, "");
+DOCTEST_DEFINE_DECORATOR(skip, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
+DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
+DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
+DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
+
+} // namespace
+
+#endif // DOCTEST_CONFIG_DISABLE


### PR DESCRIPTION
## Description

Extracts test-suite and test-case decorators to `doctest/parts/decorators.h`.

See #992 for why this was done separately

## GitHub Issues

#941