### PR TITLE
ci: Implement concurrency logic for GitHub Actions

### DIFF
--- a/.github/workflows/ci-mingw-w64.yml
+++ b/.github/workflows/ci-mingw-w64.yml
@@ -16,6 +16,10 @@ on:
       - "LICENSE.txt"
       - "README.md"
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|ci-mingw-w64
+  cancel-in-progress: true
+
 env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2

--- a/.github/workflows/ci-msvs.yml
+++ b/.github/workflows/ci-msvs.yml
@@ -16,6 +16,10 @@ on:
       - "LICENSE.txt"
       - "README.md"
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|ci-msvs
+  cancel-in-progress: true
+
 env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2

--- a/.github/workflows/ci-oneapi.yml
+++ b/.github/workflows/ci-oneapi.yml
@@ -20,6 +20,10 @@ env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|ci-oneapi
+  cancel-in-progress: true
+
 jobs:
   ci-oneapi:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|ci
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,6 +20,10 @@ env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|clang-tidy
+  cancel-in-progress: true
+
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -14,6 +14,10 @@ on:
       - "LICENSE.txt"
       - "README.md"
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|code-generation
+  cancel-in-progress: true
+
 jobs:
   check-generated-header:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '38 1 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|codeql-analysis
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,10 @@ env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|coverage
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -20,6 +20,10 @@ env:
   CTEST_OUTPUT_ON_FAILURE: ON
   CTEST_PARALLEL_LEVEL: 2
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|sanitizers
+  cancel-in-progress: true
+
 jobs:
   sanitizers:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description
Ensures that GitHub Actions utilize "concurrency" logic, in order to gracefully handle PRs/pushes in rapid succession. With this change, only the latest instance for a given PR/branch-push will get ran, as older versions are timed out if they're still running