### PR TITLE
chore: Run clang-format across segmented files

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -55,9 +55,8 @@
 #define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 
 #define DOCTEST_VERSION_STR                                                                        \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR)                                                           \
+    "." DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "." DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
 
 #define DOCTEST_VERSION                                                                            \
     (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
@@ -73,7 +72,7 @@
 #define DOCTEST_CPLUSPLUS __cplusplus
 #endif
 
-#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
+#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
 
 // GCC/Clang and GCC/MSVC are mutually exclusive, but Clang/MSVC are not because of clang-cl...
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
@@ -287,8 +286,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
-        || defined(__wasi__)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND) ||                \
+        defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
@@ -437,14 +436,13 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 // =================================================================================================
 #define DOCTEST_DECLARE_INTERFACE(name)                                                            \
     virtual ~name();                                                                               \
-    name() = default;                                                                              \
-    name(const name&) = delete;                                                                    \
-    name(name&&) = delete;                                                                         \
+    name()                       = default;                                                        \
+    name(const name&)            = delete;                                                         \
+    name(name&&)                 = delete;                                                         \
     name& operator=(const name&) = delete;                                                         \
-    name& operator=(name&&) = delete;
+    name& operator=(name&&)      = delete;
 
-#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
-    name::~name() = default;
+#define DOCTEST_DEFINE_INTERFACE(name) name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -463,11 +461,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 
 namespace doctest { namespace detail {
     static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
-}}
+}} // namespace doctest::detail
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
-    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                              \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                            \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 // not using __APPLE__ because... this is how Catch does it
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
@@ -496,7 +494,11 @@ namespace doctest { namespace detail {
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
 #elif defined(__ppc__) || defined(__ppc64__)
 // https://www.cocoawithlove.com/2008/03/break-into-debugger.html
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER()                                                              \
+    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n"                                   \
+            :                                                                                      \
+            :                                                                                      \
+            : "memory", "r0", "r3", "r4") // NOLINT(hicpp-no-assembler)
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
@@ -514,11 +516,9 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
     DOCTEST_INTERFACE bool isDebuggerActive();
-} // detail
-} // doctest
+}} // namespace doctest::detail
 
 #endif
 #ifdef DOCTEST_CONFIG_USE_STD_HEADERS
@@ -532,17 +532,17 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-namespace std { // NOLINT(cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
-typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
+namespace std {                            // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr)       nullptr_t; // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void*)) size_t;    // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+class basic_ostream;                                    // NOLINT(fuchsia-virtual-inheritance)
 typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
-template<class traits>
+template <class traits>
 // NOLINTNEXTLINE
 basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
 template <class charT, class traits>
@@ -565,209 +565,275 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
 namespace doctest {
-  using std::size_t;
+using std::size_t;
 }
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-namespace doctest {
-namespace detail {
-namespace types {
+namespace doctest { namespace detail { namespace types {
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  using namespace std;
+    using namespace std;
 #else
-  template <bool COND, typename T = void>
-  struct enable_if { };
+    template <bool COND, typename T = void>
+    struct enable_if
+    {
+    };
 
-  template <typename T>
-  struct enable_if<true, T> { using type = T; };
+    template <typename T>
+    struct enable_if<true, T>
+    {
+        using type = T;
+    };
 
-  struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
-  struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
+    struct true_type
+    {
+        static DOCTEST_CONSTEXPR bool value = true;
+    };
+    struct false_type
+    {
+        static DOCTEST_CONSTEXPR bool value = false;
+    };
 
-  template <typename T> struct remove_reference { using type = T; };
-  template <typename T> struct remove_reference<T&> { using type = T; };
-  template <typename T> struct remove_reference<T&&> { using type = T; };
+    template <typename T>
+    struct remove_reference
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_reference<T&>
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_reference<T&&>
+    {
+        using type = T;
+    };
 
-  template <typename T> struct is_rvalue_reference : false_type { };
-  template <typename T> struct is_rvalue_reference<T&&> : true_type { };
+    template <typename T>
+    struct is_rvalue_reference : false_type
+    {
+    };
+    template <typename T>
+    struct is_rvalue_reference<T&&> : true_type
+    {
+    };
 
-  template<typename T> struct remove_const { using type = T; };
-  template <typename T> struct remove_const<const T> { using type = T; };
+    template <typename T>
+    struct remove_const
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_const<const T>
+    {
+        using type = T;
+    };
 
-  // Compiler intrinsics
-  template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
-  template <typename T> struct underlying_type { using type = __underlying_type(T); };
+    // Compiler intrinsics
+    template <typename T>
+    struct is_enum
+    {
+        static DOCTEST_CONSTEXPR bool value = __is_enum(T);
+    };
+    template <typename T>
+    struct underlying_type
+    {
+        using type = __underlying_type(T);
+    };
 
-  template <typename T> struct is_pointer : false_type { };
-  template <typename T> struct is_pointer<T*> : true_type { };
+    template <typename T>
+    struct is_pointer : false_type
+    {
+    };
+    template <typename T>
+    struct is_pointer<T*> : true_type
+    {
+    };
 
-  template <typename T> struct is_array : false_type { };
-  // NOLINTNEXTLINE(*-avoid-c-arrays)
-  template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+    template <typename T>
+    struct is_array : false_type
+    {
+    };
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
+    template <typename T, size_t SIZE>
+    struct is_array<T[SIZE]> : true_type
+    {
+    };
 #endif
 
-} // namespace types
-} // namespace detail
-} // namespace doctest
-namespace doctest {
-namespace detail {
+}}} // namespace doctest::detail::types
+namespace doctest { namespace detail {
 
-  // <utility>
-  template <typename T>
-  T&& declval();
+    // <utility>
+    template <typename T>
+    T&& declval();
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t)
+            DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t)
+            DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
 
-  template <typename T>
-  struct deferred_false : types::false_type { };
+    template <typename T>
+    struct deferred_false : types::false_type
+    {
+    };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 namespace doctest {
 #ifndef DOCTEST_CONFIG_STRING_SIZE_TYPE
 #define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
 #endif
 
-    // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
-    // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
-    // - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
-    // - if small - capacity left before going on the heap - using the lowest 5 bits
-    // - if small - 2 bits are left unused - the second and third highest ones
-    // - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
-    //              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
-    // Idea taken from this lecture about the string implementation of facebook/folly - fbstring
-    // https://www.youtube.com/watch?v=kPR8h4-qZdk
-    // TODO:
-    // - optimizations - like not deleting memory unnecessarily in operator= and etc.
-    // - resize/reserve/clear
-    // - replace
-    // - back/front
-    // - iterator stuff
-    // - find & friends
-    // - push_back/pop_back
-    // - assign/insert/erase
-    // - relational operators as free functions - taking const char* as one of the params
-    class DOCTEST_INTERFACE String
+// A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
+// of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
+// - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
+// - if small - capacity left before going on the heap - using the lowest 5 bits
+// - if small - 2 bits are left unused - the second and third highest ones
+// - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
+//              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
+// Idea taken from this lecture about the string implementation of facebook/folly - fbstring
+// https://www.youtube.com/watch?v=kPR8h4-qZdk
+// TODO:
+// - optimizations - like not deleting memory unnecessarily in operator= and etc.
+// - resize/reserve/clear
+// - replace
+// - back/front
+// - iterator stuff
+// - find & friends
+// - push_back/pop_back
+// - assign/insert/erase
+// - relational operators as free functions - taking const char* as one of the params
+class DOCTEST_INTERFACE String
+{
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
+    static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
+
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
     {
-    public:
-        using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
-
-    private:
-        static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
-        static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
-
-        struct view // len should be more than sizeof(view) - because of the final byte for flags
-        {
-            char*    ptr;
-            size_type size;
-            size_type capacity;
-        };
-
-        union
-        {
-            char buf[len]; // NOLINT(*-avoid-c-arrays)
-            view data;
-        };
-
-        char* allocate(size_type sz);
-
-        bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
-        void setOnHeap() noexcept;
-        void setLast(size_type in = last) noexcept;
-        void setSize(size_type sz) noexcept;
-
-        void copy(const String& other);
-
-    public:
-        static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
-
-        String() noexcept;
-        ~String();
-
-        // cppcheck-suppress noExplicitConstructor
-        String(const char* in);
-        String(const char* in, size_type in_size);
-
-        String(std::istream& in, size_type in_size);
-
-        String(const String& other);
-        String& operator=(const String& other);
-
-        String& operator+=(const String& other);
-
-        String(String&& other) noexcept;
-        String& operator=(String&& other) noexcept;
-
-        char  operator[](size_type i) const;
-        char& operator[](size_type i);
-
-        // the only functions I'm willing to leave in the interface - available for inlining
-        const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-        char*       c_str() {
-            if (isOnStack()) {
-                return reinterpret_cast<char*>(buf);
-            }
-            return data.ptr;
-        }
-
-        size_type size() const;
-        size_type capacity() const;
-
-        String substr(size_type pos, size_type cnt = npos) &&;
-        String substr(size_type pos, size_type cnt = npos) const &;
-
-        size_type find(char ch, size_type pos = 0) const;
-        size_type rfind(char ch, size_type pos = npos) const;
-
-        int compare(const char* other, bool no_case = false) const;
-        int compare(const String& other, bool no_case = false) const;
-
-        friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+        char*     ptr;
+        size_type size;
+        size_type capacity;
     };
 
-    DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+    union
+    {
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
+        view data;
+    };
 
-    DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
+    char* allocate(size_type sz);
+
+    bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
+
+    void copy(const String& other);
+
+public:
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
+    ~String();
+
+    // cppcheck-suppress noExplicitConstructor
+    String(const char* in);
+    String(const char* in, size_type in_size);
+
+    String(std::istream& in, size_type in_size);
+
+    String(const String& other);
+    String& operator=(const String& other);
+
+    String& operator+=(const String& other);
+
+    String(String&& other) noexcept;
+    String& operator=(String&& other) noexcept;
+
+    char  operator[](size_type i) const;
+    char& operator[](size_type i);
+
+    // the only functions I'm willing to leave in the interface - available for inlining
+    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
+    char*       c_str() {
+        if(isOnStack()) {
+            return reinterpret_cast<char*>(buf);
+        }
+        return data.ptr;
+    }
+
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const&;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
+
+    int compare(const char* other, bool no_case = false) const;
+    int compare(const String& other, bool no_case = false) const;
+
+    friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+};
+
+DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+
+DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
 namespace detail {
 
 // MSVS 2015 :(
 #if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
     template <typename T, typename = void>
-    struct has_global_insertion_operator : types::false_type { };
+    struct has_global_insertion_operator : types::false_type
+    {
+    };
 
     template <typename T>
-    struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    struct has_global_insertion_operator<
+            T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())>
+            : types::true_type
+    {
+    };
 
     template <typename T, typename = void>
-    struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+    struct has_insertion_operator
+    {
+        static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value;
+    };
 
     template <typename T, bool global>
     struct insert_hack;
 
     template <typename T>
-    struct insert_hack<T, true> {
+    struct insert_hack<T, true>
+    {
         static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
     };
 
     template <typename T>
-    struct insert_hack<T, false> {
+    struct insert_hack<T, false>
+    {
         static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
     };
 
@@ -775,26 +841,36 @@ namespace detail {
     using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
 #else
     template <typename T, typename = void>
-    struct has_insertion_operator : types::false_type { };
+    struct has_insertion_operator : types::false_type
+    {
+    };
 #endif
 
     template <typename T>
-    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    struct has_insertion_operator<
+            T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())>
+            : types::true_type
+    {
+    };
 
     template <typename T>
-    struct should_stringify_as_underlying_type {
-        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+    struct should_stringify_as_underlying_type
+    {
+        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value &&
+                                              !doctest::detail::has_insertion_operator<T>::value;
     };
 
     DOCTEST_INTERFACE std::ostream* tlssPush();
-    DOCTEST_INTERFACE String tlssPop();
+    DOCTEST_INTERFACE String        tlssPop();
 
     template <bool C>
-    struct StringMakerBase {
+    struct StringMakerBase
+    {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T)) {
 #ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
-            static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+            static_assert(deferred_false<T>::value,
+                          "No stringification detected for type T. See string conversion manual");
 #endif
             return "{?}";
         }
@@ -823,7 +899,8 @@ namespace detail {
     }
 
     template <>
-    struct StringMakerBase<true> {
+    struct StringMakerBase<true>
+    {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T) in) {
             return toStream(in);
@@ -832,10 +909,12 @@ namespace detail {
 
 } // namespace detail
 
-    template <typename T>
-    struct StringMaker : public detail::StringMakerBase<
-        detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
-    {};
+template <typename T>
+struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value ||
+                                                    detail::types::is_pointer<T>::value ||
+                                                    detail::types::is_array<T>::value>
+{
+};
 
 #ifndef DOCTEST_STRINGIFY
 #ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
@@ -845,84 +924,92 @@ namespace detail {
 #endif
 #endif
 
-    template <typename T>
-    String toString() {
-    #if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
-        String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
-        String::size_type beginPos = ret.find('<');
-        return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
-    #else
-        String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
-        String::size_type begin = ret.find('=') + 2;
-        return ret.substr(begin, ret.size() - begin - 1);
-    #endif // Compiler
-    }
+template <typename T>
+String toString() {
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1,
+                      ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    String            ret   = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif // Compiler
+}
 
-    template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        return StringMaker<T>::convert(value);
-    }
+template <typename T,
+          typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value,
+                                            bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
+}
 
-    inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+inline String&& toString(String&& in) { return static_cast<String&&>(in); }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE String toString(const char* in);
+DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-    // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-    DOCTEST_INTERFACE String toString(const std::string& in);
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string& in);
 #endif // VS 2019
 
-    DOCTEST_INTERFACE String toString(const String& in);
+DOCTEST_INTERFACE String toString(const String& in);
 
-    DOCTEST_INTERFACE String toString(std::nullptr_t);
+DOCTEST_INTERFACE String toString(std::nullptr_t);
 
-    DOCTEST_INTERFACE String toString(bool in);
+DOCTEST_INTERFACE String toString(bool in);
 
-    DOCTEST_INTERFACE String toString(float in);
-    DOCTEST_INTERFACE String toString(double in);
-    DOCTEST_INTERFACE String toString(double long in);
+DOCTEST_INTERFACE String toString(float in);
+DOCTEST_INTERFACE String toString(double in);
+DOCTEST_INTERFACE String toString(double long in);
 
-    DOCTEST_INTERFACE String toString(char in);
-    DOCTEST_INTERFACE String toString(char signed in);
-    DOCTEST_INTERFACE String toString(char unsigned in);
-    DOCTEST_INTERFACE String toString(short in);
-    DOCTEST_INTERFACE String toString(short unsigned in);
-    DOCTEST_INTERFACE String toString(signed in);
-    DOCTEST_INTERFACE String toString(unsigned in);
-    DOCTEST_INTERFACE String toString(long in);
-    DOCTEST_INTERFACE String toString(long unsigned in);
-    DOCTEST_INTERFACE String toString(long long in);
-    DOCTEST_INTERFACE String toString(long long unsigned in);
+DOCTEST_INTERFACE String toString(char in);
+DOCTEST_INTERFACE String toString(char signed in);
+DOCTEST_INTERFACE String toString(char unsigned in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-    template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        using UT = typename detail::types::underlying_type<T>::type;
-        return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
-    }
+template <typename T,
+          typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value,
+                                            bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
 namespace detail {
     template <typename T>
     struct filldata
     {
         static void fill(std::ostream* stream, const T& in) {
-    #if defined(_MSC_VER) && _MSC_VER <= 1900
-        insert_hack_t<T>::insert(*stream, in);
-    #else
-        operator<<(*stream, in);
-    #endif // _MSV_VER
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+            insert_hack_t<T>::insert(*stream, in);
+#else
+            operator<<(*stream, in);
+#endif // _MSV_VER
         }
     };
 
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
     // NOLINTBEGIN(*-avoid-c-arrays)
     template <typename T, size_t N>
-    struct filldata<T[N]> {
-        static void fill(std::ostream* stream, const T(&in)[N]) {
+    struct filldata<T[N]>
+    {
+        static void fill(std::ostream* stream, const T (&in)[N]) {
             *stream << "[";
-            for (size_t i = 0; i < N; i++) {
-                if (i != 0) { *stream << ", "; }
+            for(size_t i = 0; i < N; i++) {
+                if(i != 0) {
+                    *stream << ", ";
+                }
                 *stream << (DOCTEST_STRINGIFY(in[i]));
             }
             *stream << "]";
@@ -934,7 +1021,8 @@ namespace detail {
     // Specialized since we don't want the terminating null byte!
     // NOLINTBEGIN(*-avoid-c-arrays)
     template <size_t N>
-    struct filldata<const char[N]> {
+    struct filldata<const char[N]>
+    {
         static void fill(std::ostream* stream, const char (&in)[N]) {
             *stream << String(in, in[N - 1] ? N : N - 1);
         } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
@@ -942,45 +1030,49 @@ namespace detail {
     // NOLINTEND(*-avoid-c-arrays)
 
     template <>
-    struct filldata<const void*> {
+    struct filldata<const void*>
+    {
         DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
     };
 
     template <>
-    struct filldata<const volatile void*> {
+    struct filldata<const volatile void*>
+    {
         DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
     };
 
     template <typename T>
-    struct filldata<T*> {
+    struct filldata<T*>
+    {
         DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            DOCTEST_MSVC_SUPPRESS_WARNING_POP
+            DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const volatile void*>::fill(stream,
-        #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
-                reinterpret_cast<const volatile void*>(in)
-        #else
-                *reinterpret_cast<const volatile void* const*>(&in)
-        #endif // DOCTEST_GCC
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                                                 reinterpret_cast<const volatile void*>(in)
+#else
+                                                 *reinterpret_cast<const volatile void* const*>(&in)
+#endif // DOCTEST_GCC
             );
-        DOCTEST_CLANG_SUPPRESS_WARNING_POP
+            DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };
 
-    #ifndef DOCTEST_CONFIG_DISABLE
+#ifndef DOCTEST_CONFIG_DISABLE
     template <typename L, typename R>
     String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
                                const DOCTEST_REF_WRAP(R) rhs) {
         return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
     }
-    #endif // DOCTEST_CONFIG_DISABLE
+#endif // DOCTEST_CONFIG_DISABLE
 } //namespace detail
 
 } // namespace doctest
 namespace doctest {
 
-class DOCTEST_INTERFACE Contains {
+class DOCTEST_INTERFACE Contains
+{
 public:
     explicit Contains(const String& string);
 
@@ -1007,9 +1099,10 @@ struct DOCTEST_INTERFACE Approx
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
+    explicit Approx(
+            const T& value,
+            typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
+                    static_cast<T*>(nullptr)) {
         *this = static_cast<double>(value);
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
@@ -1084,10 +1177,13 @@ namespace doctest {
 template <typename F>
 struct DOCTEST_INTERFACE_DECL IsNaN
 {
-    F value; bool flipped;
-    IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
-    IsNaN<F> operator!() const { return { value, !flipped }; }
-    operator bool() const;
+    F    value;
+    bool flipped;
+    IsNaN(F f, bool flip = false)
+            : value(f)
+            , flipped(flip) {}
+    IsNaN<F> operator!() const { return {value, !flipped}; }
+             operator bool() const;
 };
 
 #ifndef __MINGW32__
@@ -1106,56 +1202,56 @@ namespace detail {
     struct DOCTEST_INTERFACE TestCase;
 } // namespace detail
 
-    struct ContextOptions //!OCLINT too many fields
-    {
-        std::ostream* cout = nullptr; // stdout stream
-        String        binary_name;    // the test binary name
+struct ContextOptions //!OCLINT too many fields
+{
+    std::ostream* cout = nullptr; // stdout stream
+    String        binary_name;    // the test binary name
 
-        const detail::TestCase* currentTest = nullptr;
+    const detail::TestCase* currentTest = nullptr;
 
-        // == parameters from the command line
-        String   out;       // output filename
-        String   order_by;  // how tests should be ordered
-        unsigned rand_seed; // the seed for rand ordering
+    // == parameters from the command line
+    String   out;       // output filename
+    String   order_by;  // how tests should be ordered
+    unsigned rand_seed; // the seed for rand ordering
 
-        unsigned first; // the first (matching) test to be executed
-        unsigned last;  // the last (matching) test to be executed
+    unsigned first; // the first (matching) test to be executed
+    unsigned last;  // the last (matching) test to be executed
 
-        int abort_after;           // stop tests after this many failed assertions
-        int subcase_filter_levels; // apply the subcase filters for the first N levels
+    int abort_after;           // stop tests after this many failed assertions
+    int subcase_filter_levels; // apply the subcase filters for the first N levels
 
-        bool success;              // include successful assertions in output
-        bool case_sensitive;       // if filtering should be case sensitive
-        bool exit;                 // if the program should be exited after the tests are ran/whatever
-        bool duration;             // print the time duration of each test case
-        bool minimal;              // minimal console output (only test failures)
-        bool quiet;                // no console output
-        bool no_throw;             // to skip exceptions-related assertion macros
-        bool no_exitcode;          // if the framework should return 0 as the exitcode
-        bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-        bool no_intro;             // to not print the intro of the framework
-        bool no_version;           // to not print the version of the framework
-        bool no_colors;            // if output to the console should be colorized
-        bool force_colors;         // forces the use of colors even when a tty cannot be detected
-        bool no_breaks;            // to not break into the debugger
-        bool no_skip;              // don't skip test cases which are marked to be skipped
-        bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-        bool no_path_in_filenames; // if the path to files should be removed from the output
-        String strip_file_prefixes;// remove the longest matching one of these prefixes from any file paths in the output
-        bool no_line_numbers;      // if source code line numbers should be omitted from the output
-        bool no_debug_output;      // no output in the debug console when a debugger is attached
-        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
-        bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
+    bool success;              // include successful assertions in output
+    bool case_sensitive;       // if filtering should be case sensitive
+    bool exit;                 // if the program should be exited after the tests are ran/whatever
+    bool duration;             // print the time duration of each test case
+    bool minimal;              // minimal console output (only test failures)
+    bool quiet;                // no console output
+    bool no_throw;             // to skip exceptions-related assertion macros
+    bool no_exitcode;          // if the framework should return 0 as the exitcode
+    bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;             // to not print the intro of the framework
+    bool no_version;           // to not print the version of the framework
+    bool no_colors;            // if output to the console should be colorized
+    bool force_colors;         // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;            // to not break into the debugger
+    bool no_skip;              // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames; // if the path to files should be removed from the output
+    String strip_file_prefixes; // remove the longest matching one of these prefixes from any file paths in the output
+    bool no_line_numbers;    // if source code line numbers should be omitted from the output
+    bool no_debug_output;    // no output in the debug console when a debugger is attached
+    bool no_skipped_summary; // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;  // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
-        bool help;             // to print the help
-        bool version;          // to print the version
-        bool count;            // if only the count of matching tests is to be retrieved
-        bool list_test_cases;  // to list all tests matching the filters
-        bool list_test_suites; // to list all suites matching the filters
-        bool list_reporters;   // lists all registered reporters
-    };
+    bool help;             // to print the help
+    bool version;          // to print the version
+    bool count;            // if only the count of matching tests is to be retrieved
+    bool list_test_cases;  // to list all tests matching the filters
+    bool list_test_suites; // to list all suites matching the filters
+    bool list_reporters;   // lists all registered reporters
+};
 
-    DOCTEST_INTERFACE const ContextOptions* getContextOptions();
+DOCTEST_INTERFACE const ContextOptions* getContextOptions();
 
 } // namespace doctest
 namespace doctest {
@@ -1253,57 +1349,63 @@ namespace assertType {
 DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
 DOCTEST_INTERFACE const char* failureString(assertType::Enum at);
 
-}
+} // namespace doctest
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData;
+struct DOCTEST_INTERFACE TestCaseData;
 
-    struct DOCTEST_INTERFACE AssertData
+struct DOCTEST_INTERFACE AssertData
+{
+    // common - for all asserts
+    const TestCaseData* m_test_case;
+    assertType::Enum    m_at;
+    const char*         m_file;
+    int                 m_line;
+    const char*         m_expr;
+    bool                m_failed;
+
+    // exception-related - for all asserts
+    bool   m_threw;
+    String m_exception;
+
+    // for normal asserts
+    String m_decomp;
+
+    // for specific exception-related asserts
+    bool        m_threw_as;
+    const char* m_exception_type;
+
+    class DOCTEST_INTERFACE StringContains
     {
-        // common - for all asserts
-        const TestCaseData* m_test_case;
-        assertType::Enum    m_at;
-        const char*         m_file;
-        int                 m_line;
-        const char*         m_expr;
-        bool                m_failed;
+    private:
+        Contains content;
+        bool     isContains;
 
-        // exception-related - for all asserts
-        bool   m_threw;
-        String m_exception;
+    public:
+        StringContains(const String& str)
+                : content(str)
+                , isContains(false) {}
+        StringContains(Contains cntn)
+                : content(static_cast<Contains&&>(cntn))
+                , isContains(true) {}
 
-        // for normal asserts
-        String m_decomp;
+        bool check(const String& str) {
+            return isContains ? (content == str) : (content.string == str);
+        }
 
-        // for specific exception-related asserts
-        bool           m_threw_as;
-        const char*    m_exception_type;
+        operator const String&() const { return content.string; }
 
-        class DOCTEST_INTERFACE StringContains {
-            private:
-                Contains content;
-                bool isContains;
+        const char* c_str() const { return content.string.c_str(); }
+    } m_exception_string;
 
-            public:
-                StringContains(const String& str) : content(str), isContains(false) { }
-                StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
-
-                bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
-
-                operator const String&() const { return content.string; }
-
-                const char* c_str() const { return content.string.c_str(); }
-        } m_exception_string;
-
-        AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-            const char* exception_type, const StringContains& exception_string);
-    };
+    AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+               const char* exception_type, const StringContains& exception_string);
+};
 
 } // namespace doctest
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail  {
+namespace doctest { namespace detail {
 
     // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1389,14 +1491,12 @@ namespace detail  {
     DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
     DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 // more checks could be added - like in Catch:
 // https://github.com/catchorg/Catch2/pull/1480/files
@@ -1456,7 +1556,7 @@ namespace detail {
         DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
                                             const DOCTEST_REF_WRAP(R) rhs) {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if (m_failed || getContextOptions()->success) {
+            if(m_failed || getContextOptions()->success) {
                 m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
             }
             return !m_failed;
@@ -1466,11 +1566,11 @@ namespace detail {
         DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
             m_failed = !val;
 
-            if (m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+            if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
                 m_failed = !m_failed;
             }
 
-            if (m_failed || getContextOptions()->success) {
+            if(m_failed || getContextOptions()->success) {
                 m_decomp = (DOCTEST_STRINGIFY(val));
             }
 
@@ -1483,17 +1583,15 @@ namespace detail {
         void react() const;
     };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 #if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 #endif
 
 // This will check if there is any way it could find a operator like member or friend and uses it.
@@ -1501,15 +1599,17 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
 #ifdef __NVCC__
-#define SFINAE_OP(ret,op) ret
+#define SFINAE_OP(ret, op) ret
 #else
-#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
+#define SFINAE_OP(ret, op)                                                                         \
+    decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()), ret{})
 #endif
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
-    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
+    DOCTEST_NOINLINE SFINAE_OP(Result, op) operator op(R&& rhs) {                                  \
+        bool res = op_macro(doctest::detail::forward<const L>(lhs),                                \
+                            doctest::detail::forward<R>(rhs));                                     \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
         if(!res || doctest::getContextOptions()->success)                                          \
@@ -1542,66 +1642,66 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-template <typename L>
-// cppcheck-suppress copyCtorAndEqOperator
-struct Expression_lhs
-{
-    L                lhs;
-    assertType::Enum m_at;
+    template <typename L>
+    // cppcheck-suppress copyCtorAndEqOperator
+    struct Expression_lhs
+    {
+        L                lhs;
+        assertType::Enum m_at;
 
-    explicit Expression_lhs(L&& in, assertType::Enum at)
-            : lhs(static_cast<L&&>(in))
-            , m_at(at) {}
+        explicit Expression_lhs(L&& in, assertType::Enum at)
+                : lhs(static_cast<L&&>(in))
+                , m_at(at) {}
 
-    DOCTEST_NOINLINE operator Result() {
-// this is needed only for MSVC 2015
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
-        bool res = static_cast<bool>(lhs);
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
-            res = !res;
+        DOCTEST_NOINLINE operator Result() {
+            // this is needed only for MSVC 2015
+            DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+            bool res = static_cast<bool>(lhs);
+            DOCTEST_MSVC_SUPPRESS_WARNING_POP
+            if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+                res = !res;
+            }
+
+            if(!res || getContextOptions()->success) {
+                return {res, (DOCTEST_STRINGIFY(lhs))};
+            }
+            return {res};
         }
 
-        if(!res || getContextOptions()->success) {
-            return { res, (DOCTEST_STRINGIFY(lhs)) };
-        }
-        return { res };
-    }
+        /* This is required for user-defined conversions from Expression_lhs to L */
+        operator L() const { return lhs; }
 
-    /* This is required for user-defined conversions from Expression_lhs to L */
-    operator L() const { return lhs; }
-
-    // clang-format off
+        // clang-format off
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>,  " >  ", DOCTEST_CMP_GT) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<,  " <  ", DOCTEST_CMP_LT) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
-    // clang-format on
+        // clang-format on
 
-    // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
-    // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-    // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
-};
+        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
+        // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
+        // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
+    };
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
@@ -1612,36 +1712,37 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 #if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
 #endif
 
-struct DOCTEST_INTERFACE ExpressionDecomposer
-{
-    assertType::Enum m_at;
+    struct DOCTEST_INTERFACE ExpressionDecomposer
+    {
+        assertType::Enum m_at;
 
-    ExpressionDecomposer(assertType::Enum at);
+        ExpressionDecomposer(assertType::Enum at);
 
-    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-    // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
-    // https://github.com/catchorg/Catch2/issues/870
-    // https://github.com/catchorg/Catch2/issues/565
-    template <typename L>
-    Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
-        return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
-    }
+        // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
+        // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+        // https://github.com/catchorg/Catch2/issues/870
+        // https://github.com/catchorg/Catch2/issues/565
+        template <typename L>
+        Expression_lhs<const L&&> operator<<(
+                const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
+            return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
+        }
 
-    template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
-    Expression_lhs<const L&> operator<<(const L &operand) {
-        return Expression_lhs<const L&>(operand, m_at);
-    }
-};
+        template <typename L,
+                  typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,
+                                            void>::type* = nullptr>
+        Expression_lhs<const L&> operator<<(const L& operand) {
+            return Expression_lhs<const L&>(operand, m_at);
+        }
+    };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
-namespace doctest {
-namespace Color {
+namespace doctest { namespace Color {
     enum Enum
     {
         None = 0,
@@ -1662,8 +1763,7 @@ namespace Color {
     };
 
     DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
-} // namespace Color
-}
+}} // namespace doctest::Color
 namespace doctest {
 
 struct DOCTEST_INTERFACE SubcaseSignature
@@ -1678,59 +1778,56 @@ struct DOCTEST_INTERFACE SubcaseSignature
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-struct DOCTEST_INTERFACE Subcase
-{
-    SubcaseSignature m_signature;
-    bool             m_entered = false;
+    struct DOCTEST_INTERFACE Subcase
+    {
+        SubcaseSignature m_signature;
+        bool             m_entered = false;
 
-    Subcase(const String& name, const char* file, int line);
-    Subcase(const Subcase&) = delete;
-    Subcase(Subcase&&) = delete;
-    Subcase& operator=(const Subcase&) = delete;
-    Subcase& operator=(Subcase&&) = delete;
-    ~Subcase();
+        Subcase(const String& name, const char* file, int line);
+        Subcase(const Subcase&)            = delete;
+        Subcase(Subcase&&)                 = delete;
+        Subcase& operator=(const Subcase&) = delete;
+        Subcase& operator=(Subcase&&)      = delete;
+        ~Subcase();
 
-    operator bool() const;
+        operator bool() const;
 
     private:
         bool checkFilters();
-};
+    };
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 
 } // namespace doctest
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-struct DOCTEST_INTERFACE TestSuite
-{
-    const char* m_test_suite = nullptr;
-    const char* m_description = nullptr;
-    bool        m_skip = false;
-    bool        m_no_breaks = false;
-    bool        m_no_output = false;
-    bool        m_may_fail = false;
-    bool        m_should_fail = false;
-    int         m_expected_failures = 0;
-    double      m_timeout = 0;
+    struct DOCTEST_INTERFACE TestSuite
+    {
+        const char* m_test_suite        = nullptr;
+        const char* m_description       = nullptr;
+        bool        m_skip              = false;
+        bool        m_no_breaks         = false;
+        bool        m_no_output         = false;
+        bool        m_may_fail          = false;
+        bool        m_should_fail       = false;
+        int         m_expected_failures = 0;
+        double      m_timeout           = 0;
 
-    TestSuite& operator*(const char* in);
+        TestSuite& operator*(const char* in);
 
-    template <typename T>
-    TestSuite& operator*(const T& in) {
-        in.fill(*this);
-        return *this;
-    }
-};
+        template <typename T>
+        TestSuite& operator*(const T& in) {
+            in.fill(*this);
+            return *this;
+        }
+    };
 
-// forward declarations of functions used by the macros
-DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+    // forward declarations of functions used by the macros
+    DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
 
-} // namespace detail
-
-} // namespace doctest
+}} // namespace doctest::detail
 
 // in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
@@ -1741,21 +1838,21 @@ DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
 #endif // DOCTEST_CONFIG_DISABLE
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData
-    {
-        String      m_file;       // the file in which the test was registered (using String - see #350)
-        unsigned    m_line;       // the line where the test was registered
-        const char* m_name;       // name of the test case
-        const char* m_test_suite; // the test suite in which the test was added
-        const char* m_description;
-        bool        m_skip;
-        bool        m_no_breaks;
-        bool        m_no_output;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
-    };
+struct DOCTEST_INTERFACE TestCaseData
+{
+    String      m_file;       // the file in which the test was registered (using String - see #350)
+    unsigned    m_line;       // the line where the test was registered
+    const char* m_name;       // name of the test case
+    const char* m_test_suite; // the test suite in which the test was added
+    const char* m_description;
+    bool        m_skip;
+    bool        m_no_breaks;
+    bool        m_no_output;
+    bool        m_may_fail;
+    bool        m_should_fail;
+    int         m_expected_failures;
+    double      m_timeout;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
@@ -1771,7 +1868,7 @@ namespace detail {
         String m_full_name; // contains the name (only for templated test cases!) + the template type
 
         TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                  const String& type = String(), int template_id = -1);
+                 const String& type = String(), int template_id = -1);
 
         TestCase(const TestCase& other);
         TestCase(TestCase&&) = delete;
@@ -1826,7 +1923,7 @@ DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
-} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 namespace doctest {
@@ -1903,51 +2000,55 @@ struct DOCTEST_INTERFACE IContextScope
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-  // ContextScope base class used to allow implementing methods of ContextScope
-  // that don't depend on the template parameter in doctest.cpp.
-  struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
-      ContextScopeBase(const ContextScopeBase&) = delete;
+    // ContextScope base class used to allow implementing methods of ContextScope
+    // that don't depend on the template parameter in doctest.cpp.
+    struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope
+    {
+        ContextScopeBase(const ContextScopeBase&) = delete;
 
-      ContextScopeBase& operator=(const ContextScopeBase&) = delete;
-      ContextScopeBase& operator=(ContextScopeBase&&) = delete;
+        ContextScopeBase& operator=(const ContextScopeBase&) = delete;
+        ContextScopeBase& operator=(ContextScopeBase&&)      = delete;
 
-      ~ContextScopeBase() override = default;
+        ~ContextScopeBase() override = default;
 
-  protected:
-      ContextScopeBase();
-      ContextScopeBase(ContextScopeBase&& other) noexcept;
+    protected:
+        ContextScopeBase();
+        ContextScopeBase(ContextScopeBase&& other) noexcept;
 
-      void destroy();
-      bool need_to_destroy{true};
-  };
+        void destroy();
+        bool need_to_destroy{true};
+    };
 
-  template <typename L> class ContextScope : public ContextScopeBase
-  {
-      L lambda_;
+    template <typename L>
+    class ContextScope : public ContextScopeBase
+    {
+        L lambda_;
 
-  public:
-      explicit ContextScope(const L &lambda) : lambda_(lambda) {}
-      explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
+    public:
+        explicit ContextScope(const L& lambda)
+                : lambda_(lambda) {}
+        explicit ContextScope(L&& lambda)
+                : lambda_(static_cast<L&&>(lambda)) {}
 
-      ContextScope(const ContextScope&) = delete;
-      ContextScope(ContextScope&&) noexcept = default;
+        ContextScope(const ContextScope&)     = delete;
+        ContextScope(ContextScope&&) noexcept = default;
 
-      ContextScope& operator=(const ContextScope&) = delete;
-      ContextScope& operator=(ContextScope&&) = delete;
+        ContextScope& operator=(const ContextScope&) = delete;
+        ContextScope& operator=(ContextScope&&)      = delete;
 
-      void stringify(std::ostream* s) const override { lambda_(s); }
+        void stringify(std::ostream* s) const override { lambda_(s); }
 
-      ~ContextScope() override {
-          if (need_to_destroy) {
-              destroy();
-          }
-      }
-  };
+        ~ContextScope() override {
+            if(need_to_destroy) {
+                destroy();
+            }
+        }
+    };
 
-  template <typename L>
-  ContextScope<L> MakeContextScope(const L &lambda) {
-      return ContextScope<L>(lambda);
-  }
+    template <typename L>
+    ContextScope<L> MakeContextScope(const L& lambda) {
+        return ContextScope<L>(lambda);
+    }
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -1955,13 +2056,13 @@ namespace detail {
 } // namespace doctest
 namespace doctest {
 
-    struct DOCTEST_INTERFACE MessageData
-    {
-        String           m_string;
-        const char*      m_file;
-        int              m_line;
-        assertType::Enum m_severity;
-    };
+struct DOCTEST_INTERFACE MessageData
+{
+    String           m_string;
+    const char*      m_file;
+    int              m_line;
+    assertType::Enum m_severity;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
@@ -1974,32 +2075,36 @@ namespace detail {
         MessageBuilder(const char* file, int line, assertType::Enum severity);
 
         MessageBuilder(const MessageBuilder&) = delete;
-        MessageBuilder(MessageBuilder&&) = delete;
+        MessageBuilder(MessageBuilder&&)      = delete;
 
         MessageBuilder& operator=(const MessageBuilder&) = delete;
-        MessageBuilder& operator=(MessageBuilder&&) = delete;
+        MessageBuilder& operator=(MessageBuilder&&)      = delete;
 
         ~MessageBuilder();
 
         // the preferred way of chaining parameters for stringification
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
         template <typename T>
         MessageBuilder& operator,(const T& in) {
             *m_stream << (DOCTEST_STRINGIFY(in));
             return *this;
         }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
         // kept here just for backwards-compatibility - the comma operator should be preferred now
         template <typename T>
-        MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
+        MessageBuilder& operator<<(const T& in) {
+            return this->operator,(in);
+        }
 
         // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
         // the `,` operator will be called last which is not what we want and thus the `*` operator
         // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
         // an operator of the MessageBuilder class is called first before the rest of the parameters
         template <typename T>
-        MessageBuilder& operator*(const T& in) { return this->operator,(in); }
+        MessageBuilder& operator*(const T& in) {
+            return this->operator,(in);
+        }
 
         bool log();
         void react();
@@ -2018,27 +2123,25 @@ DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-  struct DOCTEST_INTERFACE TestFailureException
-  {
-  };
+    struct DOCTEST_INTERFACE TestFailureException
+    {
+    };
 
-  DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+    DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_NORETURN
+    DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_INTERFACE void throwException();
+    DOCTEST_INTERFACE void throwException();
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 namespace doctest {
 
-    DOCTEST_INTERFACE extern bool is_running_in_test;
+DOCTEST_INTERFACE extern bool is_running_in_test;
 
 namespace detail {
     using assert_handler = void (*)(const AssertData&);
@@ -2055,10 +2158,10 @@ public:
     explicit Context(int argc = 0, const char* const* argv = nullptr);
 
     Context(const Context&) = delete;
-    Context(Context&&) = delete;
+    Context(Context&&)      = delete;
 
     Context& operator=(const Context&) = delete;
-    Context& operator=(Context&&) = delete;
+    Context& operator=(Context&&)      = delete;
 
     ~Context(); // NOLINT(performance-trivially-destructible)
 
@@ -2083,8 +2186,7 @@ public:
 } // namespace doctest
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
 
@@ -2105,8 +2207,7 @@ namespace detail {
                     throwException();                                                              \
             }                                                                                      \
             return !failed;                                                                        \
-        }                                                                                          \
-    } while(false)
+    }} while(false)
 
 #define DOCTEST_ASSERT_IN_TESTS(decomp)                                                            \
     ResultBuilder rb(at, file, line, expr);                                                        \
@@ -2150,8 +2251,7 @@ namespace detail {
         return !failed;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 namespace doctest {
@@ -2173,91 +2273,92 @@ namespace TestCaseFailureReason {
     };
 } // namespace TestCaseFailureReason
 
-    struct DOCTEST_INTERFACE CurrentTestCaseStats
-    {
-        int    numAssertsCurrentTest;
-        int    numAssertsFailedCurrentTest;
-        double seconds;
-        int    failure_flags; // use TestCaseFailureReason::Enum
-        bool   testCaseSuccess;
-    };
+struct DOCTEST_INTERFACE CurrentTestCaseStats
+{
+    int    numAssertsCurrentTest;
+    int    numAssertsFailedCurrentTest;
+    double seconds;
+    int    failure_flags; // use TestCaseFailureReason::Enum
+    bool   testCaseSuccess;
+};
 
-    struct DOCTEST_INTERFACE TestCaseException
-    {
-        String error_string;
-        bool   is_crash;
-    };
+struct DOCTEST_INTERFACE TestCaseException
+{
+    String error_string;
+    bool   is_crash;
+};
 
-    struct DOCTEST_INTERFACE TestRunStats
-    {
-        unsigned numTestCases;
-        unsigned numTestCasesPassingFilters;
-        unsigned numTestSuitesPassingFilters;
-        unsigned numTestCasesFailed;
-        int      numAsserts;
-        int      numAssertsFailed;
-    };
+struct DOCTEST_INTERFACE TestRunStats
+{
+    unsigned numTestCases;
+    unsigned numTestCasesPassingFilters;
+    unsigned numTestSuitesPassingFilters;
+    unsigned numTestCasesFailed;
+    int      numAsserts;
+    int      numAssertsFailed;
+};
 
-    struct QueryData
-    {
-        const TestRunStats*  run_stats = nullptr;
-        const TestCaseData** data      = nullptr;
-        unsigned             num_data  = 0;
-    };
+struct QueryData
+{
+    const TestRunStats*  run_stats = nullptr;
+    const TestCaseData** data      = nullptr;
+    unsigned             num_data  = 0;
+};
 
-    struct DOCTEST_INTERFACE IReporter
-    {
-        // The constructor has to accept "const ContextOptions&" as a single argument
-        // which has most of the options for the run + a pointer to the stdout stream
-        // Reporter(const ContextOptions& in)
+struct DOCTEST_INTERFACE IReporter
+{
+    // The constructor has to accept "const ContextOptions&" as a single argument
+    // which has most of the options for the run + a pointer to the stdout stream
+    // Reporter(const ContextOptions& in)
 
-        // called when a query should be reported (listing test cases, printing the version, etc.)
-        virtual void report_query(const QueryData&) = 0;
+    // called when a query should be reported (listing test cases, printing the version, etc.)
+    virtual void report_query(const QueryData&) = 0;
 
-        // called when the whole test run starts
-        virtual void test_run_start() = 0;
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const TestRunStats&) = 0;
+    // called when the whole test run starts
+    virtual void test_run_start() = 0;
+    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+    virtual void test_run_end(const TestRunStats&) = 0;
 
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const TestCaseData&) = 0;
-        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const TestCaseData&) = 0;
-        // called when a test case has ended
-        virtual void test_case_end(const CurrentTestCaseStats&) = 0;
+    // called when a test case is started (safe to cache a pointer to the input)
+    virtual void test_case_start(const TestCaseData&) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData&) = 0;
+    // called when a test case has ended
+    virtual void test_case_end(const CurrentTestCaseStats&) = 0;
 
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const TestCaseException&) = 0;
+    // called when an exception is thrown from the test case (or it crashes)
+    virtual void test_case_exception(const TestCaseException&) = 0;
 
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const SubcaseSignature&) = 0;
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() = 0;
+    // called whenever a subcase is entered (don't cache pointers to the input)
+    virtual void subcase_start(const SubcaseSignature&) = 0;
+    // called whenever a subcase is exited (don't cache pointers to the input)
+    virtual void subcase_end() = 0;
 
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const AssertData&) = 0;
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const MessageData&) = 0;
+    // called for each assert (don't cache pointers to the input)
+    virtual void log_assert(const AssertData&) = 0;
+    // called for each message (don't cache pointers to the input)
+    virtual void log_message(const MessageData&) = 0;
 
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const TestCaseData&) = 0;
+    // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
+    // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
+    virtual void test_case_skipped(const TestCaseData&) = 0;
 
-        DOCTEST_DECLARE_INTERFACE(IReporter)
+    DOCTEST_DECLARE_INTERFACE(IReporter)
 
-        // can obtain all currently active contexts and stringify them if one wishes to do so
-        static int                         get_num_active_contexts();
-        static const IContextScope* const* get_active_contexts();
+    // can obtain all currently active contexts and stringify them if one wishes to do so
+    static int                         get_num_active_contexts();
+    static const IContextScope* const* get_active_contexts();
 
-        // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-        static int           get_num_stringified_contexts();
-        static const String* get_stringified_contexts();
-    };
+    // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
+    static int           get_num_stringified_contexts();
+    static const String* get_stringified_contexts();
+};
 
 namespace detail {
-    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
+    using reporterCreatorFunc = IReporter* (*)(const ContextOptions&);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c,
+                                                bool isReporter);
 
     template <typename Reporter>
     IReporter* reporterCreator(const ContextOptions& o) {
@@ -2265,20 +2366,20 @@ namespace detail {
     }
 } // namespace detail
 
-    template <typename Reporter>
-    int registerReporter(const char* name, int priority, bool isReporter) {
-        detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
-        return 0;
-    }
+template <typename Reporter>
+int registerReporter(const char* name, int priority, bool isReporter) {
+    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+    return 0;
+}
 } // namespace doctest
 #ifndef DOCTEST_CONFIG_DISABLE
-namespace doctest {
-namespace detail {
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+namespace doctest { namespace detail {
+    template <typename T>
+    int instantiationHelper(const T&) {
+        return 0;
+    }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
@@ -2302,7 +2403,8 @@ namespace detail {
 
 // common code in asserts - for convenience
 #define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
-    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
+    if(b.log())                                                                                    \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
     b.react();                                                                                     \
     DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
@@ -2326,7 +2428,8 @@ namespace detail {
 
 // registers the test by initializing a dummy var with a function
 #define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(                                                      \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */                                     \
             doctest::detail::regTest(                                                              \
                     doctest::detail::TestCase(                                                     \
                             f, __FILE__, __LINE__,                                                 \
@@ -2399,11 +2502,12 @@ namespace detail {
         struct iter<std::tuple<Type, Rest...>>                                                     \
         {                                                                                          \
             iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::toString<Type>(),                             \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
+                doctest::detail::regTest(                                                          \
+                        doctest::detail::TestCase(                                                 \
+                                func<Type>, file, line,                                            \
+                                doctest_detail_test_suite_ns::getCurrentTestSuite(),               \
+                                doctest::toString<Type>(), int(line) * 1000 + index) *             \
+                        dec);                                                                      \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
             }                                                                                      \
         };                                                                                         \
@@ -2421,16 +2525,21 @@ namespace detail {
                                            DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
-        doctest::detail::instantiationHelper(                                                      \
-            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_CAT(                                                                           \
+                    anon,                                                                          \
+                    DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */   \
+            doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ >         \
+                                                 (__FILE__, __LINE__, 0)))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_),          \
+                                                std::tuple<__VA_ARGS__>)                           \
     static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_),          \
+                                                __VA_ARGS__)                                       \
     static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
@@ -2444,7 +2553,7 @@ namespace detail {
 
 // for subcases
 #define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
+    if(const doctest::detail::Subcase& DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =   \
                doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
@@ -2474,20 +2583,22 @@ namespace detail {
 
 // for starting a testsuite block
 #define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                     \
             doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
     static_assert(true, "")
 
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END                                                                     \
     DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+                               doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))   \
     using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
     inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */              \
             doctest::registerExceptionTranslator(translatorName))                                  \
     doctest::String translatorName(signature)
 
@@ -2497,13 +2608,15 @@ namespace detail {
 
 // for registering reporters
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                \
             doctest::registerReporter<reporter>(name, priority, true))                             \
     static_assert(true, "")
 
 // for registering listeners
 #define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                \
             doctest::registerReporter<reporter>(name, priority, false))                            \
     static_assert(true, "")
 
@@ -2515,12 +2628,12 @@ namespace detail {
                       __VA_ARGS__)
 // clang-format on
 
-#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
-    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
-        [&](std::ostream* s_name) {                                                                \
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                                    \
+    auto DOCTEST_ANONYMOUS(                                                                        \
+            DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope([&](std::ostream* s_name) {      \
         doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
         mb_name.m_stream = s_name;                                                                 \
-        mb_name * __VA_ARGS__;                                                                     \
+        mb_name* __VA_ARGS__;                                                                      \
     })
 
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
@@ -2528,11 +2641,12 @@ namespace detail {
 #define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb * __VA_ARGS__;                                                                          \
+        mb*                             __VA_ARGS__;                                               \
         if(mb.log())                                                                               \
             DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
         mb.react();                                                                                \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
@@ -2552,7 +2666,7 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
     /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
     doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
-                                               __LINE__, #__VA_ARGS__);                            \
+                                              __LINE__, #__VA_ARGS__);                             \
     DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
             << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
@@ -2560,27 +2674,28 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 #define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+    DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__); }             \
+    DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 #define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         DOCTEST_WRAP_IN_TRY(                                                                       \
                 DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
                         __VA_ARGS__))                                                              \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -2652,11 +2767,12 @@ namespace detail {
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         if(!doctest::getContextOptions()->no_throw) {                                              \
             doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
+                                                      __LINE__, #expr, #__VA_ARGS__, message);     \
             try {                                                                                  \
                 DOCTEST_CAST_TO_VOID(expr)                                                         \
             } catch(const typename doctest::detail::types::remove_const<                           \
-                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
+                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::        \
+                            type&) {                                                               \
                 DOCTEST_RB.translateException();                                                   \
                 DOCTEST_RB.m_threw_as = true;                                                      \
             } catch(...) { DOCTEST_RB.translateException(); }                                      \
@@ -2664,31 +2780,34 @@ namespace detail {
         } else { /* NOLINT(*-else-after-return) */                                                 \
             DOCTEST_FUNC_SCOPE_RET(false);                                                         \
         }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         if(!doctest::getContextOptions()->no_throw) {                                              \
             doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
+                                                      __LINE__, expr_str, "", __VA_ARGS__);        \
             try {                                                                                  \
                 DOCTEST_CAST_TO_VOID(expr)                                                         \
             } catch(...) { DOCTEST_RB.translateException(); }                                      \
             DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
         } else { /* NOLINT(*-else-after-return) */                                                 \
-           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
         }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         try {                                                                                      \
             DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
         } catch(...) { DOCTEST_RB.translateException(); }                                          \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
@@ -2740,7 +2859,9 @@ namespace detail {
     namespace /* NOLINT */ {                                                                       \
         template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
         struct der : public base                                                                   \
-        { void f(); };                                                                             \
+        {                                                                                          \
+            void f();                                                                              \
+        };                                                                                         \
     }                                                                                              \
     template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
@@ -2806,8 +2927,8 @@ namespace detail {
 #define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
 #define DOCTEST_FAIL(...) (static_cast<void>(0))
 
-#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
- && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED) &&                                 \
+        defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
 
 #define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
 #define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
@@ -2823,11 +2944,12 @@ namespace detail {
 #define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
 #define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 #define DOCTEST_RELATIONAL_OP(name, op)                                                            \
     template <typename L, typename R>                                                              \
-    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                      \
+        return lhs op rhs;                                                                         \
+    }
 
     DOCTEST_RELATIONAL_OP(eq, ==)
     DOCTEST_RELATIONAL_OP(ne, !=)
@@ -2835,8 +2957,7 @@ namespace detail {
     DOCTEST_RELATIONAL_OP(gt, >)
     DOCTEST_RELATIONAL_OP(le, <=)
     DOCTEST_RELATIONAL_OP(ge, >=)
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #define DOCTEST_WARN_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
 #define DOCTEST_CHECK_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
@@ -2865,39 +2986,157 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
-#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...)                                                  \
+    [] {                                                                                           \
+        static_assert(false, "Exception translation is not available when doctest is disabled.");  \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_WARN_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_WARN_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_CHECK_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_REQUIRE_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_WARN_THROWS(...)                                                                   \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS(...)                                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS(...)                                                                \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_WARN_THROWS_AS(expr, ...)                                                          \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_AS(expr, ...)                                                         \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...)                                                       \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_WARN_NOTHROW(...)                                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_CHECK_NOTHROW(...)                                                                 \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_REQUIRE_NOTHROW(...)                                                               \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
 
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...)                                                     \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...)                                                    \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...)                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...)                                              \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...)                                             \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...)                                           \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...)                                                    \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...)                                                   \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...)                                                 \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
@@ -2988,8 +3227,13 @@ namespace detail {
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
-    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
+#define DOCTEST_EXCEPTION_EMPTY_FUNC                                                               \
+    [] {                                                                                           \
+        static_assert(false, "Exceptions are disabled! "                                           \
+                             "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want "  \
+                             "to compile with exceptions disabled.");                              \
+        return false;                                                                              \
+    }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -3115,8 +3359,10 @@ namespace detail {
 #define TEST_SUITE_BEGIN(name) DOCTEST_TEST_SUITE_BEGIN(name)
 #define TEST_SUITE_END DOCTEST_TEST_SUITE_END
 #define REGISTER_EXCEPTION_TRANSLATOR(signature) DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)
-#define REGISTER_REPORTER(name, priority, reporter) DOCTEST_REGISTER_REPORTER(name, priority, reporter)
-#define REGISTER_LISTENER(name, priority, reporter) DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+#define REGISTER_REPORTER(name, priority, reporter)                                                \
+    DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define REGISTER_LISTENER(name, priority, reporter)                                                \
+    DOCTEST_REGISTER_LISTENER(name, priority, reporter)
 #define INFO(...) DOCTEST_INFO(__VA_ARGS__)
 #define CAPTURE(x) DOCTEST_CAPTURE(x)
 #define ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_MESSAGE_AT(file, line, __VA_ARGS__)
@@ -3146,29 +3392,38 @@ namespace detail {
 #define REQUIRE_THROWS(...) DOCTEST_REQUIRE_THROWS(__VA_ARGS__)
 #define REQUIRE_THROWS_AS(expr, ...) DOCTEST_REQUIRE_THROWS_AS(expr, __VA_ARGS__)
 #define REQUIRE_THROWS_WITH(expr, ...) DOCTEST_REQUIRE_THROWS_WITH(expr, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS(expr, with, ...)                                                    \
+    DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
 #define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
 #define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
 #define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
 #define WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define WARN_THROWS_WITH_MESSAGE(expr, with, ...)                                                  \
+    DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                           \
+    DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_WARN_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 #define CHECK_MESSAGE(cond, ...) DOCTEST_CHECK_MESSAGE(cond, __VA_ARGS__)
 #define CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_CHECK_THROWS_MESSAGE(expr, __VA_ARGS__)
-#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...)                                                     \
+    DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...)                                                 \
+    DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                          \
+    DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_CHECK_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 #define REQUIRE_MESSAGE(cond, ...) DOCTEST_REQUIRE_MESSAGE(cond, __VA_ARGS__)
 #define REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_REQUIRE_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_REQUIRE_THROWS_MESSAGE(expr, __VA_ARGS__)
-#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...)                                                   \
+    DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...)                                               \
+    DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                        \
+    DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 
 #define SCENARIO(name) DOCTEST_SCENARIO(name)
@@ -3233,7 +3488,8 @@ namespace detail {
 #define FAST_CHECK_UNARY_FALSE(...) DOCTEST_FAST_CHECK_UNARY_FALSE(__VA_ARGS__)
 #define FAST_REQUIRE_UNARY_FALSE(...) DOCTEST_FAST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
-#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                                    \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
@@ -3337,7 +3593,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <mutex>
 #define DOCTEST_DECLARE_MUTEX(name) std::mutex name;
 #define DOCTEST_DECLARE_STATIC_MUTEX(name) static DOCTEST_DECLARE_MUTEX(name)
-#define DOCTEST_LOCK_MUTEX(name) std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
+#define DOCTEST_LOCK_MUTEX(name)                                                                   \
+    std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
 #else // DOCTEST_CONFIG_NO_MULTITHREADING
 #define DOCTEST_DECLARE_MUTEX(name)
 #define DOCTEST_DECLARE_STATIC_MUTEX(name)
@@ -3414,7 +3671,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_THREAD_LOCAL
-#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) ||                                                   \
+        DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
 #define DOCTEST_THREAD_LOCAL
 #else // DOCTEST_MSVC
 #define DOCTEST_THREAD_LOCAL thread_local
@@ -3439,26 +3697,24 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-namespace timer_large_integer
-{
+    namespace timer_large_integer {
 
 #if defined(DOCTEST_PLATFORM_WINDOWS)
-    using type = ULONGLONG;
-#else // DOCTEST_PLATFORM_WINDOWS
-    using type = std::uint64_t;
+        using type = ULONGLONG;
+#else  // DOCTEST_PLATFORM_WINDOWS
+        using type = std::uint64_t;
 #endif // DOCTEST_PLATFORM_WINDOWS
-}
+    } // namespace timer_large_integer
 
-using ticks_t = timer_large_integer::type;
+    using ticks_t = timer_large_integer::type;
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
     ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
     ticks_t getCurrentTicks() {
-        static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
+        static LARGE_INTEGER hz = {{0}}, hzo = {{0}};
         if(!hz.QuadPart) {
             QueryPerformanceFrequency(&hz);
             QueryPerformanceCounter(&hzo);
@@ -3484,26 +3740,26 @@ using ticks_t = timer_large_integer::type;
         //unsigned int getElapsedMilliseconds() const {
         //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
         //}
-        double getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
+        double getElapsedSeconds() const {
+            return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0;
+        }
 
     private:
         ticks_t m_ticks = 0;
     };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 #ifdef DOCTEST_CONFIG_NO_MULTITHREADING
     template <typename T>
     using Atomic = T;
-#else // DOCTEST_CONFIG_NO_MULTITHREADING
+#else  // DOCTEST_CONFIG_NO_MULTITHREADING
     template <typename T>
     using Atomic = std::atomic<T>;
 #endif // DOCTEST_CONFIG_NO_MULTITHREADING
@@ -3511,7 +3767,7 @@ namespace detail {
 #if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
     template <typename T>
     using MultiLaneAtomic = Atomic<T>;
-#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+#else  // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
     // Provides a multilane implementation of an atomic variable that supports add, sub, load,
     // store. Instead of using a single atomic variable, this splits up into multiple ones,
     // each sitting on a separate cache line. The goal is to provide a speedup when most
@@ -3528,7 +3784,7 @@ namespace detail {
         struct CacheLineAlignedAtomic
         {
             Atomic<T> atomic{};
-            char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
+            char      padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
         };
         CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
 
@@ -3563,7 +3819,8 @@ namespace detail {
             return desired;
         }
 
-        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        void store(T                 desired,
+                   std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
             // first value becomes desired", all others become 0.
             for(auto& c : m_atomics) {
                 c.atomic.store(desired, order);
@@ -3585,7 +3842,7 @@ namespace detail {
         // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
         //    little overhead.
         Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
-            static Atomic<size_t> laneCounter;
+            static Atomic<size_t>       laneCounter;
             DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
                     laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
 
@@ -3594,16 +3851,13 @@ namespace detail {
     };
 #endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
-
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // this holds both parameters from the command line and runtime data for tests
     struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
@@ -3622,12 +3876,12 @@ namespace detail {
         std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
 
         // stuff for subcases
-        bool reachedLeaf;
-        std::vector<SubcaseSignature> subcaseStack;
-        std::vector<SubcaseSignature> nextSubcaseStack;
+        bool                                   reachedLeaf;
+        std::vector<SubcaseSignature>          subcaseStack;
+        std::vector<SubcaseSignature>          nextSubcaseStack;
         std::unordered_set<unsigned long long> fullyTraversedSubcases;
-        size_t currentSubcaseDepth;
-        Atomic<bool> shouldLogCurrentException;
+        size_t                                 currentSubcaseDepth;
+        Atomic<bool>                           shouldLogCurrentException;
 
         void resetRunData() {
             numTestCases                = 0;
@@ -3690,8 +3944,7 @@ namespace detail {
     // could be a race or that there wouldn't be a race even if using the context directly
     DOCTEST_THREAD_LOCAL bool g_no_colors;
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -3699,18 +3952,25 @@ namespace detail {
 
 namespace doctest {
 
-    using detail::g_cs;
+using detail::g_cs;
 
-    AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const StringContains& exception_string)
-        : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
-        m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
-        m_exception_string(exception_string) {
-    #if DOCTEST_MSVC
-        if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-    #endif // MSVC
-    }
+AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+                       const char* exception_type, const StringContains& exception_string)
+        : m_test_case(g_cs->currentTest)
+        , m_at(at)
+        , m_file(file)
+        , m_line(line)
+        , m_expr(expr)
+        , m_failed(true)
+        , m_threw(false)
+        , m_threw_as(false)
+        , m_exception_type(exception_type)
+        , m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
 
 } // namespace doctest
 
@@ -3718,21 +3978,18 @@ namespace doctest {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-        : m_at(at) {}
+    ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
+            : m_at(at) {}
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     void failed_out_of_a_testing_context(const AssertData& ad) {
         if(g_cs->ah)
@@ -3754,8 +4011,7 @@ namespace detail {
         return !failed;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -3787,8 +4043,7 @@ namespace {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
     using detail::g_cs;
 
@@ -3808,7 +4063,7 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
+        while(g_cs->subcaseStack.size()) {
             g_cs->subcaseStack.pop_back();
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
         }
@@ -3821,15 +4076,13 @@ namespace {
     }
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
         m_stream   = tlssPush();
@@ -3839,14 +4092,14 @@ namespace detail {
     }
 
     MessageBuilder::~MessageBuilder() {
-        if (!logged)
+        if(!logged)
             tlssPop();
     }
 
     bool MessageBuilder::log() {
-        if (!logged) {
+        if(!logged) {
             m_string = tlssPop();
-            logged = true;
+            logged   = true;
         }
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
@@ -3860,7 +4113,8 @@ namespace detail {
         }
 
         return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+               (g_cs->currentTest == nullptr ||
+                !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
     void MessageBuilder::react() {
@@ -3868,15 +4122,13 @@ namespace detail {
             throwException();
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     Result::Result(bool passed, const String& decomposition)
             : m_passed(passed)
@@ -3884,11 +4136,11 @@ namespace detail {
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
                                  const char* exception_type, const String& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+            : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const Contains& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+                                 const char* exception_type, const Contains& exception_string)
+            : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
     void ResultBuilder::setResult(const Result& res) {
         m_decomp = res.m_decomp;
@@ -3903,20 +4155,18 @@ namespace detail {
             throwException();
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
     using namespace detail;
 
     template <typename Ex>
     DOCTEST_NORETURN void throw_exception(Ex const& e) {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS
 #ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
         DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
 #else // DOCTEST_CONFIG_HANDLE_EXCEPTION
@@ -3934,9 +4184,7 @@ namespace {
     throw_exception(std::logic_error(                                                              \
             __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
 #endif // DOCTEST_INTERNAL_ERROR
-} // namespace
-
-} // namespace doctest
+}} // namespace doctest
 
 namespace doctest {
 
@@ -4029,9 +4277,9 @@ namespace {
         using namespace detail;
         static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
         static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
-    #ifdef DOCTEST_CONFIG_COLORS_ANSI
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
         if(g_no_colors ||
-            (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+           (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
             return;
 
         auto col = "";
@@ -4057,14 +4305,15 @@ namespace {
             DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // clang-format on
         s << "\033" << col;
-    #endif // DOCTEST_CONFIG_COLORS_ANSI
+#endif // DOCTEST_CONFIG_COLORS_ANSI
 
-    #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
         if(g_no_colors ||
-            (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+           (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
             return;
 
-        static struct ConsoleHelper {
+        static struct ConsoleHelper
+        {
             HANDLE stdoutHandle;
             WORD   origFgAttrs;
             WORD   origBgAttrs;
@@ -4074,13 +4323,13 @@ namespace {
                 CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
                 GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
                 origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                    BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+                                                       BACKGROUND_BLUE | BACKGROUND_INTENSITY);
                 origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                    FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+                                                       FOREGROUND_BLUE | FOREGROUND_INTENSITY);
             }
         } ch;
 
-    #define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
 
         // clang-format off
         switch (code) {
@@ -4100,16 +4349,18 @@ namespace {
             default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
         }
             // clang-format on
-    #endif // DOCTEST_CONFIG_COLORS_WINDOWS
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
     }
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
-}
+} // namespace
 #endif // DOCTEST_CONFIG_DISABLED
-}
+} // namespace doctest
 
 namespace doctest {
 
-    const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs); }
+const ContextOptions* getContextOptions() {
+    return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs);
+}
 
 } // namespace doctest
 
@@ -4121,57 +4372,51 @@ namespace doctest {
 
 namespace doctest {
 
-    void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
-        if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-            0) //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-                << Color::None;
+void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
+    if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
+       0) //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
 
-        if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-        } else if((rb.m_at & assertType::is_throws_as) &&
-                    (rb.m_at & assertType::is_throws_with)) { //!OCLINT
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string.c_str()
-                << "\", " << rb.m_exception_type << " ) " << Color::None;
-            if(rb.m_threw) {
-                if(!rb.m_failed) {
-                    s << "threw as expected!\n";
-                } else {
-                    s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
-                }
+    if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+        s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
+    } else if((rb.m_at & assertType::is_throws_as) &&
+              (rb.m_at & assertType::is_throws_with)) { //!OCLINT
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+          << rb.m_exception_string.c_str() << "\", " << rb.m_exception_type << " ) " << Color::None;
+        if(rb.m_threw) {
+            if(!rb.m_failed) {
+                s << "threw as expected!\n";
             } else {
-                s << "did NOT throw at all!\n";
+                s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
             }
-        } else if(rb.m_at &
-                    assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-                << rb.m_exception_type << " ) " << Color::None
-                << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                                "threw a DIFFERENT exception: ") :
-                                "did NOT throw at all!")
-                << Color::Cyan << rb.m_exception << "\n";
-        } else if(rb.m_at &
-                    assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string.c_str()
-                << "\" ) " << Color::None
-                << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                                "threw a DIFFERENT exception: ") :
-                                "did NOT throw at all!")
-                << Color::Cyan << rb.m_exception << "\n";
-        } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-                << rb.m_exception << "\n";
         } else {
-            s << (rb.m_threw ? "THREW exception: " :
-                                (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-            if(rb.m_threw)
-                s << rb.m_exception << "\n";
-            else
-                s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
+            s << "did NOT throw at all!\n";
         }
+    } else if(rb.m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
+          << rb.m_exception_type << " ) " << Color::None
+          << (rb.m_threw ?
+                      (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ") :
+                      "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if(rb.m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+          << rb.m_exception_string.c_str() << "\" ) " << Color::None
+          << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ") :
+                           "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception
+          << "\n";
+    } else {
+        s << (rb.m_threw ? "THREW exception: " :
+                           (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+        if(rb.m_threw)
+            s << rb.m_exception << "\n";
+        else
+            s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
     }
+}
 
 } // namespace doctest
 
@@ -4187,141 +4432,142 @@ namespace doctest {
 
 namespace doctest {
 
-    struct Whitespace
-    {
-        int nrSpaces;
-        explicit Whitespace(int nr)
-                : nrSpaces(nr) {}
-    };
+struct Whitespace
+{
+    int nrSpaces;
+    explicit Whitespace(int nr)
+            : nrSpaces(nr) {}
+};
 
-    std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-        if(ws.nrSpaces != 0)
-            out << std::setw(ws.nrSpaces) << ' ';
-        return out;
+std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
+    if(ws.nrSpaces != 0)
+        out << std::setw(ws.nrSpaces) << ' ';
+    return out;
+}
+
+struct ConsoleReporter : public IReporter
+{
+    std::ostream&                 s;
+    bool                          hasLoggedCurrentTestStart;
+    std::vector<SubcaseSignature> subcasesStack;
+    size_t                        currentSubcaseLevel;
+    DOCTEST_DECLARE_MUTEX(mutex)
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc;
+
+    ConsoleReporter(const ContextOptions& co)
+            : s(*co.cout)
+            , opt(co) {}
+
+    ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
+            : s(ostr)
+            , opt(co) {}
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
+    // =========================================================================================
+
+    void separator_to_stream() {
+        s << Color::Yellow
+          << "==============================================================================="
+             "\n";
     }
 
-    struct ConsoleReporter : public IReporter
-    {
-        std::ostream&                 s;
-        bool                          hasLoggedCurrentTestStart;
-        std::vector<SubcaseSignature> subcasesStack;
-        size_t                        currentSubcaseLevel;
-        DOCTEST_DECLARE_MUTEX(mutex)
+    const char* getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str) {
+        if(success)
+            return success_str;
+        return failureString(at);
+    }
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc;
+    Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
+        return success                    ? Color::BrightGreen :
+               (at & assertType::is_warn) ? Color::Yellow :
+                                            Color::Red;
+    }
 
-        ConsoleReporter(const ContextOptions& co)
-                : s(*co.cout)
-                , opt(co) {}
+    void successOrFailColoredStringToStream(bool success, assertType::Enum at,
+                                            const char* success_str = "SUCCESS") {
+        s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str)
+          << ": ";
+    }
 
-        ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-                : s(ostr)
-                , opt(co) {}
+    void log_contexts() {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto contexts = get_active_contexts();
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
-        // =========================================================================================
-
-        void separator_to_stream() {
-            s << Color::Yellow
-              << "==============================================================================="
-                 "\n";
-        }
-
-        const char* getSuccessOrFailString(bool success, assertType::Enum at,
-                                           const char* success_str) {
-            if(success)
-                return success_str;
-            return failureString(at);
-        }
-
-        Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
-            return success ? Color::BrightGreen :
-                             (at & assertType::is_warn) ? Color::Yellow : Color::Red;
-        }
-
-        void successOrFailColoredStringToStream(bool success, assertType::Enum at,
-                                                const char* success_str = "SUCCESS") {
-            s << getSuccessOrFailColor(success, at)
-              << getSuccessOrFailString(success, at, success_str) << ": ";
-        }
-
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto contexts = get_active_contexts();
-
-                s << Color::None << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
-                    s << (i == 0 ? "" : "          ");
-                    contexts[i]->stringify(&s);
-                    s << "\n";
-                }
+            s << Color::None << "  logged: ";
+            for(int i = 0; i < num_contexts; ++i) {
+                s << (i == 0 ? "" : "          ");
+                contexts[i]->stringify(&s);
+                s << "\n";
             }
-
-            s << "\n";
         }
 
-        // this was requested to be made virtual so users could override it
-        virtual void file_line_to_stream(const char* file, int line,
-                                        const char* tail = "") {
-            s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
-            << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-            << (opt.gnu_file_line ? ":" : "):") << tail;
+        s << "\n";
+    }
+
+    // this was requested to be made virtual so users could override it
+    virtual void file_line_to_stream(const char* file, int line, const char* tail = "") {
+        s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+          << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+          << (opt.gnu_file_line ? ":" : "):") << tail;
+    }
+
+    void logTestStart() {
+        if(hasLoggedCurrentTestStart)
+            return;
+
+        separator_to_stream();
+        file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
+        if(tc->m_description)
+            s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
+        if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+        if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+            s << Color::Yellow << "TEST CASE:  ";
+        s << Color::None << tc->m_name << "\n";
+
+        for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+            if(subcasesStack[i].m_name[0] != '\0')
+                s << "  " << subcasesStack[i].m_name << "\n";
         }
 
-        void logTestStart() {
-            if(hasLoggedCurrentTestStart)
-                return;
-
-            separator_to_stream();
-            file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
-            if(tc->m_description)
-                s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-            if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
-                s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-            if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-                s << Color::Yellow << "TEST CASE:  ";
-            s << Color::None << tc->m_name << "\n";
-
-            for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+        if(currentSubcaseLevel != subcasesStack.size()) {
+            s << Color::Yellow
+              << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n"
+              << Color::None;
+            for(size_t i = 0; i < subcasesStack.size(); ++i) {
                 if(subcasesStack[i].m_name[0] != '\0')
                     s << "  " << subcasesStack[i].m_name << "\n";
             }
-
-            if(currentSubcaseLevel != subcasesStack.size()) {
-                s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
-                for(size_t i = 0; i < subcasesStack.size(); ++i) {
-                    if(subcasesStack[i].m_name[0] != '\0')
-                        s << "  " << subcasesStack[i].m_name << "\n";
-                }
-            }
-
-            s << "\n";
-
-            hasLoggedCurrentTestStart = true;
         }
 
-        void printVersion() {
-            if(opt.no_version == false)
-                s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-                  << DOCTEST_VERSION_STR << "\"\n";
-        }
+        s << "\n";
 
-        void printIntro() {
-            if(opt.no_intro == false) {
-                printVersion();
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
-            }
-        }
+        hasLoggedCurrentTestStart = true;
+    }
 
-        void printHelp() {
-            int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+    void printVersion() {
+        if(opt.no_version == false)
+            s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
+              << DOCTEST_VERSION_STR << "\"\n";
+    }
+
+    void printIntro() {
+        if(opt.no_intro == false) {
             printVersion();
-            // clang-format off
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+        }
+    }
+
+    void printHelp() {
+        int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+        printVersion();
+        // clang-format off
             s << Color::Cyan << "[doctest]\n" << Color::None;
             s << Color::Cyan << "[doctest] " << Color::None;
             s << "boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n";
@@ -4431,231 +4677,240 @@ namespace doctest {
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
               << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
             // ================================================================================== << 79
-            // clang-format on
+        // clang-format on
 
-            s << Color::Cyan << "\n[doctest] " << Color::None;
-            s << "for more information visit the project documentation\n\n";
-        }
+        s << Color::Cyan << "\n[doctest] " << Color::None;
+        s << "for more information visit the project documentation\n\n";
+    }
 
-        void printRegisteredReporters() {
-            printVersion();
-            auto printReporters = [this] (const reporterMap& reporters, const char* type) {
-                if(reporters.size()) {
-                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
-                    for(auto& curr : reporters)
-                        s << "priority: " << std::setw(5) << curr.first.first
-                          << " name: " << curr.first.second << "\n";
-                }
-            };
-            printReporters(getListeners(), "listeners");
-            printReporters(getReporters(), "reporters");
-        }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData& in) override {
-            if(opt.version) {
-                printVersion();
-            } else if(opt.help) {
-                printHelp();
-            } else if(opt.list_reporters) {
-                printRegisteredReporters();
-            } else if(opt.count || opt.list_test_cases) {
-                if(opt.list_test_cases) {
-                    s << Color::Cyan << "[doctest] " << Color::None
-                      << "listing all test case names\n";
-                    separator_to_stream();
-                }
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i]->m_name << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-
-            } else if(opt.list_test_suites) {
-                s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
-                separator_to_stream();
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i]->m_test_suite << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "test suites with unskipped test cases passing the current filters: "
-                  << g_cs->numTestSuitesPassingFilters << "\n";
+    void printRegisteredReporters() {
+        printVersion();
+        auto printReporters = [this](const reporterMap& reporters, const char* type) {
+            if(reporters.size()) {
+                s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type
+                  << "\n";
+                for(auto& curr : reporters)
+                    s << "priority: " << std::setw(5) << curr.first.first
+                      << " name: " << curr.first.second << "\n";
             }
-        }
+        };
+        printReporters(getListeners(), "listeners");
+        printReporters(getReporters(), "reporters");
+    }
 
-        void test_run_start() override {
-            if(!opt.minimal)
-                printIntro();
-        }
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
 
-        void test_run_end(const TestRunStats& p) override {
-            if(opt.minimal && p.numTestCasesFailed == 0)
-                return;
+    void report_query(const QueryData& in) override {
+        if(opt.version) {
+            printVersion();
+        } else if(opt.help) {
+            printHelp();
+        } else if(opt.list_reporters) {
+            printRegisteredReporters();
+        } else if(opt.count || opt.list_test_cases) {
+            if(opt.list_test_cases) {
+                s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
+                separator_to_stream();
+            }
+
+            for(unsigned i = 0; i < in.num_data; ++i)
+                s << Color::None << in.data[i]->m_name << "\n";
 
             separator_to_stream();
-            s << std::dec;
 
-            auto totwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-            auto passwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-            auto failwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
-              << p.numTestCasesPassingFilters << " | "
-              << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                          Color::Green)
-              << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-              << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
-            if(opt.no_skipped_summary == false) {
-                const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
-                  << " skipped" << Color::None;
-            }
-            s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
-              << p.numAsserts << " | "
-              << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
-              << p.numAssertsFailed << " failed" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
-              << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
-              << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+              << "unskipped test cases passing the current filters: "
+              << g_cs->numTestCasesPassingFilters << "\n";
+
+        } else if(opt.list_test_suites) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
+            separator_to_stream();
+
+            for(unsigned i = 0; i < in.num_data; ++i)
+                s << Color::None << in.data[i]->m_test_suite << "\n";
+
+            separator_to_stream();
+
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "unskipped test cases passing the current filters: "
+              << g_cs->numTestCasesPassingFilters << "\n";
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "test suites with unskipped test cases passing the current filters: "
+              << g_cs->numTestSuitesPassingFilters << "\n";
         }
+    }
 
-        void test_case_start(const TestCaseData& in) override {
-            hasLoggedCurrentTestStart = false;
-            tc                        = &in;
-            subcasesStack.clear();
-            currentSubcaseLevel = 0;
+    void test_run_start() override {
+        if(!opt.minimal)
+            printIntro();
+    }
+
+    void test_run_end(const TestRunStats& p) override {
+        if(opt.minimal && p.numTestCasesFailed == 0)
+            return;
+
+        separator_to_stream();
+        s << std::dec;
+
+        auto totwidth = int(
+                std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters,
+                                                             static_cast<unsigned>(p.numAsserts))) +
+                                1)));
+        auto passwidth = int(
+                std::ceil(log10(static_cast<double>(std::max(
+                                        p.numTestCasesPassingFilters - p.numTestCasesFailed,
+                                        static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) +
+                                1)));
+        auto       failwidth      = int(std::ceil(
+                log10(static_cast<double>(std::max(p.numTestCasesFailed,
+                                                              static_cast<unsigned>(p.numAssertsFailed))) +
+                                 1)));
+        const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+        s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
+          << p.numTestCasesPassingFilters << " | "
+          << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green)
+          << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed
+          << " passed" << Color::None << " | "
+          << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
+          << p.numTestCasesFailed << " failed" << Color::None << " |";
+        if(opt.no_skipped_summary == false) {
+            const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
+            s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped << " skipped"
+              << Color::None;
         }
+        s << "\n";
+        s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
+          << p.numAsserts << " | "
+          << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+          << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+          << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
+          << p.numAssertsFailed << " failed" << Color::None << " |\n";
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
+          << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+    }
 
-        void test_case_reenter(const TestCaseData&) override {
-            subcasesStack.clear();
-        }
+    void test_case_start(const TestCaseData& in) override {
+        hasLoggedCurrentTestStart = false;
+        tc                        = &in;
+        subcasesStack.clear();
+        currentSubcaseLevel = 0;
+    }
 
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            if(tc->m_no_output)
-                return;
+    void test_case_reenter(const TestCaseData&) override { subcasesStack.clear(); }
 
-            // log the preamble of the test case only if there is something
-            // else to print - something other than that an assert has failed
-            if(opt.duration ||
-               (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
-                logTestStart();
+    void test_case_end(const CurrentTestCaseStats& st) override {
+        if(tc->m_no_output)
+            return;
 
-            if(opt.duration)
-                s << Color::None << std::setprecision(6) << std::fixed << st.seconds
-                  << " s: " << tc->m_name << "\n";
-
-            if(st.failure_flags & TestCaseFailureReason::Timeout)
-                s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-                  << std::fixed << tc->m_timeout << "!\n";
-
-            if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
-                s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
-                s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
-                s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-                s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
-                  << " times so marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
-                s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
-                  << " times as expected so marking it as not failed!\n";
-            }
-            if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
-                s << Color::Red << "Aborting - too many failed asserts!\n";
-            }
-            s << Color::None; // lgtm [cpp/useless-expression]
-        }
-
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-            if(tc->m_no_output)
-                return;
-
+        // log the preamble of the test case only if there is something
+        // else to print - something other than that an assert has failed
+        if(opt.duration ||
+           (st.failure_flags &&
+            st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
             logTestStart();
 
-            file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
-            successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
-                                                                   assertType::is_check);
-            s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
-              << Color::Cyan << e.error_string << "\n";
+        if(opt.duration)
+            s << Color::None << std::setprecision(6) << std::fixed << st.seconds
+              << " s: " << tc->m_name << "\n";
 
-            int num_stringified_contexts = get_num_stringified_contexts();
-            if(num_stringified_contexts) {
-                auto stringified_contexts = get_stringified_contexts();
-                s << Color::None << "  logged: ";
-                for(int i = num_stringified_contexts; i > 0; --i) {
-                    s << (i == num_stringified_contexts ? "" : "          ")
-                      << stringified_contexts[i - 1] << "\n";
-                }
+        if(st.failure_flags & TestCaseFailureReason::Timeout)
+            s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
+              << std::fixed << tc->m_timeout << "!\n";
+
+        if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+            s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
+        } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+            s << Color::Yellow << "Failed as expected so marking it as not failed\n";
+        } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+            s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
+        } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+            s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
+              << " times so marking it as failed!\n";
+        } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+            s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
+              << " times as expected so marking it as not failed!\n";
+        }
+        if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+            s << Color::Red << "Aborting - too many failed asserts!\n";
+        }
+        s << Color::None; // lgtm [cpp/useless-expression]
+    }
+
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+        if(tc->m_no_output)
+            return;
+
+        logTestStart();
+
+        file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
+        successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
+                                                               assertType::is_check);
+        s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
+          << Color::Cyan << e.error_string << "\n";
+
+        int num_stringified_contexts = get_num_stringified_contexts();
+        if(num_stringified_contexts) {
+            auto stringified_contexts = get_stringified_contexts();
+            s << Color::None << "  logged: ";
+            for(int i = num_stringified_contexts; i > 0; --i) {
+                s << (i == num_stringified_contexts ? "" : "          ")
+                  << stringified_contexts[i - 1] << "\n";
             }
-            s << "\n" << Color::None;
         }
+        s << "\n" << Color::None;
+    }
 
-        void subcase_start(const SubcaseSignature& subc) override {
-            subcasesStack.push_back(subc);
-            ++currentSubcaseLevel;
-            hasLoggedCurrentTestStart = false;
-        }
+    void subcase_start(const SubcaseSignature& subc) override {
+        subcasesStack.push_back(subc);
+        ++currentSubcaseLevel;
+        hasLoggedCurrentTestStart = false;
+    }
 
-        void subcase_end() override {
-            --currentSubcaseLevel;
-            hasLoggedCurrentTestStart = false;
-        }
+    void subcase_end() override {
+        --currentSubcaseLevel;
+        hasLoggedCurrentTestStart = false;
+    }
 
-        void log_assert(const AssertData& rb) override {
-            if((!rb.m_failed && !opt.success) || tc->m_no_output)
-                return;
+    void log_assert(const AssertData& rb) override {
+        if((!rb.m_failed && !opt.success) || tc->m_no_output)
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            logTestStart();
+        logTestStart();
 
-            file_line_to_stream(rb.m_file, rb.m_line, " ");
-            successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
+        file_line_to_stream(rb.m_file, rb.m_line, " ");
+        successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
 
-            fulltext_log_assert_to_stream(s, rb);
+        fulltext_log_assert_to_stream(s, rb);
 
-            log_contexts();
-        }
+        log_contexts();
+    }
 
-        void log_message(const MessageData& mb) override {
-            if(tc->m_no_output)
-                return;
+    void log_message(const MessageData& mb) override {
+        if(tc->m_no_output)
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            logTestStart();
+        logTestStart();
 
-            file_line_to_stream(mb.m_file, mb.m_line, " ");
-            s << getSuccessOrFailColor(false, mb.m_severity)
-              << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE") << ": ";
-            s << Color::None << mb.m_string << "\n";
-            log_contexts();
-        }
+        file_line_to_stream(mb.m_file, mb.m_line, " ");
+        s << getSuccessOrFailColor(false, mb.m_severity)
+          << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE")
+          << ": ";
+        s << Color::None << mb.m_string << "\n";
+        log_contexts();
+    }
 
-        void test_case_skipped(const TestCaseData&) override {}
-    };
+    void test_case_skipped(const TestCaseData&) override {}
+};
 
-    DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
+DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
 
 } // namespace doctest
 
@@ -4663,8 +4918,7 @@ namespace doctest {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) ::OutputDebugStringA(text)
@@ -4709,27 +4963,23 @@ namespace {
     DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     std::vector<const IExceptionTranslator*>& getExceptionTranslators();
-    String translateActiveException();
+    String                                    translateActiveException();
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // all the registered tests
     std::set<TestCase>& getRegisteredTests() {
@@ -4737,15 +4987,13 @@ namespace detail {
         return data;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
     // matching of a string against a wildcard mask (case sensitivity configurable) taken from
     // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
@@ -4787,25 +5035,22 @@ namespace {
 
     // checks if the name matches any of the filters (and can be configured what to do when empty)
     bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-        bool caseSensitive) {
-        if (filters.empty() && matchEmpty)
+                    bool caseSensitive) {
+        if(filters.empty() && matchEmpty)
             return true;
-        for (auto& curr : filters)
-            if (wildcmp(name, curr.c_str(), caseSensitive))
+        for(auto& curr : filters)
+            if(wildcmp(name, curr.c_str(), caseSensitive))
                 return true;
         return false;
     }
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
-namespace {
+namespace doctest { namespace detail { namespace {
 
     using namespace detail;
 
@@ -4822,7 +5067,7 @@ namespace {
 
     struct SignalDefs
     {
-        DWORD id;
+        DWORD       id;
         const char* name;
     };
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -4889,7 +5134,8 @@ namespace {
                 reportFatal("Terminate handler called");
                 if(isDebuggerActive() && !g_cs->no_breaks)
                     DOCTEST_BREAK_INTO_DEBUGGER();
-                std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
+                std::exit(
+                        EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
             });
 
             // SIGABRT is raised when:
@@ -4920,7 +5166,8 @@ namespace {
             // input (e.g. passing an invalid file descriptor). The default handling
             // for these assertions is to pop up a dialog and wait for user input.
             // Instead ask the CRT to dump such assertions to stderr non-interactively.
-            prev_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            prev_report_mode =
+                    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
             prev_report_file = _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
         }
 
@@ -4948,10 +5195,10 @@ namespace {
         static unsigned int prev_abort_behavior;
         static int          prev_report_mode;
         static _HFILE       prev_report_file;
-        static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
-        static std::terminate_handler original_terminate_handler;
-        static bool isSet;
-        static ULONG guaranteeSize;
+        static void(DOCTEST_CDECL* prev_sigabrt_handler)(int);
+        static std::terminate_handler       original_terminate_handler;
+        static bool                         isSet;
+        static ULONG                        guaranteeSize;
         static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
@@ -4960,11 +5207,11 @@ namespace {
     unsigned int FatalConditionHandler::prev_abort_behavior;
     int          FatalConditionHandler::prev_report_mode;
     _HFILE       FatalConditionHandler::prev_report_file;
-    void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
-    std::terminate_handler FatalConditionHandler::original_terminate_handler;
-    bool FatalConditionHandler::isSet = false;
-    ULONG FatalConditionHandler::guaranteeSize = 0;
-    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
+    void(DOCTEST_CDECL* FatalConditionHandler::prev_sigabrt_handler)(int);
+    std::terminate_handler       FatalConditionHandler::original_terminate_handler;
+    bool                         FatalConditionHandler::isSet         = false;
+    ULONG                        FatalConditionHandler::guaranteeSize = 0;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop   = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
@@ -5002,13 +5249,9 @@ namespace {
             raise(sig);
         }
 
-        static void allocateAltStackMem() {
-            altStackMem = new char[altStackSize];
-        }
+        static void allocateAltStackMem() { altStackMem = new char[altStackSize]; }
 
-        static void freeAltStackMem() {
-            delete[] altStackMem;
-        }
+        static void freeAltStackMem() { delete[] altStackMem; }
 
         FatalConditionHandler() {
             isSet = true;
@@ -5039,40 +5282,38 @@ namespace {
         }
     };
 
-    bool             FatalConditionHandler::isSet = false;
+    bool             FatalConditionHandler::isSet                                      = false;
     struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-    stack_t          FatalConditionHandler::oldSigStack = {};
+    stack_t          FatalConditionHandler::oldSigStack                                = {};
     size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
-    char*            FatalConditionHandler::altStackMem = nullptr;
+    char*            FatalConditionHandler::altStackMem  = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-} // namespace
-} // namespace detail
-} // namespace doctest
+}}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
 
-    bool is_running_in_test = false;
+bool is_running_in_test = false;
 
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    Context::Context(int, const char* const*) {}
-    Context::~Context() = default;
-    void Context::applyCommandLine(int, const char* const*) {}
-    void Context::addFilter(const char*, const char*) {}
-    void Context::clearFilters() {}
-    void Context::setOption(const char*, bool) {}
-    void Context::setOption(const char*, int) {}
-    void Context::setOption(const char*, const char*) {}
-    bool Context::shouldExit() { return false; }
-    void Context::setAsDefaultForAssertsOutOfTestCases() {}
-    void Context::setAssertHandler(detail::assert_handler) {}
-    void Context::setCout(std::ostream*) {}
-    int  Context::run() { return 0; }
+Context::Context(int, const char* const*) {}
+Context::~Context() = default;
+void Context::applyCommandLine(int, const char* const*) {}
+void Context::addFilter(const char*, const char*) {}
+void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
+void Context::setOption(const char*, int) {}
+void Context::setOption(const char*, const char*) {}
+bool Context::shouldExit() { return false; }
+void Context::setAsDefaultForAssertsOutOfTestCases() {}
+void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream*) {}
+int  Context::run() { return 0; }
 
 #else
 
@@ -5111,8 +5352,10 @@ namespace {
         // going from the end to the beginning and stopping on the first occurrence from the end
         for(int i = argc; i > 0; --i) {
             auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
+            auto temp  = std::strstr(argv[index], pattern);
+            if(temp &&
+               (value ||
+                strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
                 // eliminate matches in which the chars before the option are not '-'
                 bool noBadCharsFound = true;
                 auto curr            = argv[index];
@@ -5142,8 +5385,8 @@ namespace {
     }
 
     // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
+    bool parseOption(int argc, const char* const* argv, const char* pattern,
+                     String* value = nullptr, const String& defaultVal = String()) {
         if(value)
             *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -5166,7 +5409,7 @@ namespace {
         if(parseOption(argc, argv, pattern, &filtersString)) {
             // tokenize with "," as a separator, unless escaped with backslash
             std::ostringstream s;
-            auto flush = [&s, &res]() {
+            auto               flush = [&s, &res]() {
                 auto string = s.str();
                 if(string.size() > 0) {
                     res.push_back(string.c_str());
@@ -5174,9 +5417,9 @@ namespace {
                 s.str("");
             };
 
-            bool seenBackslash = false;
-            const char* current = filtersString.c_str();
-            const char* end = current + strlen(current);
+            bool        seenBackslash = false;
+            const char* current       = filtersString.c_str();
+            const char* end           = current + strlen(current);
             while(current != end) {
                 char character = *current++;
                 if(seenBackslash) {
@@ -5222,22 +5465,22 @@ namespace {
             // integer
             // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
             int theInt = std::atoi(parsedValue.c_str());
-            if (theInt != 0) {
+            if(theInt != 0) {
                 res = theInt; //!OCLINT parameter reassignment
                 return true;
             }
         } else {
             // boolean
-            const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
-            const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
+            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
 
             // if the value matches any of the positive/negative possibilities
-            for (unsigned i = 0; i < 4; i++) {
-                if (parsedValue.compare(positive[i], true) == 0) {
+            for(unsigned i = 0; i < 4; i++) {
+                if(parsedValue.compare(positive[i], true) == 0) {
                     res = 1; //!OCLINT parameter reassignment
                     return true;
                 }
-                if (parsedValue.compare(negative[i], true) == 0) {
+                if(parsedValue.compare(negative[i], true) == 0) {
                     res = 0; //!OCLINT parameter reassignment
                     return true;
                 }
@@ -5248,30 +5491,30 @@ namespace {
 
 } // namespace
 
-    Context::Context(int argc, const char* const* argv)
-            : p(new detail::ContextState) {
-        parseArgs(argc, argv, true);
-        if(argc)
-            p->binary_name = argv[0];
-    }
+Context::Context(int argc, const char* const* argv)
+        : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+    if(argc)
+        p->binary_name = argv[0];
+}
 
-    Context::~Context() {
-        if(g_cs == p)
-            g_cs = nullptr;
-        delete p;
-    }
+Context::~Context() {
+    if(g_cs == p)
+        g_cs = nullptr;
+    delete p;
+}
 
-    void Context::applyCommandLine(int argc, const char* const* argv) {
-        parseArgs(argc, argv);
-        if(argc)
-            p->binary_name = argv[0];
-    }
+void Context::applyCommandLine(int argc, const char* const* argv) {
+    parseArgs(argc, argv);
+    if(argc)
+        p->binary_name = argv[0];
+}
 
-    // parses args
-    void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-        using namespace detail;
+// parses args
+void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
+    using namespace detail;
 
-        // clang-format off
+    // clang-format off
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
@@ -5290,35 +5533,35 @@ namespace {
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
-        // clang-format on
+    // clang-format on
 
-        int    intRes = 0;
-        String strRes;
+    int    intRes = 0;
+    String strRes;
 
-    #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-            p->var = static_cast<bool>(intRes);                                                        \
-        else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
-                parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
-            p->var = true;                                                                             \
-        else if(withDefaults)                                                                          \
-        p->var = default
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
+    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
+       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
+        p->var = static_cast<bool>(intRes);                                                        \
+    else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
+            parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
+        p->var = true;                                                                             \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-    #define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
-            p->var = intRes;                                                                           \
-        else if(withDefaults)                                                                          \
-        p->var = default
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
+    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
+       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
+        p->var = intRes;                                                                           \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-    #define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-        if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
-           parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
-           withDefaults)                                                                               \
-        p->var = strRes
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
+    if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
+       parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
+       withDefaults)                                                                               \
+    p->var = strRes
 
-        // clang-format off
+    // clang-format off
         DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
         DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
         DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
@@ -5351,371 +5594,371 @@ namespace {
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
-        // clang-format on
+    // clang-format on
 
-        if(withDefaults) {
-            p->help             = false;
-            p->version          = false;
-            p->count            = false;
-            p->list_test_cases  = false;
-            p->list_test_suites = false;
-            p->list_reporters   = false;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
-            p->help = true;
-            p->exit = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
-            p->version = true;
-            p->exit    = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
-            p->count = true;
-            p->exit  = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
-            p->list_test_cases = true;
-            p->exit            = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
-            p->list_test_suites = true;
-            p->exit             = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
-            p->list_reporters = true;
-            p->exit           = true;
-        }
+    if(withDefaults) {
+        p->help             = false;
+        p->version          = false;
+        p->count            = false;
+        p->list_test_cases  = false;
+        p->list_test_suites = false;
+        p->list_reporters   = false;
     }
-
-    // allows the user to add procedurally to the filters from the command line
-    void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
-
-    // allows the user to clear all filters from the command line
-    void Context::clearFilters() {
-        for(auto& curr : p->filters)
-            curr.clear();
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+        p->help = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the bool options from the command line
-    void Context::setOption(const char* option, bool value) {
-        setOption(option, value ? "true" : "false");
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+        p->version = true;
+        p->exit    = true;
     }
-
-    // allows the user to override procedurally the int options from the command line
-    void Context::setOption(const char* option, int value) {
-        setOption(option, toString(value).c_str());
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+        p->count = true;
+        p->exit  = true;
     }
-
-    // allows the user to override procedurally the string options from the command line
-    void Context::setOption(const char* option, const char* value) {
-        auto argv   = String("-") + option + "=" + value;
-        auto lvalue = argv.c_str();
-        parseArgs(1, &lvalue);
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+        p->list_test_cases = true;
+        p->exit            = true;
     }
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+        p->list_test_suites = true;
+        p->exit             = true;
+    }
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+        p->list_reporters = true;
+        p->exit           = true;
+    }
+}
 
-    // users should query this in their main() and exit the program if true
-    bool Context::shouldExit() { return p->exit; }
+// allows the user to add procedurally to the filters from the command line
+void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
 
-    void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
+// allows the user to clear all filters from the command line
+void Context::clearFilters() {
+    for(auto& curr : p->filters)
+        curr.clear();
+}
 
-    void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
 
-    void Context::setCout(std::ostream* out) { p->cout = out; }
+// allows the user to override procedurally the int options from the command line
+void Context::setOption(const char* option, int value) {
+    setOption(option, toString(value).c_str());
+}
 
-    static class DiscardOStream : public std::ostream
+// allows the user to override procedurally the string options from the command line
+void Context::setOption(const char* option, const char* value) {
+    auto argv   = String("-") + option + "=" + value;
+    auto lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
+}
+
+// users should query this in their main() and exit the program if true
+bool Context::shouldExit() { return p->exit; }
+
+void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
+
+void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+    class : public std::streambuf
     {
     private:
-        class : public std::streambuf
-        {
-        private:
-            // allowing some buffering decreases the amount of calls to overflow
-            char buf[1024];
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
 
-        protected:
-            std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+    protected:
+        std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
 
-            int_type overflow(int_type ch) override {
-                setp(std::begin(buf), std::end(buf));
-                return traits_type::not_eof(ch);
-            }
-        } discardBuf;
-
-    public:
-        DiscardOStream()
-                : std::ostream(&discardBuf) {}
-    } discardOut;
-
-    // the main function that does all the filtering and test running
-    int Context::run() {
-        using namespace detail;
-
-        // save the old context state in case such was setup - for using asserts out of a testing context
-        auto old_cs = g_cs;
-        // this is the current contest
-        g_cs               = p;
-        is_running_in_test = true;
-
-        g_no_colors = p->no_colors;
-        p->resetRunData();
-
-        std::fstream fstr;
-        if(p->cout == nullptr) {
-            if(p->quiet) {
-                p->cout = &discardOut;
-            } else if(p->out.size()) {
-                // to a file if specified
-                fstr.open(p->out.c_str(), std::fstream::out);
-                p->cout = &fstr;
-            } else {
-    #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                // stdout by default
-                p->cout = &std::cout;
-    #else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                return EXIT_FAILURE;
-    #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-            }
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
         }
+    } discardBuf;
 
-        FatalConditionHandler::allocateAltStackMem();
+public:
+    DiscardOStream()
+            : std::ostream(&discardBuf) {}
+} discardOut;
 
-        auto cleanup_and_return = [&]() {
-            FatalConditionHandler::freeAltStackMem();
+// the main function that does all the filtering and test running
+int Context::run() {
+    using namespace detail;
 
-            if(fstr.is_open())
-                fstr.close();
+    // save the old context state in case such was setup - for using asserts out of a testing context
+    auto old_cs = g_cs;
+    // this is the current contest
+    g_cs               = p;
+    is_running_in_test = true;
 
-            // restore context
-            g_cs               = old_cs;
-            is_running_in_test = false;
+    g_no_colors = p->no_colors;
+    p->resetRunData();
 
-            // we have to free the reporters which were allocated when the run started
-            for(auto& curr : p->reporters_currently_used)
-                delete curr;
-            p->reporters_currently_used.clear();
-
-            if(p->numTestCasesFailed && !p->no_exitcode)
-                return EXIT_FAILURE;
-            return EXIT_SUCCESS;
-        };
-
-        // setup default reporter if none is given through the command line
-        if(p->filters[8].empty())
-            p->filters[8].push_back("console");
-
-        // check to see if any of the registered reporters has been selected
-        for(auto& curr : getReporters()) {
-            if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-                p->reporters_currently_used.push_back(curr.second(*g_cs));
-        }
-
-        // TODO: check if there is nothing in reporters_currently_used
-
-        // prepend all listeners
-        for(auto& curr : getListeners())
-            p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
-
-    #ifdef DOCTEST_PLATFORM_WINDOWS
-        if(isDebuggerActive() && p->no_debug_output == false)
-            p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
-    #endif // DOCTEST_PLATFORM_WINDOWS
-
-        // handle version, help and no_run
-        if(p->no_run || p->version || p->help || p->list_reporters) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
-
-            return cleanup_and_return();
-        }
-
-        std::vector<const TestCase*> testArray;
-        for(auto& curr : getRegisteredTests())
-            testArray.push_back(&curr);
-        p->numTestCases = testArray.size();
-
-        // sort the collected records
-        if(!testArray.empty()) {
-            if(p->order_by.compare("file", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
-            } else if(p->order_by.compare("suite", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
-            } else if(p->order_by.compare("name", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
-            } else if(p->order_by.compare("rand", true) == 0) {
-                std::srand(p->rand_seed);
-
-                // random_shuffle implementation
-                const auto first = &testArray[0];
-                for(size_t i = testArray.size() - 1; i > 0; --i) {
-                    int idxToSwap = std::rand() % (i + 1);
-
-                    const auto temp = first[i];
-
-                    first[i]         = first[idxToSwap];
-                    first[idxToSwap] = temp;
-                }
-            } else if(p->order_by.compare("none", true) == 0) {
-                // means no sorting - beneficial for death tests which call into the executable
-                // with a specific test case in mind - we don't want to slow down the startup times
-            }
-        }
-
-        std::set<String> testSuitesPassingFilt;
-
-        bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
-        std::vector<const TestCaseData*> queryResults;
-
-        if(!query_mode)
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
-
-        // invoke the registered functions if they match the filter criteria (or just count them)
-        for(auto& curr : testArray) {
-            const auto& tc = *curr;
-
-            bool skip_me = false;
-            if(tc.m_skip && !p->no_skip)
-                skip_me = true;
-
-            if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-                skip_me = true;
-
-            if(!skip_me)
-                p->numTestCasesPassingFilters++;
-
-            // skip the test if it is not in the execution range
-            if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-               (p->first > p->numTestCasesPassingFilters))
-                skip_me = true;
-
-            if(skip_me) {
-                if(!query_mode)
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
-                continue;
-            }
-
-            // do not execute the test if we are to only count the number of filter passing tests
-            if(p->count)
-                continue;
-
-            // print the name of the test and don't execute it
-            if(p->list_test_cases) {
-                queryResults.push_back(&tc);
-                continue;
-            }
-
-            // print the name of the test suite if not done already and don't execute it
-            if(p->list_test_suites) {
-                if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                    queryResults.push_back(&tc);
-                    testSuitesPassingFilt.insert(tc.m_test_suite);
-                    p->numTestSuitesPassingFilters++;
-                }
-                continue;
-            }
-
-            // execute the test if it passes all the filtering
-            {
-                p->currentTest = &tc;
-
-                p->failure_flags = TestCaseFailureReason::None;
-                p->seconds       = 0;
-
-                // reset atomic counters
-                p->numAssertsFailedCurrentTest_atomic = 0;
-                p->numAssertsCurrentTest_atomic       = 0;
-
-                p->fullyTraversedSubcases.clear();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
-
-                p->timer.start();
-
-                bool run_test = true;
-
-                do {
-                    // reset some of the fields for subcases (except for the set of fully passed ones)
-                    p->reachedLeaf = false;
-                    // May not be empty if previous subcase exited via exception.
-                    p->subcaseStack.clear();
-                    p->currentSubcaseDepth = 0;
-
-                    p->shouldLogCurrentException = true;
-
-                    // reset stuff for logging with INFO()
-                    p->stringifiedContexts.clear();
-
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    try {
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
-                        FatalConditionHandler fatalConditionHandler; // Handle signals
-                        // execute the test
-                        tc.m_test();
-                        fatalConditionHandler.reset();
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    } catch(const TestFailureException&) {
-                        p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                    } catch(...) {
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
-                                                          {translateActiveException(), false});
-                        p->failure_flags |= TestCaseFailureReason::Exception;
-                    }
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                    // exit this loop if enough assertions have failed - even if there are more subcases
-                    if(p->abort_after > 0 &&
-                       p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                        run_test = false;
-                        p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
-                    }
-
-                    if(!p->nextSubcaseStack.empty() && run_test)
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
-                    if(p->nextSubcaseStack.empty())
-                        run_test = false;
-                } while(run_test);
-
-                p->finalizeTestCaseData();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-                p->currentTest = nullptr;
-
-                // stop executing tests if enough assertions have failed
-                if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                    break;
-            }
-        }
-
-        if(!query_mode) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    std::fstream fstr;
+    if(p->cout == nullptr) {
+        if(p->quiet) {
+            p->cout = &discardOut;
+        } else if(p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
         } else {
-            QueryData qdata;
-            qdata.run_stats = g_cs;
-            qdata.data      = queryResults.data();
-            qdata.num_data  = unsigned(queryResults.size());
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            // stdout by default
+            p->cout = &std::cout;
+#else  // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         }
+    }
+
+    FatalConditionHandler::allocateAltStackMem();
+
+    auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
+        if(fstr.is_open())
+            fstr.close();
+
+        // restore context
+        g_cs               = old_cs;
+        is_running_in_test = false;
+
+        // we have to free the reporters which were allocated when the run started
+        for(auto& curr : p->reporters_currently_used)
+            delete curr;
+        p->reporters_currently_used.clear();
+
+        if(p->numTestCasesFailed && !p->no_exitcode)
+            return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    };
+
+    // setup default reporter if none is given through the command line
+    if(p->filters[8].empty())
+        p->filters[8].push_back("console");
+
+    // check to see if any of the registered reporters has been selected
+    for(auto& curr : getReporters()) {
+        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+            p->reporters_currently_used.push_back(curr.second(*g_cs));
+    }
+
+    // TODO: check if there is nothing in reporters_currently_used
+
+    // prepend all listeners
+    for(auto& curr : getListeners())
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if(isDebuggerActive() && p->no_debug_output == false)
+        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    // handle version, help and no_run
+    if(p->no_run || p->version || p->help || p->list_reporters) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
 
         return cleanup_and_return();
     }
+
+    std::vector<const TestCase*> testArray;
+    for(auto& curr : getRegisteredTests())
+        testArray.push_back(&curr);
+    p->numTestCases = testArray.size();
+
+    // sort the collected records
+    if(!testArray.empty()) {
+        if(p->order_by.compare("file", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+        } else if(p->order_by.compare("suite", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+        } else if(p->order_by.compare("name", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+        } else if(p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const auto first = &testArray[0];
+            for(size_t i = testArray.size() - 1; i > 0; --i) {
+                int idxToSwap = std::rand() % (i + 1);
+
+                const auto temp = first[i];
+
+                first[i]         = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        } else if(p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
+        }
+    }
+
+    std::set<String> testSuitesPassingFilt;
+
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData*> queryResults;
+
+    if(!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for(auto& curr : testArray) {
+        const auto& tc = *curr;
+
+        bool skip_me = false;
+        if(tc.m_skip && !p->no_skip)
+            skip_me = true;
+
+        if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+            skip_me = true;
+        if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+            skip_me = true;
+        if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+
+        if(!skip_me)
+            p->numTestCasesPassingFilters++;
+
+        // skip the test if it is not in the execution range
+        if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+           (p->first > p->numTestCasesPassingFilters))
+            skip_me = true;
+
+        if(skip_me) {
+            if(!query_mode)
+                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+            continue;
+        }
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if(p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if(p->list_test_cases) {
+            queryResults.push_back(&tc);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if(p->list_test_suites) {
+            if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+                queryResults.push_back(&tc);
+                testSuitesPassingFilt.insert(tc.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &tc;
+
+            p->failure_flags = TestCaseFailureReason::None;
+            p->seconds       = 0;
+
+            // reset atomic counters
+            p->numAssertsFailedCurrentTest_atomic = 0;
+            p->numAssertsCurrentTest_atomic       = 0;
+
+            p->fullyTraversedSubcases.clear();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+            p->timer.start();
+
+            bool run_test = true;
+
+            do {
+                // reset some of the fields for subcases (except for the set of fully passed ones)
+                p->reachedLeaf = false;
+                // May not be empty if previous subcase exited via exception.
+                p->subcaseStack.clear();
+                p->currentSubcaseDepth = 0;
+
+                p->shouldLogCurrentException = true;
+
+                // reset stuff for logging with INFO()
+                p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+       // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
+                    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
+                    FatalConditionHandler fatalConditionHandler;  // Handle signals
+                    // execute the test
+                    tc.m_test();
+                    fatalConditionHandler.reset();
+                    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch(const TestFailureException&) {
+                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
+                } catch(...) {
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
+                                                      {translateActiveException(), false});
+                    p->failure_flags |= TestCaseFailureReason::Exception;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                // exit this loop if enough assertions have failed - even if there are more subcases
+                if(p->abort_after > 0 &&
+                   p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+                    run_test = false;
+                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+                }
+
+                if(!p->nextSubcaseStack.empty() && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if(p->nextSubcaseStack.empty())
+                    run_test = false;
+            } while(run_test);
+
+            p->finalizeTestCaseData();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+            p->currentTest = nullptr;
+
+            // stop executing tests if enough assertions have failed
+            if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                break;
+        }
+    }
+
+    if(!query_mode) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    } else {
+        QueryData qdata;
+        qdata.run_stats = g_cs;
+        qdata.data      = queryResults.data();
+        qdata.num_data  = unsigned(queryResults.size());
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+    }
+
+    return cleanup_and_return();
+}
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5723,11 +5966,10 @@ namespace {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
-    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
-}
-} // namespace doctest
+namespace doctest { namespace detail {
+    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*>
+                                g_infoContexts; // for logging with INFO()
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5739,12 +5981,10 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 namespace detail {
     DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+    ContextScopeBase::ContextScopeBase() { g_infoContexts.push_back(this); }
 
     ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
-        if (other.need_to_destroy) {
+        if(other.need_to_destroy) {
             other.destroy();
         }
         other.need_to_destroy = false;
@@ -5758,11 +5998,12 @@ namespace detail {
     // ContextScope has been destroyed (base class destructors run after derived class destructors).
     // Instead, ContextScope calls this method directly from its destructor.
     void ContextScopeBase::destroy() {
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&          \
+        (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
         if(std::uncaught_exceptions() > 0) {
-    #else
+#else
         if(std::uncaught_exception()) {
-    #endif
+#endif
             std::ostringstream s;
             this->stringify(&s);
             g_cs->stringifiedContexts.push_back(s.str().c_str());
@@ -5779,23 +6020,25 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 #ifdef DOCTEST_IS_DEBUGGER_ACTIVE
     bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
 #else // DOCTEST_IS_DEBUGGER_ACTIVE
 #ifdef DOCTEST_PLATFORM_LINUX
-    class ErrnoGuard {
+    class ErrnoGuard
+    {
     public:
-        ErrnoGuard() : m_oldErrno(errno) {}
+        ErrnoGuard()
+                : m_oldErrno(errno) {}
         ~ErrnoGuard() { errno = m_oldErrno; }
+
     private:
         int m_oldErrno;
     };
     // See the comments in Catch2 for the reasoning behind this implementation:
     // https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
     bool isDebuggerActive() {
-        ErrnoGuard guard;
+        ErrnoGuard    guard;
         std::ifstream in("/proc/self/status");
         for(std::string line; std::getline(in, line);) {
             static const int PREFIX_LEN = 11;
@@ -5838,8 +6081,7 @@ namespace detail {
     bool isDebuggerActive() { return false; }
 #endif // Platform
 #endif // DOCTEST_IS_DEBUGGER_ACTIVE
-} // detail
-} // doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5864,20 +6106,17 @@ const char* skipPathFromFilename(const char* file) {
             return forward + 1;
         }
     } else {
-        const auto prefixes = getContextOptions()->strip_file_prefixes;
-        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        const auto        prefixes      = getContextOptions()->strip_file_prefixes;
+        const char        separator     = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
         String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
+        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos) {
             const auto prefix_start = pos;
             pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
 
             const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
+            if(prefix_size > longest_match) {
                 // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
+                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size)) {
                     longest_match = prefix_size;
                 }
             }
@@ -5899,16 +6138,14 @@ namespace {
     using namespace detail;
 
     DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(unsigned long long a, unsigned long long b) {
-        return (a << 5) + b;
-    }
+    unsigned long long hash(unsigned long long a, unsigned long long b) { return (a << 5) + b; }
 
     // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
     DOCTEST_NO_SANITIZE_INTEGER
     unsigned long long hash(const char* str) {
         unsigned long long hash = 5381;
-        char c;
-        while ((c = *str++))
+        char               c;
+        while((c = *str++))
             hash = ((hash << 5) + hash) + c; // hash * 33 + c
         return hash;
     }
@@ -5919,8 +6156,8 @@ namespace {
 
     unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
         unsigned long long running = 0;
-        auto end = sigs.begin() + count;
-        for (auto it = sigs.begin(); it != end; it++) {
+        auto               end     = sigs.begin() + count;
+        for(auto it = sigs.begin(); it != end; it++) {
             running = hash(running, hash(*it));
         }
         return running;
@@ -5928,13 +6165,12 @@ namespace {
 
     unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
         unsigned long long running = 0;
-        for (const SubcaseSignature& sig : sigs) {
+        for(const SubcaseSignature& sig : sigs) {
             running = hash(running, hash(sig));
         }
         return running;
     }
 } // namespace
-
 
 namespace detail {
 
@@ -5946,7 +6182,8 @@ namespace detail {
     bool ResultBuilder::log() {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+        } else if((m_at & assertType::is_throws_as) &&
+                  (m_at & assertType::is_throws_with)) { //!OCLINT
             m_failed = !m_threw_as || !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
@@ -5970,7 +6207,8 @@ namespace detail {
         }
 
         return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+               (g_cs->currentTest == nullptr ||
+                !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
 } // namespace detail
@@ -5979,8 +6217,7 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // clang-format off
 
@@ -6082,8 +6319,7 @@ namespace detail {
 
     // clang-format on
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -6091,242 +6327,242 @@ namespace detail {
 
 namespace doctest {
 
-    struct XmlReporter : public IReporter
-    {
-        XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
+struct XmlReporter : public IReporter
+{
+    XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc = nullptr;
 
-        XmlReporter(const ContextOptions& co)
-                : xml(*co.cout)
-                , opt(co) {}
+    XmlReporter(const ContextOptions& co)
+            : xml(*co.cout)
+            , opt(co) {}
 
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto              contexts = get_active_contexts();
-                std::stringstream ss;
-                for(int i = 0; i < num_contexts; ++i) {
-                    contexts[i]->stringify(&ss);
-                    xml.scopedElement("Info").writeText(ss.str());
-                    ss.str("");
-                }
+    void log_contexts() {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto              contexts = get_active_contexts();
+            std::stringstream ss;
+            for(int i = 0; i < num_contexts; ++i) {
+                contexts[i]->stringify(&ss);
+                xml.scopedElement("Info").writeText(ss.str());
+                ss.str("");
             }
         }
+    }
 
-        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+    unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
 
-        void test_case_start_impl(const TestCaseData& in) {
-            bool open_ts_tag = false;
-            if(tc != nullptr) { // we have already opened a test suite
-                if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
-                    xml.endElement();
-                    open_ts_tag = true;
-                }
+    void test_case_start_impl(const TestCaseData& in) {
+        bool open_ts_tag = false;
+        if(tc != nullptr) { // we have already opened a test suite
+            if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+                xml.endElement();
+                open_ts_tag = true;
             }
-            else {
-                open_ts_tag = true; // first test case ==> first test suite
-            }
-
-            if(open_ts_tag) {
-                xml.startElement("TestSuite");
-                xml.writeAttribute("name", in.m_test_suite);
-            }
-
-            tc = &in;
-            xml.startElement("TestCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
-                    .writeAttribute("line", line(in.m_line))
-                    .writeAttribute("description", in.m_description);
-
-            if(Approx(in.m_timeout) != 0)
-                xml.writeAttribute("timeout", in.m_timeout);
-            if(in.m_may_fail)
-                xml.writeAttribute("may_fail", true);
-            if(in.m_should_fail)
-                xml.writeAttribute("should_fail", true);
+        } else {
+            open_ts_tag = true; // first test case ==> first test suite
         }
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
+        if(open_ts_tag) {
+            xml.startElement("TestSuite");
+            xml.writeAttribute("name", in.m_test_suite);
+        }
 
-        void report_query(const QueryData& in) override {
-            test_run_start();
-            if(opt.list_reporters) {
-                for(auto& curr : getListeners())
-                    xml.scopedElement("Listener")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-                for(auto& curr : getReporters())
-                    xml.scopedElement("Reporter")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-            } else if(opt.count || opt.list_test_cases) {
-                for(unsigned i = 0; i < in.num_data; ++i) {
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+        tc = &in;
+        xml.startElement("TestCase")
+                .writeAttribute("name", in.m_name)
+                .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+                .writeAttribute("line", line(in.m_line))
+                .writeAttribute("description", in.m_description);
+
+        if(Approx(in.m_timeout) != 0)
+            xml.writeAttribute("timeout", in.m_timeout);
+        if(in.m_may_fail)
+            xml.writeAttribute("may_fail", true);
+        if(in.m_should_fail)
+            xml.writeAttribute("should_fail", true);
+    }
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData& in) override {
+        test_run_start();
+        if(opt.list_reporters) {
+            for(auto& curr : getListeners())
+                xml.scopedElement("Listener")
+                        .writeAttribute("priority", curr.first.first)
+                        .writeAttribute("name", curr.first.second);
+            for(auto& curr : getReporters())
+                xml.scopedElement("Reporter")
+                        .writeAttribute("priority", curr.first.first)
+                        .writeAttribute("name", curr.first.second);
+        } else if(opt.count || opt.list_test_cases) {
+            for(unsigned i = 0; i < in.num_data; ++i) {
+                xml.scopedElement("TestCase")
+                        .writeAttribute("name", in.data[i]->m_name)
                         .writeAttribute("testsuite", in.data[i]->m_test_suite)
-                        .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
+                        .writeAttribute("filename",
+                                        skipPathFromFilename(in.data[i]->m_file.c_str()))
                         .writeAttribute("line", line(in.data[i]->m_line))
                         .writeAttribute("skipped", in.data[i]->m_skip);
-                }
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-            } else if(opt.list_test_suites) {
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-                xml.scopedElement("OverallResultsTestSuites")
-                        .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
             }
-            xml.endElement();
+            xml.scopedElement("OverallResultsTestCases")
+                    .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+        } else if(opt.list_test_suites) {
+            for(unsigned i = 0; i < in.num_data; ++i)
+                xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
+            xml.scopedElement("OverallResultsTestCases")
+                    .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+            xml.scopedElement("OverallResultsTestSuites")
+                    .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
         }
+        xml.endElement();
+    }
 
-        void test_run_start() override {
-            xml.writeDeclaration();
+    void test_run_start() override {
+        xml.writeDeclaration();
 
-            // remove .exe extension - mainly to have the same output on UNIX and Windows
-            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+        // remove .exe extension - mainly to have the same output on UNIX and Windows
+        std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-            if(binary_name.rfind(".exe") != std::string::npos)
-                binary_name = binary_name.substr(0, binary_name.length() - 4);
+        if(binary_name.rfind(".exe") != std::string::npos)
+            binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-            xml.startElement("doctest").writeAttribute("binary", binary_name);
-            if(opt.no_version == false)
-                xml.writeAttribute("version", DOCTEST_VERSION_STR);
+        xml.startElement("doctest").writeAttribute("binary", binary_name);
+        if(opt.no_version == false)
+            xml.writeAttribute("version", DOCTEST_VERSION_STR);
 
-            // only the consequential ones (TODO: filters)
-            xml.scopedElement("Options")
-                    .writeAttribute("order_by", opt.order_by.c_str())
-                    .writeAttribute("rand_seed", opt.rand_seed)
-                    .writeAttribute("first", opt.first)
-                    .writeAttribute("last", opt.last)
-                    .writeAttribute("abort_after", opt.abort_after)
-                    .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
-                    .writeAttribute("case_sensitive", opt.case_sensitive)
-                    .writeAttribute("no_throw", opt.no_throw)
-                    .writeAttribute("no_skip", opt.no_skip);
-        }
+        // only the consequential ones (TODO: filters)
+        xml.scopedElement("Options")
+                .writeAttribute("order_by", opt.order_by.c_str())
+                .writeAttribute("rand_seed", opt.rand_seed)
+                .writeAttribute("first", opt.first)
+                .writeAttribute("last", opt.last)
+                .writeAttribute("abort_after", opt.abort_after)
+                .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+                .writeAttribute("case_sensitive", opt.case_sensitive)
+                .writeAttribute("no_throw", opt.no_throw)
+                .writeAttribute("no_skip", opt.no_skip);
+    }
 
-        void test_run_end(const TestRunStats& p) override {
-            if(tc) // the TestSuite tag - only if there has been at least 1 test case
-                xml.endElement();
-
-            xml.scopedElement("OverallResultsAsserts")
-                    .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
-                    .writeAttribute("failures", p.numAssertsFailed);
-
-            xml.startElement("OverallResultsTestCases")
-                    .writeAttribute("successes",
-                                    p.numTestCasesPassingFilters - p.numTestCasesFailed)
-                    .writeAttribute("failures", p.numTestCasesFailed);
-            if(opt.no_skipped_summary == false)
-                xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+    void test_run_end(const TestRunStats& p) override {
+        if(tc) // the TestSuite tag - only if there has been at least 1 test case
             xml.endElement();
 
-            xml.endElement();
-        }
+        xml.scopedElement("OverallResultsAsserts")
+                .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+                .writeAttribute("failures", p.numAssertsFailed);
 
-        void test_case_start(const TestCaseData& in) override {
+        xml.startElement("OverallResultsTestCases")
+                .writeAttribute("successes", p.numTestCasesPassingFilters - p.numTestCasesFailed)
+                .writeAttribute("failures", p.numTestCasesFailed);
+        if(opt.no_skipped_summary == false)
+            xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+        xml.endElement();
+
+        xml.endElement();
+    }
+
+    void test_case_start(const TestCaseData& in) override {
+        test_case_start_impl(in);
+        xml.ensureTagClosed();
+    }
+
+    void test_case_reenter(const TestCaseData&) override {}
+
+    void test_case_end(const CurrentTestCaseStats& st) override {
+        xml.startElement("OverallResultsAsserts")
+                .writeAttribute("successes",
+                                st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+                .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+                .writeAttribute("test_case_success", st.testCaseSuccess);
+        if(opt.duration)
+            xml.writeAttribute("duration", st.seconds);
+        if(tc->m_expected_failures)
+            xml.writeAttribute("expected_failures", tc->m_expected_failures);
+        xml.endElement();
+
+        xml.endElement();
+    }
+
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.scopedElement("Exception")
+                .writeAttribute("crash", e.is_crash)
+                .writeText(e.error_string.c_str());
+    }
+
+    void subcase_start(const SubcaseSignature& in) override {
+        xml.startElement("SubCase")
+                .writeAttribute("name", in.m_name)
+                .writeAttribute("filename", skipPathFromFilename(in.m_file))
+                .writeAttribute("line", line(in.m_line));
+        xml.ensureTagClosed();
+    }
+
+    void subcase_end() override { xml.endElement(); }
+
+    void log_assert(const AssertData& rb) override {
+        if(!rb.m_failed && !opt.success)
+            return;
+
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.startElement("Expression")
+                .writeAttribute("success", !rb.m_failed)
+                .writeAttribute("type", assertString(rb.m_at))
+                .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+                .writeAttribute("line", line(rb.m_line));
+
+        xml.scopedElement("Original").writeText(rb.m_expr);
+
+        if(rb.m_threw)
+            xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
+
+        if(rb.m_at & assertType::is_throws_as)
+            xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
+        if(rb.m_at & assertType::is_throws_with)
+            xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+        if((rb.m_at & assertType::is_normal) && !rb.m_threw)
+            xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
+
+        log_contexts();
+
+        xml.endElement();
+    }
+
+    void log_message(const MessageData& mb) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.startElement("Message")
+                .writeAttribute("type", failureString(mb.m_severity))
+                .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+                .writeAttribute("line", line(mb.m_line));
+
+        xml.scopedElement("Text").writeText(mb.m_string.c_str());
+
+        log_contexts();
+
+        xml.endElement();
+    }
+
+    void test_case_skipped(const TestCaseData& in) override {
+        if(opt.no_skipped_summary == false) {
             test_case_start_impl(in);
-            xml.ensureTagClosed();
-        }
-
-        void test_case_reenter(const TestCaseData&) override {}
-
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            xml.startElement("OverallResultsAsserts")
-                    .writeAttribute("successes",
-                                    st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-                    .writeAttribute("failures", st.numAssertsFailedCurrentTest)
-                    .writeAttribute("test_case_success", st.testCaseSuccess);
-            if(opt.duration)
-                xml.writeAttribute("duration", st.seconds);
-            if(tc->m_expected_failures)
-                xml.writeAttribute("expected_failures", tc->m_expected_failures);
-            xml.endElement();
-
+            xml.writeAttribute("skipped", "true");
             xml.endElement();
         }
+    }
+};
 
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.scopedElement("Exception")
-                    .writeAttribute("crash", e.is_crash)
-                    .writeText(e.error_string.c_str());
-        }
-
-        void subcase_start(const SubcaseSignature& in) override {
-            xml.startElement("SubCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file))
-                    .writeAttribute("line", line(in.m_line));
-            xml.ensureTagClosed();
-        }
-
-        void subcase_end() override { xml.endElement(); }
-
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt.success)
-                return;
-
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.startElement("Expression")
-                    .writeAttribute("success", !rb.m_failed)
-                    .writeAttribute("type", assertString(rb.m_at))
-                    .writeAttribute("filename", skipPathFromFilename(rb.m_file))
-                    .writeAttribute("line", line(rb.m_line));
-
-            xml.scopedElement("Original").writeText(rb.m_expr);
-
-            if(rb.m_threw)
-                xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
-
-            if(rb.m_at & assertType::is_throws_as)
-                xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-            if(rb.m_at & assertType::is_throws_with)
-                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
-            if((rb.m_at & assertType::is_normal) && !rb.m_threw)
-                xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void log_message(const MessageData& mb) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.startElement("Message")
-                    .writeAttribute("type", failureString(mb.m_severity))
-                    .writeAttribute("filename", skipPathFromFilename(mb.m_file))
-                    .writeAttribute("line", line(mb.m_line));
-
-            xml.scopedElement("Text").writeText(mb.m_string.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void test_case_skipped(const TestCaseData& in) override {
-            if(opt.no_skipped_summary == false) {
-                test_case_start_impl(in);
-                xml.writeAttribute("skipped", "true");
-                xml.endElement();
-            }
-        }
-    };
-
-    DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
+DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
 
 } // namespace doctest
 
@@ -6334,246 +6570,253 @@ namespace doctest {
 
 namespace doctest {
 
-    // TODO:
-    // - log_message()
-    // - respond to queries
-    // - honor remaining options
-    // - more attributes in tags
-    struct JUnitReporter : public IReporter
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter
+{
+    XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+    Timer               timer;
+    std::vector<String> deepestSubcaseStackNames;
+
+    struct JUnitTestCaseData
     {
-        XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
-        Timer timer;
-        std::vector<String> deepestSubcaseStackNames;
+        static std::string getCurrentTimestamp() {
+            // Beware, this is not reentrant because of backward compatibility issues
+            // Also, UTC only, again because of backward compatibility (%z is C++11)
+            time_t rawtime;
+            std::time(&rawtime);
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
-        struct JUnitTestCaseData
-        {
-            static std::string getCurrentTimestamp() {
-                // Beware, this is not reentrant because of backward compatibility issues
-                // Also, UTC only, again because of backward compatibility (%z is C++11)
-                time_t rawtime;
-                std::time(&rawtime);
-                auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
-
-                std::tm timeInfo;
+            std::tm timeInfo;
 #ifdef DOCTEST_PLATFORM_WINDOWS
-                gmtime_s(&timeInfo, &rawtime);
-#else // DOCTEST_PLATFORM_WINDOWS
-                gmtime_r(&rawtime, &timeInfo);
+            gmtime_s(&timeInfo, &rawtime);
+#else  // DOCTEST_PLATFORM_WINDOWS
+            gmtime_r(&rawtime, &timeInfo);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-                char timeStamp[timeStampSize];
-                const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            char              timeStamp[timeStampSize];
+            const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
-                std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
-                return std::string(timeStamp);
-            }
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+            return std::string(timeStamp);
+        }
 
-            struct JUnitTestMessage
-            {
-                JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
-                    : message(_message), type(_type), details(_details) {}
+        struct JUnitTestMessage
+        {
+            JUnitTestMessage(const std::string& _message, const std::string& _type,
+                             const std::string& _details)
+                    : message(_message)
+                    , type(_type)
+                    , details(_details) {}
 
-                JUnitTestMessage(const std::string& _message, const std::string& _details)
-                    : message(_message), type(), details(_details) {}
+            JUnitTestMessage(const std::string& _message, const std::string& _details)
+                    : message(_message)
+                    , type()
+                    , details(_details) {}
 
-                std::string message, type, details;
-            };
-
-            struct JUnitTestCase
-            {
-                JUnitTestCase(const std::string& _classname, const std::string& _name)
-                    : classname(_classname), name(_name), time(0), failures() {}
-
-                std::string classname, name;
-                double time;
-                std::vector<JUnitTestMessage> failures, errors;
-            };
-
-            void add(const std::string& classname, const std::string& name) {
-                testcases.emplace_back(classname, name);
-            }
-
-            void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
-                for(auto& curr: nameStack)
-                    if(curr.size())
-                        testcases.back().name += std::string("/") + curr.c_str();
-            }
-
-            void addTime(double time) {
-                if(time < 1e-4)
-                    time = 0;
-                testcases.back().time = time;
-                totalSeconds += time;
-            }
-
-            void addFailure(const std::string& message, const std::string& type, const std::string& details) {
-                testcases.back().failures.emplace_back(message, type, details);
-                ++totalFailures;
-            }
-
-            void addError(const std::string& message, const std::string& details) {
-                testcases.back().errors.emplace_back(message, details);
-                ++totalErrors;
-            }
-
-            std::vector<JUnitTestCase> testcases;
-            double totalSeconds = 0;
-            int totalErrors = 0, totalFailures = 0;
+            std::string message, type, details;
         };
 
-        JUnitTestCaseData testCaseData;
+        struct JUnitTestCase
+        {
+            JUnitTestCase(const std::string& _classname, const std::string& _name)
+                    : classname(_classname)
+                    , name(_name)
+                    , time(0)
+                    , failures() {}
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+            std::string                   classname, name;
+            double                        time;
+            std::vector<JUnitTestMessage> failures, errors;
+        };
 
-        JUnitReporter(const ContextOptions& co)
-                : xml(*co.cout)
-                , opt(co) {}
-
-        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData&) override {
-            xml.writeDeclaration();
+        void add(const std::string& classname, const std::string& name) {
+            testcases.emplace_back(classname, name);
         }
 
-        void test_run_start() override {
-            xml.writeDeclaration();
+        void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
+            for(auto& curr : nameStack)
+                if(curr.size())
+                    testcases.back().name += std::string("/") + curr.c_str();
         }
 
-        void test_run_end(const TestRunStats& p) override {
-            // remove .exe extension - mainly to have the same output on UNIX and Windows
-            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+        void addTime(double time) {
+            if(time < 1e-4)
+                time = 0;
+            testcases.back().time = time;
+            totalSeconds += time;
+        }
+
+        void addFailure(const std::string& message, const std::string& type,
+                        const std::string& details) {
+            testcases.back().failures.emplace_back(message, type, details);
+            ++totalFailures;
+        }
+
+        void addError(const std::string& message, const std::string& details) {
+            testcases.back().errors.emplace_back(message, details);
+            ++totalErrors;
+        }
+
+        std::vector<JUnitTestCase> testcases;
+        double                     totalSeconds = 0;
+        int                        totalErrors = 0, totalFailures = 0;
+    };
+
+    JUnitTestCaseData testCaseData;
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc = nullptr;
+
+    JUnitReporter(const ContextOptions& co)
+            : xml(*co.cout)
+            , opt(co) {}
+
+    unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData&) override { xml.writeDeclaration(); }
+
+    void test_run_start() override { xml.writeDeclaration(); }
+
+    void test_run_end(const TestRunStats& p) override {
+        // remove .exe extension - mainly to have the same output on UNIX and Windows
+        std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-            if(binary_name.rfind(".exe") != std::string::npos)
-                binary_name = binary_name.substr(0, binary_name.length() - 4);
+        if(binary_name.rfind(".exe") != std::string::npos)
+            binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
-            xml.startElement("testsuites");
-            xml.startElement("testsuite").writeAttribute("name", binary_name)
-                    .writeAttribute("errors", testCaseData.totalErrors)
-                    .writeAttribute("failures", testCaseData.totalFailures)
-                    .writeAttribute("tests", p.numAsserts);
-            if(opt.no_time_in_output == false) {
-                xml.writeAttribute("time", testCaseData.totalSeconds);
-                xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
-            }
-            if(opt.no_version == false)
-                xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
+        xml.startElement("testsuites");
+        xml.startElement("testsuite")
+                .writeAttribute("name", binary_name)
+                .writeAttribute("errors", testCaseData.totalErrors)
+                .writeAttribute("failures", testCaseData.totalFailures)
+                .writeAttribute("tests", p.numAsserts);
+        if(opt.no_time_in_output == false) {
+            xml.writeAttribute("time", testCaseData.totalSeconds);
+            xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
+        }
+        if(opt.no_version == false)
+            xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
 
-            for(const auto& testCase : testCaseData.testcases) {
-                xml.startElement("testcase")
+        for(const auto& testCase : testCaseData.testcases) {
+            xml.startElement("testcase")
                     .writeAttribute("classname", testCase.classname)
                     .writeAttribute("name", testCase.name);
-                if(opt.no_time_in_output == false)
-                    xml.writeAttribute("time", testCase.time);
-                // This is not ideal, but it should be enough to mimic gtest's junit output.
-                xml.writeAttribute("status", "run");
+            if(opt.no_time_in_output == false)
+                xml.writeAttribute("time", testCase.time);
+            // This is not ideal, but it should be enough to mimic gtest's junit output.
+            xml.writeAttribute("status", "run");
 
-                for(const auto& failure : testCase.failures) {
-                    xml.scopedElement("failure")
+            for(const auto& failure : testCase.failures) {
+                xml.scopedElement("failure")
                         .writeAttribute("message", failure.message)
                         .writeAttribute("type", failure.type)
                         .writeText(failure.details, false);
-                }
+            }
 
-                for(const auto& error : testCase.errors) {
-                    xml.scopedElement("error")
+            for(const auto& error : testCase.errors) {
+                xml.scopedElement("error")
                         .writeAttribute("message", error.message)
                         .writeText(error.details);
-                }
-
-                xml.endElement();
             }
-            xml.endElement();
+
             xml.endElement();
         }
+        xml.endElement();
+        xml.endElement();
+    }
 
-        void test_case_start(const TestCaseData& in) override {
-            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
-            timer.start();
-        }
+    void test_case_start(const TestCaseData& in) override {
+        testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+        timer.start();
+    }
 
-        void test_case_reenter(const TestCaseData& in) override {
-            testCaseData.addTime(timer.getElapsedSeconds());
-            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
-            deepestSubcaseStackNames.clear();
+    void test_case_reenter(const TestCaseData& in) override {
+        testCaseData.addTime(timer.getElapsedSeconds());
+        testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+        deepestSubcaseStackNames.clear();
 
-            timer.start();
-            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
-        }
+        timer.start();
+        testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+    }
 
-        void test_case_end(const CurrentTestCaseStats&) override {
-            testCaseData.addTime(timer.getElapsedSeconds());
-            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
-            deepestSubcaseStackNames.clear();
-        }
+    void test_case_end(const CurrentTestCaseStats&) override {
+        testCaseData.addTime(timer.getElapsedSeconds());
+        testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+        deepestSubcaseStackNames.clear();
+    }
 
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-            testCaseData.addError("exception", e.error_string.c_str());
-        }
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+        testCaseData.addError("exception", e.error_string.c_str());
+    }
 
-        void subcase_start(const SubcaseSignature& in) override {
-            deepestSubcaseStackNames.push_back(in.m_name);
-        }
+    void subcase_start(const SubcaseSignature& in) override {
+        deepestSubcaseStackNames.push_back(in.m_name);
+    }
 
-        void subcase_end() override {}
+    void subcase_end() override {}
 
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed) // report only failures & ignore the `success` option
-                return;
+    void log_assert(const AssertData& rb) override {
+        if(!rb.m_failed) // report only failures & ignore the `success` option
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            std::ostringstream os;
-            os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
-              << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+        std::ostringstream os;
+        os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(rb.m_line)
+           << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
-            fulltext_log_assert_to_stream(os, rb);
-            log_contexts(os);
-            testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
-        }
+        fulltext_log_assert_to_stream(os, rb);
+        log_contexts(os);
+        testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
+    }
 
-        void log_message(const MessageData& mb) override {
-            if(mb.m_severity & assertType::is_warn) // report only failures
-                return;
+    void log_message(const MessageData& mb) override {
+        if(mb.m_severity & assertType::is_warn) // report only failures
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            std::ostringstream os;
-            os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(")
-              << line(mb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+        std::ostringstream os;
+        os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(mb.m_line)
+           << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
-            os << mb.m_string.c_str() << "\n";
-            log_contexts(os);
+        os << mb.m_string.c_str() << "\n";
+        log_contexts(os);
 
-            testCaseData.addFailure(mb.m_string.c_str(),
-                mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str());
-        }
+        testCaseData.addFailure(mb.m_string.c_str(),
+                                mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL",
+                                os.str());
+    }
 
-        void test_case_skipped(const TestCaseData&) override {}
+    void test_case_skipped(const TestCaseData&) override {}
 
-        void log_contexts(std::ostringstream& s) {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto contexts = get_active_contexts();
+    void log_contexts(std::ostringstream& s) {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto contexts = get_active_contexts();
 
-                s << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
-                    s << (i == 0 ? "" : "          ");
-                    contexts[i]->stringify(&s);
-                    s << std::endl;
-                }
+            s << "  logged: ";
+            for(int i = 0; i < num_contexts; ++i) {
+                s << (i == 0 ? "" : "          ");
+                contexts[i]->stringify(&s);
+                s << std::endl;
             }
         }
-    };
+    }
+};
 
-    DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
 
 } // namespace doctest
 
@@ -6587,8 +6830,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
@@ -6630,15 +6872,13 @@ namespace detail {
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     bool checkIfShouldThrow(assertType::Enum at) {
         if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
@@ -6658,12 +6898,11 @@ namespace detail {
         g_cs->shouldLogCurrentException = false;
         throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
     }
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
     void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -6707,23 +6946,20 @@ bool operator<(const Approx& lhs, double rhs) { return lhs.m_value < rhs && lhs 
 bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs != rhs; }
 bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
-String toString(const Approx& in) {
-    return "Approx( " + doctest::toString(in.m_value) + " )";
-}
+String toString(const Approx& in) { return "Approx( " + doctest::toString(in.m_value) + " )"; }
 
 } // namespace doctest
 
 namespace doctest {
 
-Contains::Contains(const String& str) : string(str) { }
+Contains::Contains(const String& str)
+        : string(str) {}
 
 bool Contains::checkWith(const String& other) const {
     return strstr(other.c_str(), string.c_str()) != nullptr;
 }
 
-String toString(const Contains& in) {
-    return "Contains( " + in.string + " )";
-}
+String toString(const Contains& in) { return "Contains( " + in.string + " )"; }
 
 bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
 bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
@@ -6745,7 +6981,9 @@ template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
 template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
 
 template <typename F>
-String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
+String toString(IsNaN<F> in) {
+    return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )";
+}
 String toString(IsNaN<float> in) { return toString<float>(in); }
 String toString(IsNaN<double> in) { return toString<double>(in); }
 String toString(IsNaN<double long> in) { return toString<double long>(in); }
@@ -6755,35 +6993,38 @@ String toString(IsNaN<double long> in) { return toString<double long>(in); }
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    int                         IReporter::get_num_active_contexts() { return 0; }
-    const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
-    int                         IReporter::get_num_stringified_contexts() { return 0; }
-    const String*               IReporter::get_stringified_contexts() { return nullptr; }
+int                         IReporter::get_num_active_contexts() { return 0; }
+const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
+int                         IReporter::get_num_stringified_contexts() { return 0; }
+const String*               IReporter::get_stringified_contexts() { return nullptr; }
 
-    int registerReporter(const char*, int, IReporter*) { return 0; }
+int registerReporter(const char*, int, IReporter*) { return 0; }
 
 #else
 
-    DOCTEST_DEFINE_INTERFACE(IReporter)
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
-    int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
-    const IContextScope* const* IReporter::get_active_contexts() {
-        return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
+const IContextScope* const* IReporter::get_active_contexts() {
+    return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
+const String* IReporter::get_stringified_contexts() {
+    return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
+}
+
+namespace detail {
+    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c,
+                              bool isReporter) {
+        if(isReporter)
+            getReporters().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
+        else
+            getListeners().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
     }
-
-    int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
-    const String* IReporter::get_stringified_contexts() {
-        return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
-    }
-
-    namespace detail {
-        void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
-            if(isReporter)
-                getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-            else
-                getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-        }
-    } // namespace detail
+} // namespace detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace doctest
@@ -6803,7 +7044,7 @@ namespace detail {
         }
 
         String pop() {
-            if (stack.empty())
+            if(stack.empty())
                 DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
 
             std::streampos pos = stack.back();
@@ -6814,230 +7055,235 @@ namespace detail {
         }
     } g_oss;
 
-    std::ostream* tlssPush() {
-        return g_oss.push();
-    }
+    std::ostream* tlssPush() { return g_oss.push(); }
 
-    String tlssPop() {
-        return g_oss.pop();
-    }
+    String tlssPop() { return g_oss.pop(); }
 
 } // namespace detail
 
-    // case insensitive strcmp
-    static int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
+// case insensitive strcmp
+static int stricmp(const char* a, const char* b) {
+    for(;; a++, b++) {
+        const int d = tolower(*a) - tolower(*b);
+        if(d != 0 || !*a)
+            return d;
     }
+}
 
-    char* String::allocate(size_type sz) {
-        if (sz <= last) {
-            buf[sz] = '\0';
-            setLast(last - sz);
-            return buf;
-        } else {
-            setOnHeap();
-            data.size = sz;
-            data.capacity = data.size + 1;
-            data.ptr = new char[data.capacity];
-            data.ptr[sz] = '\0';
-            return data.ptr;
-        }
+char* String::allocate(size_type sz) {
+    if(sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size     = sz;
+        data.capacity = data.size + 1;
+        data.ptr      = new char[data.capacity];
+        data.ptr[sz]  = '\0';
+        return data.ptr;
     }
+}
 
-    void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-    void String::setLast(size_type in) noexcept { buf[last] = char(in); }
-    void String::setSize(size_type sz) noexcept {
-        if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
-        else { data.ptr[sz] = '\0'; data.size = sz; }
+void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
+void String::setLast(size_type in) noexcept { buf[last] = char(in); }
+void String::setSize(size_type sz) noexcept {
+    if(isOnStack()) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+    } else {
+        data.ptr[sz] = '\0';
+        data.size    = sz;
     }
+}
 
-    void String::copy(const String& other) {
-        if(other.isOnStack()) {
-            memcpy(buf, other.buf, len);
-        } else {
-            memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
-        }
+void String::copy(const String& other) {
+    if(other.isOnStack()) {
+        memcpy(buf, other.buf, len);
+    } else {
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
+}
 
-    String::String() noexcept {
-        buf[0] = '\0';
-        setLast();
-    }
+String::String() noexcept {
+    buf[0] = '\0';
+    setLast();
+}
 
-    String::~String() {
+String::~String() {
+    if(!isOnStack())
+        delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String(const char* in)
+        : String(in, strlen(in)) {}
+
+String::String(const char* in, size_type in_size) { memcpy(allocate(in_size), in, in_size); }
+
+String::String(std::istream& in, size_type in_size) { in.read(allocate(in_size), in_size); }
+
+String::String(const String& other) { copy(other); }
+
+String& String::operator=(const String& other) {
+    if(this != &other) {
         if(!isOnStack())
             delete[] data.ptr;
-    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-    String::String(const char* in)
-            : String(in, strlen(in)) {}
-
-    String::String(const char* in, size_type in_size) {
-        memcpy(allocate(in_size), in, in_size);
+        copy(other);
     }
 
-    String::String(std::istream& in, size_type in_size) {
-        in.read(allocate(in_size), in_size);
-    }
+    return *this;
+}
 
-    String::String(const String& other) { copy(other); }
-
-    String& String::operator=(const String& other) {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-
-            copy(other);
-        }
-
-        return *this;
-    }
-
-    String& String::operator+=(const String& other) {
-        const size_type my_old_size = size();
-        const size_type other_size  = other.size();
-        const size_type total_size  = my_old_size + other_size;
-        if(isOnStack()) {
-            if(total_size < len) {
-                // append to the current stack space
-                memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-                // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-                setLast(last - total_size);
-            } else {
-                // alloc new chunk
-                char* temp = new char[total_size + 1];
-                // copy current data to new location before writing in the union
-                memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-                // update data in union
-                setOnHeap();
-                data.size     = total_size;
-                data.capacity = data.size + 1;
-                data.ptr      = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+String& String::operator+=(const String& other) {
+    const size_type my_old_size = size();
+    const size_type other_size  = other.size();
+    const size_type total_size  = my_old_size + other_size;
+    if(isOnStack()) {
+        if(total_size < len) {
+            // append to the current stack space
+            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            setLast(last - total_size);
         } else {
-            if(data.capacity > total_size) {
-                // append to the current heap block
-                data.size = total_size;
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            } else {
-                // resize
-                data.capacity *= 2;
-                if(data.capacity <= total_size)
-                    data.capacity = total_size + 1;
-                // alloc new chunk
-                char* temp = new char[data.capacity];
-                // copy current data to new location before releasing it
-                memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-                // release old chunk
-                delete[] data.ptr;
-                // update the rest of the union members
-                data.size = total_size;
-                data.ptr  = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+            // alloc new chunk
+            char* temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size     = total_size;
+            data.capacity = data.size + 1;
+            data.ptr      = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
-
-        return *this;
+    } else {
+        if(data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if(data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char* temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr  = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
     }
 
-    String::String(String&& other) noexcept {
+    return *this;
+}
+
+String::String(String&& other) noexcept {
+    memcpy(buf, other.buf, len);
+    other.buf[0] = '\0';
+    other.setLast();
+}
+
+String& String::operator=(String&& other) noexcept {
+    if(this != &other) {
+        if(!isOnStack())
+            delete[] data.ptr;
         memcpy(buf, other.buf, len);
         other.buf[0] = '\0';
         other.setLast();
     }
+    return *this;
+}
 
-    String& String::operator=(String&& other) noexcept {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-            memcpy(buf, other.buf, len);
-            other.buf[0] = '\0';
-            other.setLast();
-        }
-        return *this;
+char String::operator[](size_type i) const { return const_cast<String*>(this)->operator[](i); }
+
+char& String::operator[](size_type i) {
+    if(isOnStack())
+        return reinterpret_cast<char*>(buf)[i];
+    return data.ptr[i];
+}
+
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
+String::size_type String::size() const {
+    if(isOnStack())
+        return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+}
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+String::size_type String::capacity() const {
+    if(isOnStack())
+        return len;
+    return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+    cnt        = std::min(cnt, size() - pos);
+    char* cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const& {
+    cnt = std::min(cnt, size() - pos);
+    return String{c_str() + pos, cnt};
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* end   = begin + size();
+    const char* it    = begin + pos;
+    for(; it < end && *it != ch; it++) {}
+    if(it < end) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char String::operator[](size_type i) const {
-        return const_cast<String*>(this)->operator[](i);
+String::size_type String::rfind(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* it    = begin + std::min(pos, size() - 1);
+    for(; it >= begin && *it != ch; it--) {}
+    if(it >= begin) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char& String::operator[](size_type i) {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf)[i];
-        return data.ptr[i];
-    }
+int String::compare(const char* other, bool no_case) const {
+    if(no_case)
+        return doctest::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
 
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-    String::size_type String::size() const {
-        if(isOnStack())
-            return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
-        return data.size;
-    }
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+int String::compare(const String& other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
 
-    String::size_type String::capacity() const {
-        if(isOnStack())
-            return len;
-        return data.capacity;
-    }
+String operator+(const String& lhs, const String& rhs) { return String(lhs) += rhs; }
 
-    String String::substr(size_type pos, size_type cnt) && {
-        cnt = std::min(cnt, size() - pos);
-        char* cptr = c_str();
-        memmove(cptr, cptr + pos, cnt);
-        setSize(cnt);
-        return std::move(*this);
-    }
+bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
+bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
+bool operator<(const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
+bool operator>(const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
+bool operator<=(const String& lhs, const String& rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) < 0 : true;
+}
+bool operator>=(const String& lhs, const String& rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) > 0 : true;
+}
 
-    String String::substr(size_type pos, size_type cnt) const & {
-        cnt = std::min(cnt, size() - pos);
-        return String{ c_str() + pos, cnt };
-    }
-
-    String::size_type String::find(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* end = begin + size();
-        const char* it = begin + pos;
-        for (; it < end && *it != ch; it++) { }
-        if (it < end) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
-
-    String::size_type String::rfind(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* it = begin + std::min(pos, size() - 1);
-        for (; it >= begin && *it != ch; it--) { }
-        if (it >= begin) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
-
-    int String::compare(const char* other, bool no_case) const {
-        if(no_case)
-            return doctest::stricmp(c_str(), other);
-        return std::strcmp(c_str(), other);
-    }
-
-    int String::compare(const String& other, bool no_case) const {
-        return compare(other.c_str(), no_case);
-    }
-
-    String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
-
-    bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
-    bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
-    bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
-    bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
-    bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
-    bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-
-    std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
 
 namespace detail {
 
@@ -7046,8 +7292,11 @@ namespace detail {
     }
 
     void filldata<const volatile void*>::fill(std::ostream* stream, const volatile void* in) {
-        if (in) { *stream << in; }
-        else { *stream << "nullptr"; }
+        if(in) {
+            *stream << in;
+        } else {
+            *stream << "nullptr";
+        }
     }
 
     template <typename T>
@@ -7093,28 +7342,29 @@ String toString(long long unsigned in) { return toStreamLit(in); }
 
 namespace doctest {
 
-    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-        return m_line == other.m_line
-            && std::strcmp(m_file, other.m_file) == 0
-            && m_name == other.m_name;
-    }
+bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+    return m_line == other.m_line && std::strcmp(m_file, other.m_file) == 0 &&
+           m_name == other.m_name;
+}
 
-    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        if(std::strcmp(m_file, other.m_file) != 0)
-            return std::strcmp(m_file, other.m_file) < 0;
-        return m_name.compare(other.m_name) < 0;
-    }
+bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+    if(m_line != other.m_line)
+        return m_line < other.m_line;
+    if(std::strcmp(m_file, other.m_file) != 0)
+        return std::strcmp(m_file, other.m_file) < 0;
+    return m_name.compare(other.m_name) < 0;
+}
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
     bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+        if(g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+            if(!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true,
+                           g_cs->case_sensitive))
                 return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+            if(matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false,
+                          g_cs->case_sensitive))
                 return true;
         }
         return false;
@@ -7122,11 +7372,13 @@ namespace detail {
 
     Subcase::Subcase(const String& name, const char* file, int line)
             : m_signature({name, file, line}) {
-        if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+        if(!g_cs->reachedLeaf) {
+            if(g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size() ||
+               g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
                 // Going down.
-                if (checkFilters()) { return; }
+                if(checkFilters()) {
+                    return;
+                }
 
                 g_cs->subcaseStack.push_back(m_signature);
                 g_cs->currentSubcaseDepth++;
@@ -7134,19 +7386,23 @@ namespace detail {
                 DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
             }
         } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+            if(g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
                 // This subcase is reentered via control flow.
                 g_cs->currentSubcaseDepth++;
                 m_entered = true;
                 DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
+            } else if(g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+                      g_cs->fullyTraversedSubcases.find(
+                              hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth),
+                                   hash(m_signature))) == g_cs->fullyTraversedSubcases.end()) {
+                if(checkFilters()) {
+                    return;
+                }
                 // This subcase is part of the one to be executed next.
                 g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+                g_cs->nextSubcaseStack.insert(
+                        g_cs->nextSubcaseStack.end(), g_cs->subcaseStack.begin(),
+                        g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
                 g_cs->nextSubcaseStack.push_back(m_signature);
             }
         }
@@ -7157,30 +7413,31 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 
     Subcase::~Subcase() {
-        if (m_entered) {
+        if(m_entered) {
             g_cs->currentSubcaseDepth--;
 
-            if (!g_cs->reachedLeaf) {
+            if(!g_cs->reachedLeaf) {
                 // Leaf.
                 g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
                 g_cs->nextSubcaseStack.clear();
                 g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
+            } else if(g_cs->nextSubcaseStack.empty()) {
                 // All children are finished.
                 g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
             }
 
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&          \
+        (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
             if(std::uncaught_exceptions() > 0
-    #else
+#else
             if(std::uncaught_exception()
-    #endif
-                && g_cs->shouldLogCurrentException) {
+#endif
+               && g_cs->shouldLogCurrentException) {
                 DOCTEST_ITERATE_THROUGH_REPORTERS(
                         test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
+                                              "when the whole test case has been exited (cannot "
+                                              "translate while there is an active exception)",
+                                              false});
                 g_cs->shouldLogCurrentException = false;
             }
 
@@ -7201,101 +7458,97 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                    const String& type, int template_id) {
-    m_file              = file;
-    m_line              = line;
-    m_name              = nullptr; // will be later overridden in operator*
-    m_test_suite        = test_suite.m_test_suite;
-    m_description       = test_suite.m_description;
-    m_skip              = test_suite.m_skip;
-    m_no_breaks         = test_suite.m_no_breaks;
-    m_no_output         = test_suite.m_no_output;
-    m_may_fail          = test_suite.m_may_fail;
-    m_should_fail       = test_suite.m_should_fail;
-    m_expected_failures = test_suite.m_expected_failures;
-    m_timeout           = test_suite.m_timeout;
+    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+                       const String& type, int template_id) {
+        m_file              = file;
+        m_line              = line;
+        m_name              = nullptr; // will be later overridden in operator*
+        m_test_suite        = test_suite.m_test_suite;
+        m_description       = test_suite.m_description;
+        m_skip              = test_suite.m_skip;
+        m_no_breaks         = test_suite.m_no_breaks;
+        m_no_output         = test_suite.m_no_output;
+        m_may_fail          = test_suite.m_may_fail;
+        m_should_fail       = test_suite.m_should_fail;
+        m_expected_failures = test_suite.m_expected_failures;
+        m_timeout           = test_suite.m_timeout;
 
-    m_test        = test;
-    m_type        = type;
-    m_template_id = template_id;
-}
-
-TestCase::TestCase(const TestCase& other)
-        : TestCaseData() {
-    *this = other;
-}
-
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-TestCase& TestCase::operator=(const TestCase& other) {
-    TestCaseData::operator=(other);
-    m_test        = other.m_test;
-    m_type        = other.m_type;
-    m_template_id = other.m_template_id;
-    m_full_name   = other.m_full_name;
-
-    if(m_template_id != -1)
-        m_name = m_full_name.c_str();
-    return *this;
-}
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-TestCase& TestCase::operator*(const char* in) {
-    m_name = in;
-    // make a new name with an appended type for templated test case
-    if(m_template_id != -1) {
-        m_full_name = String(m_name) + "<" + m_type + ">";
-        // redirect the name to point to the newly constructed full name
-        m_name = m_full_name.c_str();
+        m_test        = test;
+        m_type        = type;
+        m_template_id = template_id;
     }
-    return *this;
-}
 
-bool TestCase::operator<(const TestCase& other) const {
-    // this will be used only to differentiate between test cases - not relevant for sorting
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    const int name_cmp = strcmp(m_name, other.m_name);
-    if(name_cmp != 0)
-        return name_cmp < 0;
-    const int file_cmp = m_file.compare(other.m_file);
-    if(file_cmp != 0)
-        return file_cmp < 0;
-    return m_template_id < other.m_template_id;
-}
+    TestCase::TestCase(const TestCase& other)
+            : TestCaseData() {
+        *this = other;
+    }
 
-// used by the macros for registering tests
-int regTest(const TestCase& tc) {
-    getRegisteredTests().insert(tc);
-    return 0;
-}
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+    TestCase& TestCase::operator=(const TestCase& other) {
+        TestCaseData::operator=(other);
+        m_test        = other.m_test;
+        m_type        = other.m_type;
+        m_template_id = other.m_template_id;
+        m_full_name   = other.m_full_name;
 
-} // namespace detail
-} // namespace doctest
+        if(m_template_id != -1)
+            m_name = m_full_name.c_str();
+        return *this;
+    }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    TestCase& TestCase::operator*(const char* in) {
+        m_name = in;
+        // make a new name with an appended type for templated test case
+        if(m_template_id != -1) {
+            m_full_name = String(m_name) + "<" + m_type + ">";
+            // redirect the name to point to the newly constructed full name
+            m_name = m_full_name.c_str();
+        }
+        return *this;
+    }
+
+    bool TestCase::operator<(const TestCase& other) const {
+        // this will be used only to differentiate between test cases - not relevant for sorting
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        const int name_cmp = strcmp(m_name, other.m_name);
+        if(name_cmp != 0)
+            return name_cmp < 0;
+        const int file_cmp = m_file.compare(other.m_file);
+        if(file_cmp != 0)
+            return file_cmp < 0;
+        return m_template_id < other.m_template_id;
+    }
+
+    // used by the macros for registering tests
+    int regTest(const TestCase& tc) {
+        getRegisteredTests().insert(tc);
+        return 0;
+    }
+
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-TestSuite& TestSuite::operator*(const char* in) {
-    m_test_suite = in;
-    return *this;
-}
+    TestSuite& TestSuite::operator*(const char* in) {
+        m_test_suite = in;
+        return *this;
+    }
 
-// sets the current test suite
-int setTestSuite(const TestSuite& ts) {
-    doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
-    return 0;
-}
+    // sets the current test suite
+    int setTestSuite(const TestSuite& ts) {
+        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+        return 0;
+    }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite
@@ -7309,8 +7562,7 @@ doctest::detail::TestSuite& getCurrentTestSuite() {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // clang-format off
 
@@ -7602,8 +7854,7 @@ namespace {
 
     // clang-format on
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/assert/data.cpp
+++ b/doctest/parts/private/assert/data.cpp
@@ -5,18 +5,25 @@
 
 namespace doctest {
 
-    using detail::g_cs;
+using detail::g_cs;
 
-    AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const StringContains& exception_string)
-        : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
-        m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
-        m_exception_string(exception_string) {
-    #if DOCTEST_MSVC
-        if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-    #endif // MSVC
-    }
+AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+                       const char* exception_type, const StringContains& exception_string)
+        : m_test_case(g_cs->currentTest)
+        , m_at(at)
+        , m_file(file)
+        , m_line(line)
+        , m_expr(expr)
+        , m_failed(true)
+        , m_threw(false)
+        , m_threw_as(false)
+        , m_exception_type(exception_type)
+        , m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/assert/expression.cpp
+++ b/doctest/parts/private/assert/expression.cpp
@@ -2,13 +2,11 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-        : m_at(at) {}
+    ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
+            : m_at(at) {}
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/assert/handler.cpp
+++ b/doctest/parts/private/assert/handler.cpp
@@ -3,8 +3,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     void failed_out_of_a_testing_context(const AssertData& ad) {
         if(g_cs->ah)
@@ -26,7 +25,6 @@ namespace detail {
         return !failed;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/assert/handler.h
+++ b/doctest/parts/private/assert/handler.h
@@ -4,8 +4,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
     using detail::g_cs;
 
@@ -25,7 +24,7 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
+        while(g_cs->subcaseStack.size()) {
             g_cs->subcaseStack.pop_back();
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
         }
@@ -38,7 +37,6 @@ namespace {
     }
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/assert/message.cpp
+++ b/doctest/parts/private/assert/message.cpp
@@ -5,8 +5,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
         m_stream   = tlssPush();
@@ -16,14 +15,14 @@ namespace detail {
     }
 
     MessageBuilder::~MessageBuilder() {
-        if (!logged)
+        if(!logged)
             tlssPop();
     }
 
     bool MessageBuilder::log() {
-        if (!logged) {
+        if(!logged) {
             m_string = tlssPop();
-            logged = true;
+            logged   = true;
         }
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
@@ -37,7 +36,8 @@ namespace detail {
         }
 
         return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+               (g_cs->currentTest == nullptr ||
+                !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
     void MessageBuilder::react() {
@@ -45,7 +45,6 @@ namespace detail {
             throwException();
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/assert/result.cpp
+++ b/doctest/parts/private/assert/result.cpp
@@ -2,8 +2,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     Result::Result(bool passed, const String& decomposition)
             : m_passed(passed)
@@ -11,11 +10,11 @@ namespace detail {
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
                                  const char* exception_type, const String& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+            : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const Contains& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+                                 const char* exception_type, const Contains& exception_string)
+            : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
     void ResultBuilder::setResult(const Result& res) {
         m_decomp = res.m_decomp;
@@ -30,7 +29,6 @@ namespace detail {
             throwException();
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/atomic.h
+++ b/doctest/parts/private/atomic.h
@@ -2,13 +2,12 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 #ifdef DOCTEST_CONFIG_NO_MULTITHREADING
     template <typename T>
     using Atomic = T;
-#else // DOCTEST_CONFIG_NO_MULTITHREADING
+#else  // DOCTEST_CONFIG_NO_MULTITHREADING
     template <typename T>
     using Atomic = std::atomic<T>;
 #endif // DOCTEST_CONFIG_NO_MULTITHREADING
@@ -16,7 +15,7 @@ namespace detail {
 #if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
     template <typename T>
     using MultiLaneAtomic = Atomic<T>;
-#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+#else  // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
     // Provides a multilane implementation of an atomic variable that supports add, sub, load,
     // store. Instead of using a single atomic variable, this splits up into multiple ones,
     // each sitting on a separate cache line. The goal is to provide a speedup when most
@@ -33,7 +32,7 @@ namespace detail {
         struct CacheLineAlignedAtomic
         {
             Atomic<T> atomic{};
-            char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
+            char      padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
         };
         CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
 
@@ -68,7 +67,8 @@ namespace detail {
             return desired;
         }
 
-        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        void store(T                 desired,
+                   std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
             // first value becomes desired", all others become 0.
             for(auto& c : m_atomics) {
                 c.atomic.store(desired, order);
@@ -90,7 +90,7 @@ namespace detail {
         // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
         //    little overhead.
         Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
-            static Atomic<size_t> laneCounter;
+            static Atomic<size_t>       laneCounter;
             DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
                     laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
 
@@ -99,8 +99,6 @@ namespace detail {
     };
 #endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
-
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/color.cpp
+++ b/doctest/parts/private/color.cpp
@@ -31,9 +31,9 @@ namespace {
         using namespace detail;
         static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
         static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
-    #ifdef DOCTEST_CONFIG_COLORS_ANSI
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
         if(g_no_colors ||
-            (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+           (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
             return;
 
         auto col = "";
@@ -59,14 +59,15 @@ namespace {
             DOCTEST_CLANG_SUPPRESS_WARNING_POP
         // clang-format on
         s << "\033" << col;
-    #endif // DOCTEST_CONFIG_COLORS_ANSI
+#endif // DOCTEST_CONFIG_COLORS_ANSI
 
-    #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
         if(g_no_colors ||
-            (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+           (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
             return;
 
-        static struct ConsoleHelper {
+        static struct ConsoleHelper
+        {
             HANDLE stdoutHandle;
             WORD   origFgAttrs;
             WORD   origBgAttrs;
@@ -76,13 +77,13 @@ namespace {
                 CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
                 GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
                 origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                    BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+                                                       BACKGROUND_BLUE | BACKGROUND_INTENSITY);
                 origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                    FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+                                                       FOREGROUND_BLUE | FOREGROUND_INTENSITY);
             }
         } ch;
 
-    #define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
 
         // clang-format off
         switch (code) {
@@ -102,9 +103,9 @@ namespace {
             default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
         }
             // clang-format on
-    #endif // DOCTEST_CONFIG_COLORS_WINDOWS
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
     }
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
-}
+} // namespace
 #endif // DOCTEST_CONFIG_DISABLED
-}
+} // namespace doctest

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -10,23 +10,23 @@
 
 namespace doctest {
 
-    bool is_running_in_test = false;
+bool is_running_in_test = false;
 
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    Context::Context(int, const char* const*) {}
-    Context::~Context() = default;
-    void Context::applyCommandLine(int, const char* const*) {}
-    void Context::addFilter(const char*, const char*) {}
-    void Context::clearFilters() {}
-    void Context::setOption(const char*, bool) {}
-    void Context::setOption(const char*, int) {}
-    void Context::setOption(const char*, const char*) {}
-    bool Context::shouldExit() { return false; }
-    void Context::setAsDefaultForAssertsOutOfTestCases() {}
-    void Context::setAssertHandler(detail::assert_handler) {}
-    void Context::setCout(std::ostream*) {}
-    int  Context::run() { return 0; }
+Context::Context(int, const char* const*) {}
+Context::~Context() = default;
+void Context::applyCommandLine(int, const char* const*) {}
+void Context::addFilter(const char*, const char*) {}
+void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
+void Context::setOption(const char*, int) {}
+void Context::setOption(const char*, const char*) {}
+bool Context::shouldExit() { return false; }
+void Context::setAsDefaultForAssertsOutOfTestCases() {}
+void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream*) {}
+int  Context::run() { return 0; }
 
 #else
 
@@ -65,8 +65,10 @@ namespace {
         // going from the end to the beginning and stopping on the first occurrence from the end
         for(int i = argc; i > 0; --i) {
             auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
+            auto temp  = std::strstr(argv[index], pattern);
+            if(temp &&
+               (value ||
+                strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
                 // eliminate matches in which the chars before the option are not '-'
                 bool noBadCharsFound = true;
                 auto curr            = argv[index];
@@ -96,8 +98,8 @@ namespace {
     }
 
     // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
+    bool parseOption(int argc, const char* const* argv, const char* pattern,
+                     String* value = nullptr, const String& defaultVal = String()) {
         if(value)
             *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -120,7 +122,7 @@ namespace {
         if(parseOption(argc, argv, pattern, &filtersString)) {
             // tokenize with "," as a separator, unless escaped with backslash
             std::ostringstream s;
-            auto flush = [&s, &res]() {
+            auto               flush = [&s, &res]() {
                 auto string = s.str();
                 if(string.size() > 0) {
                     res.push_back(string.c_str());
@@ -128,9 +130,9 @@ namespace {
                 s.str("");
             };
 
-            bool seenBackslash = false;
-            const char* current = filtersString.c_str();
-            const char* end = current + strlen(current);
+            bool        seenBackslash = false;
+            const char* current       = filtersString.c_str();
+            const char* end           = current + strlen(current);
             while(current != end) {
                 char character = *current++;
                 if(seenBackslash) {
@@ -176,22 +178,22 @@ namespace {
             // integer
             // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
             int theInt = std::atoi(parsedValue.c_str());
-            if (theInt != 0) {
+            if(theInt != 0) {
                 res = theInt; //!OCLINT parameter reassignment
                 return true;
             }
         } else {
             // boolean
-            const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
-            const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
+            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
 
             // if the value matches any of the positive/negative possibilities
-            for (unsigned i = 0; i < 4; i++) {
-                if (parsedValue.compare(positive[i], true) == 0) {
+            for(unsigned i = 0; i < 4; i++) {
+                if(parsedValue.compare(positive[i], true) == 0) {
                     res = 1; //!OCLINT parameter reassignment
                     return true;
                 }
-                if (parsedValue.compare(negative[i], true) == 0) {
+                if(parsedValue.compare(negative[i], true) == 0) {
                     res = 0; //!OCLINT parameter reassignment
                     return true;
                 }
@@ -202,30 +204,30 @@ namespace {
 
 } // namespace
 
-    Context::Context(int argc, const char* const* argv)
-            : p(new detail::ContextState) {
-        parseArgs(argc, argv, true);
-        if(argc)
-            p->binary_name = argv[0];
-    }
+Context::Context(int argc, const char* const* argv)
+        : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+    if(argc)
+        p->binary_name = argv[0];
+}
 
-    Context::~Context() {
-        if(g_cs == p)
-            g_cs = nullptr;
-        delete p;
-    }
+Context::~Context() {
+    if(g_cs == p)
+        g_cs = nullptr;
+    delete p;
+}
 
-    void Context::applyCommandLine(int argc, const char* const* argv) {
-        parseArgs(argc, argv);
-        if(argc)
-            p->binary_name = argv[0];
-    }
+void Context::applyCommandLine(int argc, const char* const* argv) {
+    parseArgs(argc, argv);
+    if(argc)
+        p->binary_name = argv[0];
+}
 
-    // parses args
-    void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-        using namespace detail;
+// parses args
+void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
+    using namespace detail;
 
-        // clang-format off
+    // clang-format off
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
@@ -244,35 +246,35 @@ namespace {
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
         parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
-        // clang-format on
+    // clang-format on
 
-        int    intRes = 0;
-        String strRes;
+    int    intRes = 0;
+    String strRes;
 
-    #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-            p->var = static_cast<bool>(intRes);                                                        \
-        else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
-                parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
-            p->var = true;                                                                             \
-        else if(withDefaults)                                                                          \
-        p->var = default
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
+    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
+       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
+        p->var = static_cast<bool>(intRes);                                                        \
+    else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
+            parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
+        p->var = true;                                                                             \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-    #define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
-            p->var = intRes;                                                                           \
-        else if(withDefaults)                                                                          \
-        p->var = default
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
+    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
+       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
+        p->var = intRes;                                                                           \
+    else if(withDefaults)                                                                          \
+    p->var = default
 
-    #define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-        if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
-           parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
-           withDefaults)                                                                               \
-        p->var = strRes
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
+    if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
+       parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
+       withDefaults)                                                                               \
+    p->var = strRes
 
-        // clang-format off
+    // clang-format off
         DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
         DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
         DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
@@ -305,371 +307,371 @@ namespace {
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
         DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
-        // clang-format on
+    // clang-format on
 
-        if(withDefaults) {
-            p->help             = false;
-            p->version          = false;
-            p->count            = false;
-            p->list_test_cases  = false;
-            p->list_test_suites = false;
-            p->list_reporters   = false;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
-            p->help = true;
-            p->exit = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
-            p->version = true;
-            p->exit    = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
-            p->count = true;
-            p->exit  = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
-            p->list_test_cases = true;
-            p->exit            = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
-            p->list_test_suites = true;
-            p->exit             = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
-            p->list_reporters = true;
-            p->exit           = true;
-        }
+    if(withDefaults) {
+        p->help             = false;
+        p->version          = false;
+        p->count            = false;
+        p->list_test_cases  = false;
+        p->list_test_suites = false;
+        p->list_reporters   = false;
     }
-
-    // allows the user to add procedurally to the filters from the command line
-    void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
-
-    // allows the user to clear all filters from the command line
-    void Context::clearFilters() {
-        for(auto& curr : p->filters)
-            curr.clear();
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+        p->help = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the bool options from the command line
-    void Context::setOption(const char* option, bool value) {
-        setOption(option, value ? "true" : "false");
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+        p->version = true;
+        p->exit    = true;
     }
-
-    // allows the user to override procedurally the int options from the command line
-    void Context::setOption(const char* option, int value) {
-        setOption(option, toString(value).c_str());
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+        p->count = true;
+        p->exit  = true;
     }
-
-    // allows the user to override procedurally the string options from the command line
-    void Context::setOption(const char* option, const char* value) {
-        auto argv   = String("-") + option + "=" + value;
-        auto lvalue = argv.c_str();
-        parseArgs(1, &lvalue);
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+        p->list_test_cases = true;
+        p->exit            = true;
     }
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+        p->list_test_suites = true;
+        p->exit             = true;
+    }
+    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+        p->list_reporters = true;
+        p->exit           = true;
+    }
+}
 
-    // users should query this in their main() and exit the program if true
-    bool Context::shouldExit() { return p->exit; }
+// allows the user to add procedurally to the filters from the command line
+void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
 
-    void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
+// allows the user to clear all filters from the command line
+void Context::clearFilters() {
+    for(auto& curr : p->filters)
+        curr.clear();
+}
 
-    void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
 
-    void Context::setCout(std::ostream* out) { p->cout = out; }
+// allows the user to override procedurally the int options from the command line
+void Context::setOption(const char* option, int value) {
+    setOption(option, toString(value).c_str());
+}
 
-    static class DiscardOStream : public std::ostream
+// allows the user to override procedurally the string options from the command line
+void Context::setOption(const char* option, const char* value) {
+    auto argv   = String("-") + option + "=" + value;
+    auto lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
+}
+
+// users should query this in their main() and exit the program if true
+bool Context::shouldExit() { return p->exit; }
+
+void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
+
+void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+    class : public std::streambuf
     {
     private:
-        class : public std::streambuf
-        {
-        private:
-            // allowing some buffering decreases the amount of calls to overflow
-            char buf[1024];
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
 
-        protected:
-            std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+    protected:
+        std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
 
-            int_type overflow(int_type ch) override {
-                setp(std::begin(buf), std::end(buf));
-                return traits_type::not_eof(ch);
-            }
-        } discardBuf;
-
-    public:
-        DiscardOStream()
-                : std::ostream(&discardBuf) {}
-    } discardOut;
-
-    // the main function that does all the filtering and test running
-    int Context::run() {
-        using namespace detail;
-
-        // save the old context state in case such was setup - for using asserts out of a testing context
-        auto old_cs = g_cs;
-        // this is the current contest
-        g_cs               = p;
-        is_running_in_test = true;
-
-        g_no_colors = p->no_colors;
-        p->resetRunData();
-
-        std::fstream fstr;
-        if(p->cout == nullptr) {
-            if(p->quiet) {
-                p->cout = &discardOut;
-            } else if(p->out.size()) {
-                // to a file if specified
-                fstr.open(p->out.c_str(), std::fstream::out);
-                p->cout = &fstr;
-            } else {
-    #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                // stdout by default
-                p->cout = &std::cout;
-    #else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                return EXIT_FAILURE;
-    #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-            }
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
         }
+    } discardBuf;
 
-        FatalConditionHandler::allocateAltStackMem();
+public:
+    DiscardOStream()
+            : std::ostream(&discardBuf) {}
+} discardOut;
 
-        auto cleanup_and_return = [&]() {
-            FatalConditionHandler::freeAltStackMem();
+// the main function that does all the filtering and test running
+int Context::run() {
+    using namespace detail;
 
-            if(fstr.is_open())
-                fstr.close();
+    // save the old context state in case such was setup - for using asserts out of a testing context
+    auto old_cs = g_cs;
+    // this is the current contest
+    g_cs               = p;
+    is_running_in_test = true;
 
-            // restore context
-            g_cs               = old_cs;
-            is_running_in_test = false;
+    g_no_colors = p->no_colors;
+    p->resetRunData();
 
-            // we have to free the reporters which were allocated when the run started
-            for(auto& curr : p->reporters_currently_used)
-                delete curr;
-            p->reporters_currently_used.clear();
-
-            if(p->numTestCasesFailed && !p->no_exitcode)
-                return EXIT_FAILURE;
-            return EXIT_SUCCESS;
-        };
-
-        // setup default reporter if none is given through the command line
-        if(p->filters[8].empty())
-            p->filters[8].push_back("console");
-
-        // check to see if any of the registered reporters has been selected
-        for(auto& curr : getReporters()) {
-            if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-                p->reporters_currently_used.push_back(curr.second(*g_cs));
-        }
-
-        // TODO: check if there is nothing in reporters_currently_used
-
-        // prepend all listeners
-        for(auto& curr : getListeners())
-            p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
-
-    #ifdef DOCTEST_PLATFORM_WINDOWS
-        if(isDebuggerActive() && p->no_debug_output == false)
-            p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
-    #endif // DOCTEST_PLATFORM_WINDOWS
-
-        // handle version, help and no_run
-        if(p->no_run || p->version || p->help || p->list_reporters) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
-
-            return cleanup_and_return();
-        }
-
-        std::vector<const TestCase*> testArray;
-        for(auto& curr : getRegisteredTests())
-            testArray.push_back(&curr);
-        p->numTestCases = testArray.size();
-
-        // sort the collected records
-        if(!testArray.empty()) {
-            if(p->order_by.compare("file", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
-            } else if(p->order_by.compare("suite", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
-            } else if(p->order_by.compare("name", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
-            } else if(p->order_by.compare("rand", true) == 0) {
-                std::srand(p->rand_seed);
-
-                // random_shuffle implementation
-                const auto first = &testArray[0];
-                for(size_t i = testArray.size() - 1; i > 0; --i) {
-                    int idxToSwap = std::rand() % (i + 1);
-
-                    const auto temp = first[i];
-
-                    first[i]         = first[idxToSwap];
-                    first[idxToSwap] = temp;
-                }
-            } else if(p->order_by.compare("none", true) == 0) {
-                // means no sorting - beneficial for death tests which call into the executable
-                // with a specific test case in mind - we don't want to slow down the startup times
-            }
-        }
-
-        std::set<String> testSuitesPassingFilt;
-
-        bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
-        std::vector<const TestCaseData*> queryResults;
-
-        if(!query_mode)
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
-
-        // invoke the registered functions if they match the filter criteria (or just count them)
-        for(auto& curr : testArray) {
-            const auto& tc = *curr;
-
-            bool skip_me = false;
-            if(tc.m_skip && !p->no_skip)
-                skip_me = true;
-
-            if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-                skip_me = true;
-
-            if(!skip_me)
-                p->numTestCasesPassingFilters++;
-
-            // skip the test if it is not in the execution range
-            if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-               (p->first > p->numTestCasesPassingFilters))
-                skip_me = true;
-
-            if(skip_me) {
-                if(!query_mode)
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
-                continue;
-            }
-
-            // do not execute the test if we are to only count the number of filter passing tests
-            if(p->count)
-                continue;
-
-            // print the name of the test and don't execute it
-            if(p->list_test_cases) {
-                queryResults.push_back(&tc);
-                continue;
-            }
-
-            // print the name of the test suite if not done already and don't execute it
-            if(p->list_test_suites) {
-                if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                    queryResults.push_back(&tc);
-                    testSuitesPassingFilt.insert(tc.m_test_suite);
-                    p->numTestSuitesPassingFilters++;
-                }
-                continue;
-            }
-
-            // execute the test if it passes all the filtering
-            {
-                p->currentTest = &tc;
-
-                p->failure_flags = TestCaseFailureReason::None;
-                p->seconds       = 0;
-
-                // reset atomic counters
-                p->numAssertsFailedCurrentTest_atomic = 0;
-                p->numAssertsCurrentTest_atomic       = 0;
-
-                p->fullyTraversedSubcases.clear();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
-
-                p->timer.start();
-
-                bool run_test = true;
-
-                do {
-                    // reset some of the fields for subcases (except for the set of fully passed ones)
-                    p->reachedLeaf = false;
-                    // May not be empty if previous subcase exited via exception.
-                    p->subcaseStack.clear();
-                    p->currentSubcaseDepth = 0;
-
-                    p->shouldLogCurrentException = true;
-
-                    // reset stuff for logging with INFO()
-                    p->stringifiedContexts.clear();
-
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    try {
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
-                        FatalConditionHandler fatalConditionHandler; // Handle signals
-                        // execute the test
-                        tc.m_test();
-                        fatalConditionHandler.reset();
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    } catch(const TestFailureException&) {
-                        p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                    } catch(...) {
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
-                                                          {translateActiveException(), false});
-                        p->failure_flags |= TestCaseFailureReason::Exception;
-                    }
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                    // exit this loop if enough assertions have failed - even if there are more subcases
-                    if(p->abort_after > 0 &&
-                       p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                        run_test = false;
-                        p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
-                    }
-
-                    if(!p->nextSubcaseStack.empty() && run_test)
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
-                    if(p->nextSubcaseStack.empty())
-                        run_test = false;
-                } while(run_test);
-
-                p->finalizeTestCaseData();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-                p->currentTest = nullptr;
-
-                // stop executing tests if enough assertions have failed
-                if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                    break;
-            }
-        }
-
-        if(!query_mode) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    std::fstream fstr;
+    if(p->cout == nullptr) {
+        if(p->quiet) {
+            p->cout = &discardOut;
+        } else if(p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
         } else {
-            QueryData qdata;
-            qdata.run_stats = g_cs;
-            qdata.data      = queryResults.data();
-            qdata.num_data  = unsigned(queryResults.size());
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            // stdout by default
+            p->cout = &std::cout;
+#else  // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         }
+    }
+
+    FatalConditionHandler::allocateAltStackMem();
+
+    auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
+        if(fstr.is_open())
+            fstr.close();
+
+        // restore context
+        g_cs               = old_cs;
+        is_running_in_test = false;
+
+        // we have to free the reporters which were allocated when the run started
+        for(auto& curr : p->reporters_currently_used)
+            delete curr;
+        p->reporters_currently_used.clear();
+
+        if(p->numTestCasesFailed && !p->no_exitcode)
+            return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    };
+
+    // setup default reporter if none is given through the command line
+    if(p->filters[8].empty())
+        p->filters[8].push_back("console");
+
+    // check to see if any of the registered reporters has been selected
+    for(auto& curr : getReporters()) {
+        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+            p->reporters_currently_used.push_back(curr.second(*g_cs));
+    }
+
+    // TODO: check if there is nothing in reporters_currently_used
+
+    // prepend all listeners
+    for(auto& curr : getListeners())
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if(isDebuggerActive() && p->no_debug_output == false)
+        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    // handle version, help and no_run
+    if(p->no_run || p->version || p->help || p->list_reporters) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
 
         return cleanup_and_return();
     }
+
+    std::vector<const TestCase*> testArray;
+    for(auto& curr : getRegisteredTests())
+        testArray.push_back(&curr);
+    p->numTestCases = testArray.size();
+
+    // sort the collected records
+    if(!testArray.empty()) {
+        if(p->order_by.compare("file", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+        } else if(p->order_by.compare("suite", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+        } else if(p->order_by.compare("name", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+        } else if(p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const auto first = &testArray[0];
+            for(size_t i = testArray.size() - 1; i > 0; --i) {
+                int idxToSwap = std::rand() % (i + 1);
+
+                const auto temp = first[i];
+
+                first[i]         = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        } else if(p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
+        }
+    }
+
+    std::set<String> testSuitesPassingFilt;
+
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData*> queryResults;
+
+    if(!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for(auto& curr : testArray) {
+        const auto& tc = *curr;
+
+        bool skip_me = false;
+        if(tc.m_skip && !p->no_skip)
+            skip_me = true;
+
+        if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+            skip_me = true;
+        if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+            skip_me = true;
+        if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+            skip_me = true;
+        if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+
+        if(!skip_me)
+            p->numTestCasesPassingFilters++;
+
+        // skip the test if it is not in the execution range
+        if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+           (p->first > p->numTestCasesPassingFilters))
+            skip_me = true;
+
+        if(skip_me) {
+            if(!query_mode)
+                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+            continue;
+        }
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if(p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if(p->list_test_cases) {
+            queryResults.push_back(&tc);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if(p->list_test_suites) {
+            if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+                queryResults.push_back(&tc);
+                testSuitesPassingFilt.insert(tc.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &tc;
+
+            p->failure_flags = TestCaseFailureReason::None;
+            p->seconds       = 0;
+
+            // reset atomic counters
+            p->numAssertsFailedCurrentTest_atomic = 0;
+            p->numAssertsCurrentTest_atomic       = 0;
+
+            p->fullyTraversedSubcases.clear();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+            p->timer.start();
+
+            bool run_test = true;
+
+            do {
+                // reset some of the fields for subcases (except for the set of fully passed ones)
+                p->reachedLeaf = false;
+                // May not be empty if previous subcase exited via exception.
+                p->subcaseStack.clear();
+                p->currentSubcaseDepth = 0;
+
+                p->shouldLogCurrentException = true;
+
+                // reset stuff for logging with INFO()
+                p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+       // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
+                    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
+                    FatalConditionHandler fatalConditionHandler;  // Handle signals
+                    // execute the test
+                    tc.m_test();
+                    fatalConditionHandler.reset();
+                    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch(const TestFailureException&) {
+                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
+                } catch(...) {
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
+                                                      {translateActiveException(), false});
+                    p->failure_flags |= TestCaseFailureReason::Exception;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                // exit this loop if enough assertions have failed - even if there are more subcases
+                if(p->abort_after > 0 &&
+                   p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+                    run_test = false;
+                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+                }
+
+                if(!p->nextSubcaseStack.empty() && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if(p->nextSubcaseStack.empty())
+                    run_test = false;
+            } while(run_test);
+
+            p->finalizeTestCaseData();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+            p->currentTest = nullptr;
+
+            // stop executing tests if enough assertions have failed
+            if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                break;
+        }
+    }
+
+    if(!query_mode) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    } else {
+        QueryData qdata;
+        qdata.run_stats = g_cs;
+        qdata.data      = queryResults.data();
+        qdata.num_data  = unsigned(queryResults.size());
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+    }
+
+    return cleanup_and_return();
+}
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/context/options.cpp
+++ b/doctest/parts/private/context/options.cpp
@@ -3,6 +3,8 @@
 
 namespace doctest {
 
-    const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs); }
+const ContextOptions* getContextOptions() {
+    return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs);
+}
 
 } // namespace doctest

--- a/doctest/parts/private/context_scope.cpp
+++ b/doctest/parts/private/context_scope.cpp
@@ -10,12 +10,10 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 namespace detail {
     DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+    ContextScopeBase::ContextScopeBase() { g_infoContexts.push_back(this); }
 
     ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
-        if (other.need_to_destroy) {
+        if(other.need_to_destroy) {
             other.destroy();
         }
         other.need_to_destroy = false;
@@ -29,11 +27,12 @@ namespace detail {
     // ContextScope has been destroyed (base class destructors run after derived class destructors).
     // Instead, ContextScope calls this method directly from its destructor.
     void ContextScopeBase::destroy() {
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&          \
+        (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
         if(std::uncaught_exceptions() > 0) {
-    #else
+#else
         if(std::uncaught_exception()) {
-    #endif
+#endif
             std::ostringstream s;
             this->stringify(&s);
             g_cs->stringifiedContexts.push_back(s.str().c_str());

--- a/doctest/parts/private/context_scope.h
+++ b/doctest/parts/private/context_scope.h
@@ -2,10 +2,9 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
-    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
-}
-} // namespace doctest
+namespace doctest { namespace detail {
+    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*>
+                                g_infoContexts; // for logging with INFO()
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/context_state.h
+++ b/doctest/parts/private/context_state.h
@@ -4,8 +4,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // this holds both parameters from the command line and runtime data for tests
     struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
@@ -24,12 +23,12 @@ namespace detail {
         std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
 
         // stuff for subcases
-        bool reachedLeaf;
-        std::vector<SubcaseSignature> subcaseStack;
-        std::vector<SubcaseSignature> nextSubcaseStack;
+        bool                                   reachedLeaf;
+        std::vector<SubcaseSignature>          subcaseStack;
+        std::vector<SubcaseSignature>          nextSubcaseStack;
         std::unordered_set<unsigned long long> fullyTraversedSubcases;
-        size_t currentSubcaseDepth;
-        Atomic<bool> shouldLogCurrentException;
+        size_t                                 currentSubcaseDepth;
+        Atomic<bool>                           shouldLogCurrentException;
 
         void resetRunData() {
             numTestCases                = 0;
@@ -92,7 +91,6 @@ namespace detail {
     // could be a race or that there wouldn't be a race even if using the context directly
     DOCTEST_THREAD_LOCAL bool g_no_colors;
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/debugger.cpp
+++ b/doctest/parts/private/debugger.cpp
@@ -2,23 +2,25 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 #ifdef DOCTEST_IS_DEBUGGER_ACTIVE
     bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
 #else // DOCTEST_IS_DEBUGGER_ACTIVE
 #ifdef DOCTEST_PLATFORM_LINUX
-    class ErrnoGuard {
+    class ErrnoGuard
+    {
     public:
-        ErrnoGuard() : m_oldErrno(errno) {}
+        ErrnoGuard()
+                : m_oldErrno(errno) {}
         ~ErrnoGuard() { errno = m_oldErrno; }
+
     private:
         int m_oldErrno;
     };
     // See the comments in Catch2 for the reasoning behind this implementation:
     // https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
     bool isDebuggerActive() {
-        ErrnoGuard guard;
+        ErrnoGuard    guard;
         std::ifstream in("/proc/self/status");
         for(std::string line; std::getline(in, line);) {
             static const int PREFIX_LEN = 11;
@@ -61,7 +63,6 @@ namespace detail {
     bool isDebuggerActive() { return false; }
 #endif // Platform
 #endif // DOCTEST_IS_DEBUGGER_ACTIVE
-} // detail
-} // doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/doctest.cpp
+++ b/doctest/parts/private/doctest.cpp
@@ -29,20 +29,17 @@ const char* skipPathFromFilename(const char* file) {
             return forward + 1;
         }
     } else {
-        const auto prefixes = getContextOptions()->strip_file_prefixes;
-        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        const auto        prefixes      = getContextOptions()->strip_file_prefixes;
+        const char        separator     = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
         String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
+        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos) {
             const auto prefix_start = pos;
             pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
 
             const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
+            if(prefix_size > longest_match) {
                 // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
+                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size)) {
                     longest_match = prefix_size;
                 }
             }
@@ -64,16 +61,14 @@ namespace {
     using namespace detail;
 
     DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(unsigned long long a, unsigned long long b) {
-        return (a << 5) + b;
-    }
+    unsigned long long hash(unsigned long long a, unsigned long long b) { return (a << 5) + b; }
 
     // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
     DOCTEST_NO_SANITIZE_INTEGER
     unsigned long long hash(const char* str) {
         unsigned long long hash = 5381;
-        char c;
-        while ((c = *str++))
+        char               c;
+        while((c = *str++))
             hash = ((hash << 5) + hash) + c; // hash * 33 + c
         return hash;
     }
@@ -84,8 +79,8 @@ namespace {
 
     unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
         unsigned long long running = 0;
-        auto end = sigs.begin() + count;
-        for (auto it = sigs.begin(); it != end; it++) {
+        auto               end     = sigs.begin() + count;
+        for(auto it = sigs.begin(); it != end; it++) {
             running = hash(running, hash(*it));
         }
         return running;
@@ -93,13 +88,12 @@ namespace {
 
     unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
         unsigned long long running = 0;
-        for (const SubcaseSignature& sig : sigs) {
+        for(const SubcaseSignature& sig : sigs) {
             running = hash(running, hash(sig));
         }
         return running;
     }
 } // namespace
-
 
 namespace detail {
 
@@ -111,7 +105,8 @@ namespace detail {
     bool ResultBuilder::log() {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+        } else if((m_at & assertType::is_throws_as) &&
+                  (m_at & assertType::is_throws_with)) { //!OCLINT
             m_failed = !m_threw_as || !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
@@ -135,7 +130,8 @@ namespace detail {
         }
 
         return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+               (g_cs->currentTest == nullptr ||
+                !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
 } // namespace detail

--- a/doctest/parts/private/exception_translator.cpp
+++ b/doctest/parts/private/exception_translator.cpp
@@ -3,8 +3,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
@@ -46,7 +45,6 @@ namespace detail {
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/exception_translator.h
+++ b/doctest/parts/private/exception_translator.h
@@ -1,12 +1,10 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     std::vector<const IExceptionTranslator*>& getExceptionTranslators();
-    String translateActiveException();
+    String                                    translateActiveException();
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/exceptions.cpp
+++ b/doctest/parts/private/exceptions.cpp
@@ -3,8 +3,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     bool checkIfShouldThrow(assertType::Enum at) {
         if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
@@ -24,11 +23,10 @@ namespace detail {
         g_cs->shouldLogCurrentException = false;
         throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
     }
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
     void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/exceptions.h
+++ b/doctest/parts/private/exceptions.h
@@ -1,14 +1,13 @@
 #include "doctest/parts/private/prelude.h"
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
     using namespace detail;
 
     template <typename Ex>
     DOCTEST_NORETURN void throw_exception(Ex const& e) {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS
 #ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
         DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
 #else // DOCTEST_CONFIG_HANDLE_EXCEPTION
@@ -26,6 +25,4 @@ namespace {
     throw_exception(std::logic_error(                                                              \
             __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
 #endif // DOCTEST_INTERNAL_ERROR
-} // namespace
-
-} // namespace doctest
+}} // namespace doctest

--- a/doctest/parts/private/filters.h
+++ b/doctest/parts/private/filters.h
@@ -2,8 +2,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
     // matching of a string against a wildcard mask (case sensitivity configurable) taken from
     // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
@@ -45,16 +44,15 @@ namespace {
 
     // checks if the name matches any of the filters (and can be configured what to do when empty)
     bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-        bool caseSensitive) {
-        if (filters.empty() && matchEmpty)
+                    bool caseSensitive) {
+        if(filters.empty() && matchEmpty)
             return true;
-        for (auto& curr : filters)
-            if (wildcmp(name, curr.c_str(), caseSensitive))
+        for(auto& curr : filters)
+            if(wildcmp(name, curr.c_str(), caseSensitive))
                 return true;
         return false;
     }
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -40,8 +40,6 @@ bool operator<(const Approx& lhs, double rhs) { return lhs.m_value < rhs && lhs 
 bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs != rhs; }
 bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
-String toString(const Approx& in) {
-    return "Approx( " + doctest::toString(in.m_value) + " )";
-}
+String toString(const Approx& in) { return "Approx( " + doctest::toString(in.m_value) + " )"; }
 
 } // namespace doctest

--- a/doctest/parts/private/matchers/contains.cpp
+++ b/doctest/parts/private/matchers/contains.cpp
@@ -2,15 +2,14 @@
 
 namespace doctest {
 
-Contains::Contains(const String& str) : string(str) { }
+Contains::Contains(const String& str)
+        : string(str) {}
 
 bool Contains::checkWith(const String& other) const {
     return strstr(other.c_str(), string.c_str()) != nullptr;
 }
 
-String toString(const Contains& in) {
-    return "Contains( " + in.string + " )";
-}
+String toString(const Contains& in) { return "Contains( " + in.string + " )"; }
 
 bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
 bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }

--- a/doctest/parts/private/matchers/is_nan.cpp
+++ b/doctest/parts/private/matchers/is_nan.cpp
@@ -13,7 +13,9 @@ template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
 template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
 
 template <typename F>
-String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
+String toString(IsNaN<F> in) {
+    return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )";
+}
 String toString(IsNaN<float> in) { return toString<float>(in); }
 String toString(IsNaN<double> in) { return toString<double>(in); }
 String toString(IsNaN<double long> in) { return toString<double long>(in); }

--- a/doctest/parts/private/prelude.h
+++ b/doctest/parts/private/prelude.h
@@ -27,7 +27,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <mutex>
 #define DOCTEST_DECLARE_MUTEX(name) std::mutex name;
 #define DOCTEST_DECLARE_STATIC_MUTEX(name) static DOCTEST_DECLARE_MUTEX(name)
-#define DOCTEST_LOCK_MUTEX(name) std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
+#define DOCTEST_LOCK_MUTEX(name)                                                                   \
+    std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
 #else // DOCTEST_CONFIG_NO_MULTITHREADING
 #define DOCTEST_DECLARE_MUTEX(name)
 #define DOCTEST_DECLARE_STATIC_MUTEX(name)
@@ -104,7 +105,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_THREAD_LOCAL
-#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) ||                                                   \
+        DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
 #define DOCTEST_THREAD_LOCAL
 #else // DOCTEST_MSVC
 #define DOCTEST_THREAD_LOCAL thread_local

--- a/doctest/parts/private/reporter.cpp
+++ b/doctest/parts/private/reporter.cpp
@@ -6,35 +6,38 @@
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    int                         IReporter::get_num_active_contexts() { return 0; }
-    const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
-    int                         IReporter::get_num_stringified_contexts() { return 0; }
-    const String*               IReporter::get_stringified_contexts() { return nullptr; }
+int                         IReporter::get_num_active_contexts() { return 0; }
+const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
+int                         IReporter::get_num_stringified_contexts() { return 0; }
+const String*               IReporter::get_stringified_contexts() { return nullptr; }
 
-    int registerReporter(const char*, int, IReporter*) { return 0; }
+int registerReporter(const char*, int, IReporter*) { return 0; }
 
 #else
 
-    DOCTEST_DEFINE_INTERFACE(IReporter)
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
-    int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
-    const IContextScope* const* IReporter::get_active_contexts() {
-        return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
+const IContextScope* const* IReporter::get_active_contexts() {
+    return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
+const String* IReporter::get_stringified_contexts() {
+    return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
+}
+
+namespace detail {
+    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c,
+                              bool isReporter) {
+        if(isReporter)
+            getReporters().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
+        else
+            getListeners().insert(
+                    reporterMap::value_type(reporterMap::key_type(priority, name), c));
     }
-
-    int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
-    const String* IReporter::get_stringified_contexts() {
-        return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
-    }
-
-    namespace detail {
-        void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
-            if(isReporter)
-                getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-            else
-                getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-        }
-    } // namespace detail
+} // namespace detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace doctest

--- a/doctest/parts/private/reporters/common.h
+++ b/doctest/parts/private/reporters/common.h
@@ -8,57 +8,51 @@
 
 namespace doctest {
 
-    void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
-        if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-            0) //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-                << Color::None;
+void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
+    if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
+       0) //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
 
-        if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-        } else if((rb.m_at & assertType::is_throws_as) &&
-                    (rb.m_at & assertType::is_throws_with)) { //!OCLINT
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string.c_str()
-                << "\", " << rb.m_exception_type << " ) " << Color::None;
-            if(rb.m_threw) {
-                if(!rb.m_failed) {
-                    s << "threw as expected!\n";
-                } else {
-                    s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
-                }
+    if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+        s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
+    } else if((rb.m_at & assertType::is_throws_as) &&
+              (rb.m_at & assertType::is_throws_with)) { //!OCLINT
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+          << rb.m_exception_string.c_str() << "\", " << rb.m_exception_type << " ) " << Color::None;
+        if(rb.m_threw) {
+            if(!rb.m_failed) {
+                s << "threw as expected!\n";
             } else {
-                s << "did NOT throw at all!\n";
+                s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
             }
-        } else if(rb.m_at &
-                    assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-                << rb.m_exception_type << " ) " << Color::None
-                << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                                "threw a DIFFERENT exception: ") :
-                                "did NOT throw at all!")
-                << Color::Cyan << rb.m_exception << "\n";
-        } else if(rb.m_at &
-                    assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                << rb.m_exception_string.c_str()
-                << "\" ) " << Color::None
-                << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                                "threw a DIFFERENT exception: ") :
-                                "did NOT throw at all!")
-                << Color::Cyan << rb.m_exception << "\n";
-        } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-                << rb.m_exception << "\n";
         } else {
-            s << (rb.m_threw ? "THREW exception: " :
-                                (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-            if(rb.m_threw)
-                s << rb.m_exception << "\n";
-            else
-                s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
+            s << "did NOT throw at all!\n";
         }
+    } else if(rb.m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
+          << rb.m_exception_type << " ) " << Color::None
+          << (rb.m_threw ?
+                      (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ") :
+                      "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if(rb.m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+          << rb.m_exception_string.c_str() << "\" ) " << Color::None
+          << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ") :
+                           "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception
+          << "\n";
+    } else {
+        s << (rb.m_threw ? "THREW exception: " :
+                           (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+        if(rb.m_threw)
+            s << rb.m_exception << "\n";
+        else
+            s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
     }
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/reporters/console.h
+++ b/doctest/parts/private/reporters/console.h
@@ -11,141 +11,142 @@
 
 namespace doctest {
 
-    struct Whitespace
-    {
-        int nrSpaces;
-        explicit Whitespace(int nr)
-                : nrSpaces(nr) {}
-    };
+struct Whitespace
+{
+    int nrSpaces;
+    explicit Whitespace(int nr)
+            : nrSpaces(nr) {}
+};
 
-    std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-        if(ws.nrSpaces != 0)
-            out << std::setw(ws.nrSpaces) << ' ';
-        return out;
+std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
+    if(ws.nrSpaces != 0)
+        out << std::setw(ws.nrSpaces) << ' ';
+    return out;
+}
+
+struct ConsoleReporter : public IReporter
+{
+    std::ostream&                 s;
+    bool                          hasLoggedCurrentTestStart;
+    std::vector<SubcaseSignature> subcasesStack;
+    size_t                        currentSubcaseLevel;
+    DOCTEST_DECLARE_MUTEX(mutex)
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc;
+
+    ConsoleReporter(const ContextOptions& co)
+            : s(*co.cout)
+            , opt(co) {}
+
+    ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
+            : s(ostr)
+            , opt(co) {}
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
+    // =========================================================================================
+
+    void separator_to_stream() {
+        s << Color::Yellow
+          << "==============================================================================="
+             "\n";
     }
 
-    struct ConsoleReporter : public IReporter
-    {
-        std::ostream&                 s;
-        bool                          hasLoggedCurrentTestStart;
-        std::vector<SubcaseSignature> subcasesStack;
-        size_t                        currentSubcaseLevel;
-        DOCTEST_DECLARE_MUTEX(mutex)
+    const char* getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str) {
+        if(success)
+            return success_str;
+        return failureString(at);
+    }
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc;
+    Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
+        return success                    ? Color::BrightGreen :
+               (at & assertType::is_warn) ? Color::Yellow :
+                                            Color::Red;
+    }
 
-        ConsoleReporter(const ContextOptions& co)
-                : s(*co.cout)
-                , opt(co) {}
+    void successOrFailColoredStringToStream(bool success, assertType::Enum at,
+                                            const char* success_str = "SUCCESS") {
+        s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str)
+          << ": ";
+    }
 
-        ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-                : s(ostr)
-                , opt(co) {}
+    void log_contexts() {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto contexts = get_active_contexts();
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
-        // =========================================================================================
-
-        void separator_to_stream() {
-            s << Color::Yellow
-              << "==============================================================================="
-                 "\n";
-        }
-
-        const char* getSuccessOrFailString(bool success, assertType::Enum at,
-                                           const char* success_str) {
-            if(success)
-                return success_str;
-            return failureString(at);
-        }
-
-        Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
-            return success ? Color::BrightGreen :
-                             (at & assertType::is_warn) ? Color::Yellow : Color::Red;
-        }
-
-        void successOrFailColoredStringToStream(bool success, assertType::Enum at,
-                                                const char* success_str = "SUCCESS") {
-            s << getSuccessOrFailColor(success, at)
-              << getSuccessOrFailString(success, at, success_str) << ": ";
-        }
-
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto contexts = get_active_contexts();
-
-                s << Color::None << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
-                    s << (i == 0 ? "" : "          ");
-                    contexts[i]->stringify(&s);
-                    s << "\n";
-                }
+            s << Color::None << "  logged: ";
+            for(int i = 0; i < num_contexts; ++i) {
+                s << (i == 0 ? "" : "          ");
+                contexts[i]->stringify(&s);
+                s << "\n";
             }
-
-            s << "\n";
         }
 
-        // this was requested to be made virtual so users could override it
-        virtual void file_line_to_stream(const char* file, int line,
-                                        const char* tail = "") {
-            s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
-            << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-            << (opt.gnu_file_line ? ":" : "):") << tail;
+        s << "\n";
+    }
+
+    // this was requested to be made virtual so users could override it
+    virtual void file_line_to_stream(const char* file, int line, const char* tail = "") {
+        s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+          << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+          << (opt.gnu_file_line ? ":" : "):") << tail;
+    }
+
+    void logTestStart() {
+        if(hasLoggedCurrentTestStart)
+            return;
+
+        separator_to_stream();
+        file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
+        if(tc->m_description)
+            s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
+        if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+        if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+            s << Color::Yellow << "TEST CASE:  ";
+        s << Color::None << tc->m_name << "\n";
+
+        for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+            if(subcasesStack[i].m_name[0] != '\0')
+                s << "  " << subcasesStack[i].m_name << "\n";
         }
 
-        void logTestStart() {
-            if(hasLoggedCurrentTestStart)
-                return;
-
-            separator_to_stream();
-            file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
-            if(tc->m_description)
-                s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-            if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
-                s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-            if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-                s << Color::Yellow << "TEST CASE:  ";
-            s << Color::None << tc->m_name << "\n";
-
-            for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+        if(currentSubcaseLevel != subcasesStack.size()) {
+            s << Color::Yellow
+              << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n"
+              << Color::None;
+            for(size_t i = 0; i < subcasesStack.size(); ++i) {
                 if(subcasesStack[i].m_name[0] != '\0')
                     s << "  " << subcasesStack[i].m_name << "\n";
             }
-
-            if(currentSubcaseLevel != subcasesStack.size()) {
-                s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
-                for(size_t i = 0; i < subcasesStack.size(); ++i) {
-                    if(subcasesStack[i].m_name[0] != '\0')
-                        s << "  " << subcasesStack[i].m_name << "\n";
-                }
-            }
-
-            s << "\n";
-
-            hasLoggedCurrentTestStart = true;
         }
 
-        void printVersion() {
-            if(opt.no_version == false)
-                s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-                  << DOCTEST_VERSION_STR << "\"\n";
-        }
+        s << "\n";
 
-        void printIntro() {
-            if(opt.no_intro == false) {
-                printVersion();
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
-            }
-        }
+        hasLoggedCurrentTestStart = true;
+    }
 
-        void printHelp() {
-            int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+    void printVersion() {
+        if(opt.no_version == false)
+            s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
+              << DOCTEST_VERSION_STR << "\"\n";
+    }
+
+    void printIntro() {
+        if(opt.no_intro == false) {
             printVersion();
-            // clang-format off
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+        }
+    }
+
+    void printHelp() {
+        int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+        printVersion();
+        // clang-format off
             s << Color::Cyan << "[doctest]\n" << Color::None;
             s << Color::Cyan << "[doctest] " << Color::None;
             s << "boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n";
@@ -255,231 +256,240 @@ namespace doctest {
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
               << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
             // ================================================================================== << 79
-            // clang-format on
+        // clang-format on
 
-            s << Color::Cyan << "\n[doctest] " << Color::None;
-            s << "for more information visit the project documentation\n\n";
-        }
+        s << Color::Cyan << "\n[doctest] " << Color::None;
+        s << "for more information visit the project documentation\n\n";
+    }
 
-        void printRegisteredReporters() {
-            printVersion();
-            auto printReporters = [this] (const reporterMap& reporters, const char* type) {
-                if(reporters.size()) {
-                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
-                    for(auto& curr : reporters)
-                        s << "priority: " << std::setw(5) << curr.first.first
-                          << " name: " << curr.first.second << "\n";
-                }
-            };
-            printReporters(getListeners(), "listeners");
-            printReporters(getReporters(), "reporters");
-        }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData& in) override {
-            if(opt.version) {
-                printVersion();
-            } else if(opt.help) {
-                printHelp();
-            } else if(opt.list_reporters) {
-                printRegisteredReporters();
-            } else if(opt.count || opt.list_test_cases) {
-                if(opt.list_test_cases) {
-                    s << Color::Cyan << "[doctest] " << Color::None
-                      << "listing all test case names\n";
-                    separator_to_stream();
-                }
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i]->m_name << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-
-            } else if(opt.list_test_suites) {
-                s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
-                separator_to_stream();
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i]->m_test_suite << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "test suites with unskipped test cases passing the current filters: "
-                  << g_cs->numTestSuitesPassingFilters << "\n";
+    void printRegisteredReporters() {
+        printVersion();
+        auto printReporters = [this](const reporterMap& reporters, const char* type) {
+            if(reporters.size()) {
+                s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type
+                  << "\n";
+                for(auto& curr : reporters)
+                    s << "priority: " << std::setw(5) << curr.first.first
+                      << " name: " << curr.first.second << "\n";
             }
-        }
+        };
+        printReporters(getListeners(), "listeners");
+        printReporters(getReporters(), "reporters");
+    }
 
-        void test_run_start() override {
-            if(!opt.minimal)
-                printIntro();
-        }
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
 
-        void test_run_end(const TestRunStats& p) override {
-            if(opt.minimal && p.numTestCasesFailed == 0)
-                return;
+    void report_query(const QueryData& in) override {
+        if(opt.version) {
+            printVersion();
+        } else if(opt.help) {
+            printHelp();
+        } else if(opt.list_reporters) {
+            printRegisteredReporters();
+        } else if(opt.count || opt.list_test_cases) {
+            if(opt.list_test_cases) {
+                s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
+                separator_to_stream();
+            }
+
+            for(unsigned i = 0; i < in.num_data; ++i)
+                s << Color::None << in.data[i]->m_name << "\n";
 
             separator_to_stream();
-            s << std::dec;
 
-            auto totwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-            auto passwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-            auto failwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
-              << p.numTestCasesPassingFilters << " | "
-              << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                          Color::Green)
-              << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-              << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
-            if(opt.no_skipped_summary == false) {
-                const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
-                  << " skipped" << Color::None;
-            }
-            s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
-              << p.numAsserts << " | "
-              << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
-              << p.numAssertsFailed << " failed" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
-              << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
-              << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+              << "unskipped test cases passing the current filters: "
+              << g_cs->numTestCasesPassingFilters << "\n";
+
+        } else if(opt.list_test_suites) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
+            separator_to_stream();
+
+            for(unsigned i = 0; i < in.num_data; ++i)
+                s << Color::None << in.data[i]->m_test_suite << "\n";
+
+            separator_to_stream();
+
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "unskipped test cases passing the current filters: "
+              << g_cs->numTestCasesPassingFilters << "\n";
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "test suites with unskipped test cases passing the current filters: "
+              << g_cs->numTestSuitesPassingFilters << "\n";
         }
+    }
 
-        void test_case_start(const TestCaseData& in) override {
-            hasLoggedCurrentTestStart = false;
-            tc                        = &in;
-            subcasesStack.clear();
-            currentSubcaseLevel = 0;
+    void test_run_start() override {
+        if(!opt.minimal)
+            printIntro();
+    }
+
+    void test_run_end(const TestRunStats& p) override {
+        if(opt.minimal && p.numTestCasesFailed == 0)
+            return;
+
+        separator_to_stream();
+        s << std::dec;
+
+        auto totwidth = int(
+                std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters,
+                                                             static_cast<unsigned>(p.numAsserts))) +
+                                1)));
+        auto passwidth = int(
+                std::ceil(log10(static_cast<double>(std::max(
+                                        p.numTestCasesPassingFilters - p.numTestCasesFailed,
+                                        static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) +
+                                1)));
+        auto       failwidth      = int(std::ceil(
+                log10(static_cast<double>(std::max(p.numTestCasesFailed,
+                                                              static_cast<unsigned>(p.numAssertsFailed))) +
+                                 1)));
+        const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+        s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
+          << p.numTestCasesPassingFilters << " | "
+          << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green)
+          << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed
+          << " passed" << Color::None << " | "
+          << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
+          << p.numTestCasesFailed << " failed" << Color::None << " |";
+        if(opt.no_skipped_summary == false) {
+            const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
+            s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped << " skipped"
+              << Color::None;
         }
+        s << "\n";
+        s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
+          << p.numAsserts << " | "
+          << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+          << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+          << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
+          << p.numAssertsFailed << " failed" << Color::None << " |\n";
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
+          << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+    }
 
-        void test_case_reenter(const TestCaseData&) override {
-            subcasesStack.clear();
-        }
+    void test_case_start(const TestCaseData& in) override {
+        hasLoggedCurrentTestStart = false;
+        tc                        = &in;
+        subcasesStack.clear();
+        currentSubcaseLevel = 0;
+    }
 
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            if(tc->m_no_output)
-                return;
+    void test_case_reenter(const TestCaseData&) override { subcasesStack.clear(); }
 
-            // log the preamble of the test case only if there is something
-            // else to print - something other than that an assert has failed
-            if(opt.duration ||
-               (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
-                logTestStart();
+    void test_case_end(const CurrentTestCaseStats& st) override {
+        if(tc->m_no_output)
+            return;
 
-            if(opt.duration)
-                s << Color::None << std::setprecision(6) << std::fixed << st.seconds
-                  << " s: " << tc->m_name << "\n";
-
-            if(st.failure_flags & TestCaseFailureReason::Timeout)
-                s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-                  << std::fixed << tc->m_timeout << "!\n";
-
-            if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
-                s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
-                s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
-                s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-                s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
-                  << " times so marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
-                s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
-                  << " times as expected so marking it as not failed!\n";
-            }
-            if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
-                s << Color::Red << "Aborting - too many failed asserts!\n";
-            }
-            s << Color::None; // lgtm [cpp/useless-expression]
-        }
-
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-            if(tc->m_no_output)
-                return;
-
+        // log the preamble of the test case only if there is something
+        // else to print - something other than that an assert has failed
+        if(opt.duration ||
+           (st.failure_flags &&
+            st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
             logTestStart();
 
-            file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
-            successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
-                                                                   assertType::is_check);
-            s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
-              << Color::Cyan << e.error_string << "\n";
+        if(opt.duration)
+            s << Color::None << std::setprecision(6) << std::fixed << st.seconds
+              << " s: " << tc->m_name << "\n";
 
-            int num_stringified_contexts = get_num_stringified_contexts();
-            if(num_stringified_contexts) {
-                auto stringified_contexts = get_stringified_contexts();
-                s << Color::None << "  logged: ";
-                for(int i = num_stringified_contexts; i > 0; --i) {
-                    s << (i == num_stringified_contexts ? "" : "          ")
-                      << stringified_contexts[i - 1] << "\n";
-                }
+        if(st.failure_flags & TestCaseFailureReason::Timeout)
+            s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
+              << std::fixed << tc->m_timeout << "!\n";
+
+        if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+            s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
+        } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+            s << Color::Yellow << "Failed as expected so marking it as not failed\n";
+        } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+            s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
+        } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+            s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
+              << " times so marking it as failed!\n";
+        } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+            s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
+              << " times as expected so marking it as not failed!\n";
+        }
+        if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+            s << Color::Red << "Aborting - too many failed asserts!\n";
+        }
+        s << Color::None; // lgtm [cpp/useless-expression]
+    }
+
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+        if(tc->m_no_output)
+            return;
+
+        logTestStart();
+
+        file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
+        successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
+                                                               assertType::is_check);
+        s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
+          << Color::Cyan << e.error_string << "\n";
+
+        int num_stringified_contexts = get_num_stringified_contexts();
+        if(num_stringified_contexts) {
+            auto stringified_contexts = get_stringified_contexts();
+            s << Color::None << "  logged: ";
+            for(int i = num_stringified_contexts; i > 0; --i) {
+                s << (i == num_stringified_contexts ? "" : "          ")
+                  << stringified_contexts[i - 1] << "\n";
             }
-            s << "\n" << Color::None;
         }
+        s << "\n" << Color::None;
+    }
 
-        void subcase_start(const SubcaseSignature& subc) override {
-            subcasesStack.push_back(subc);
-            ++currentSubcaseLevel;
-            hasLoggedCurrentTestStart = false;
-        }
+    void subcase_start(const SubcaseSignature& subc) override {
+        subcasesStack.push_back(subc);
+        ++currentSubcaseLevel;
+        hasLoggedCurrentTestStart = false;
+    }
 
-        void subcase_end() override {
-            --currentSubcaseLevel;
-            hasLoggedCurrentTestStart = false;
-        }
+    void subcase_end() override {
+        --currentSubcaseLevel;
+        hasLoggedCurrentTestStart = false;
+    }
 
-        void log_assert(const AssertData& rb) override {
-            if((!rb.m_failed && !opt.success) || tc->m_no_output)
-                return;
+    void log_assert(const AssertData& rb) override {
+        if((!rb.m_failed && !opt.success) || tc->m_no_output)
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            logTestStart();
+        logTestStart();
 
-            file_line_to_stream(rb.m_file, rb.m_line, " ");
-            successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
+        file_line_to_stream(rb.m_file, rb.m_line, " ");
+        successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
 
-            fulltext_log_assert_to_stream(s, rb);
+        fulltext_log_assert_to_stream(s, rb);
 
-            log_contexts();
-        }
+        log_contexts();
+    }
 
-        void log_message(const MessageData& mb) override {
-            if(tc->m_no_output)
-                return;
+    void log_message(const MessageData& mb) override {
+        if(tc->m_no_output)
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            logTestStart();
+        logTestStart();
 
-            file_line_to_stream(mb.m_file, mb.m_line, " ");
-            s << getSuccessOrFailColor(false, mb.m_severity)
-              << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE") << ": ";
-            s << Color::None << mb.m_string << "\n";
-            log_contexts();
-        }
+        file_line_to_stream(mb.m_file, mb.m_line, " ");
+        s << getSuccessOrFailColor(false, mb.m_severity)
+          << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE")
+          << ": ";
+        s << Color::None << mb.m_string << "\n";
+        log_contexts();
+    }
 
-        void test_case_skipped(const TestCaseData&) override {}
-    };
+    void test_case_skipped(const TestCaseData&) override {}
+};
 
-    DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
+DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
 
 } // namespace doctest
 

--- a/doctest/parts/private/reporters/debug_output_window.h
+++ b/doctest/parts/private/reporters/debug_output_window.h
@@ -3,8 +3,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace {
+namespace doctest { namespace {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) ::OutputDebugStringA(text)
@@ -49,7 +48,6 @@ namespace {
     DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-} // namespace
-} // namespace doctest
+}} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/reporters/junit.h
+++ b/doctest/parts/private/reporters/junit.h
@@ -4,245 +4,252 @@
 
 namespace doctest {
 
-    // TODO:
-    // - log_message()
-    // - respond to queries
-    // - honor remaining options
-    // - more attributes in tags
-    struct JUnitReporter : public IReporter
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter
+{
+    XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+    Timer               timer;
+    std::vector<String> deepestSubcaseStackNames;
+
+    struct JUnitTestCaseData
     {
-        XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
-        Timer timer;
-        std::vector<String> deepestSubcaseStackNames;
+        static std::string getCurrentTimestamp() {
+            // Beware, this is not reentrant because of backward compatibility issues
+            // Also, UTC only, again because of backward compatibility (%z is C++11)
+            time_t rawtime;
+            std::time(&rawtime);
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
-        struct JUnitTestCaseData
-        {
-            static std::string getCurrentTimestamp() {
-                // Beware, this is not reentrant because of backward compatibility issues
-                // Also, UTC only, again because of backward compatibility (%z is C++11)
-                time_t rawtime;
-                std::time(&rawtime);
-                auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
-
-                std::tm timeInfo;
+            std::tm timeInfo;
 #ifdef DOCTEST_PLATFORM_WINDOWS
-                gmtime_s(&timeInfo, &rawtime);
-#else // DOCTEST_PLATFORM_WINDOWS
-                gmtime_r(&rawtime, &timeInfo);
+            gmtime_s(&timeInfo, &rawtime);
+#else  // DOCTEST_PLATFORM_WINDOWS
+            gmtime_r(&rawtime, &timeInfo);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-                char timeStamp[timeStampSize];
-                const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            char              timeStamp[timeStampSize];
+            const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
-                std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
-                return std::string(timeStamp);
-            }
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+            return std::string(timeStamp);
+        }
 
-            struct JUnitTestMessage
-            {
-                JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
-                    : message(_message), type(_type), details(_details) {}
+        struct JUnitTestMessage
+        {
+            JUnitTestMessage(const std::string& _message, const std::string& _type,
+                             const std::string& _details)
+                    : message(_message)
+                    , type(_type)
+                    , details(_details) {}
 
-                JUnitTestMessage(const std::string& _message, const std::string& _details)
-                    : message(_message), type(), details(_details) {}
+            JUnitTestMessage(const std::string& _message, const std::string& _details)
+                    : message(_message)
+                    , type()
+                    , details(_details) {}
 
-                std::string message, type, details;
-            };
-
-            struct JUnitTestCase
-            {
-                JUnitTestCase(const std::string& _classname, const std::string& _name)
-                    : classname(_classname), name(_name), time(0), failures() {}
-
-                std::string classname, name;
-                double time;
-                std::vector<JUnitTestMessage> failures, errors;
-            };
-
-            void add(const std::string& classname, const std::string& name) {
-                testcases.emplace_back(classname, name);
-            }
-
-            void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
-                for(auto& curr: nameStack)
-                    if(curr.size())
-                        testcases.back().name += std::string("/") + curr.c_str();
-            }
-
-            void addTime(double time) {
-                if(time < 1e-4)
-                    time = 0;
-                testcases.back().time = time;
-                totalSeconds += time;
-            }
-
-            void addFailure(const std::string& message, const std::string& type, const std::string& details) {
-                testcases.back().failures.emplace_back(message, type, details);
-                ++totalFailures;
-            }
-
-            void addError(const std::string& message, const std::string& details) {
-                testcases.back().errors.emplace_back(message, details);
-                ++totalErrors;
-            }
-
-            std::vector<JUnitTestCase> testcases;
-            double totalSeconds = 0;
-            int totalErrors = 0, totalFailures = 0;
+            std::string message, type, details;
         };
 
-        JUnitTestCaseData testCaseData;
+        struct JUnitTestCase
+        {
+            JUnitTestCase(const std::string& _classname, const std::string& _name)
+                    : classname(_classname)
+                    , name(_name)
+                    , time(0)
+                    , failures() {}
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+            std::string                   classname, name;
+            double                        time;
+            std::vector<JUnitTestMessage> failures, errors;
+        };
 
-        JUnitReporter(const ContextOptions& co)
-                : xml(*co.cout)
-                , opt(co) {}
-
-        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData&) override {
-            xml.writeDeclaration();
+        void add(const std::string& classname, const std::string& name) {
+            testcases.emplace_back(classname, name);
         }
 
-        void test_run_start() override {
-            xml.writeDeclaration();
+        void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
+            for(auto& curr : nameStack)
+                if(curr.size())
+                    testcases.back().name += std::string("/") + curr.c_str();
         }
 
-        void test_run_end(const TestRunStats& p) override {
-            // remove .exe extension - mainly to have the same output on UNIX and Windows
-            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+        void addTime(double time) {
+            if(time < 1e-4)
+                time = 0;
+            testcases.back().time = time;
+            totalSeconds += time;
+        }
+
+        void addFailure(const std::string& message, const std::string& type,
+                        const std::string& details) {
+            testcases.back().failures.emplace_back(message, type, details);
+            ++totalFailures;
+        }
+
+        void addError(const std::string& message, const std::string& details) {
+            testcases.back().errors.emplace_back(message, details);
+            ++totalErrors;
+        }
+
+        std::vector<JUnitTestCase> testcases;
+        double                     totalSeconds = 0;
+        int                        totalErrors = 0, totalFailures = 0;
+    };
+
+    JUnitTestCaseData testCaseData;
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc = nullptr;
+
+    JUnitReporter(const ContextOptions& co)
+            : xml(*co.cout)
+            , opt(co) {}
+
+    unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData&) override { xml.writeDeclaration(); }
+
+    void test_run_start() override { xml.writeDeclaration(); }
+
+    void test_run_end(const TestRunStats& p) override {
+        // remove .exe extension - mainly to have the same output on UNIX and Windows
+        std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-            if(binary_name.rfind(".exe") != std::string::npos)
-                binary_name = binary_name.substr(0, binary_name.length() - 4);
+        if(binary_name.rfind(".exe") != std::string::npos)
+            binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
-            xml.startElement("testsuites");
-            xml.startElement("testsuite").writeAttribute("name", binary_name)
-                    .writeAttribute("errors", testCaseData.totalErrors)
-                    .writeAttribute("failures", testCaseData.totalFailures)
-                    .writeAttribute("tests", p.numAsserts);
-            if(opt.no_time_in_output == false) {
-                xml.writeAttribute("time", testCaseData.totalSeconds);
-                xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
-            }
-            if(opt.no_version == false)
-                xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
+        xml.startElement("testsuites");
+        xml.startElement("testsuite")
+                .writeAttribute("name", binary_name)
+                .writeAttribute("errors", testCaseData.totalErrors)
+                .writeAttribute("failures", testCaseData.totalFailures)
+                .writeAttribute("tests", p.numAsserts);
+        if(opt.no_time_in_output == false) {
+            xml.writeAttribute("time", testCaseData.totalSeconds);
+            xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
+        }
+        if(opt.no_version == false)
+            xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
 
-            for(const auto& testCase : testCaseData.testcases) {
-                xml.startElement("testcase")
+        for(const auto& testCase : testCaseData.testcases) {
+            xml.startElement("testcase")
                     .writeAttribute("classname", testCase.classname)
                     .writeAttribute("name", testCase.name);
-                if(opt.no_time_in_output == false)
-                    xml.writeAttribute("time", testCase.time);
-                // This is not ideal, but it should be enough to mimic gtest's junit output.
-                xml.writeAttribute("status", "run");
+            if(opt.no_time_in_output == false)
+                xml.writeAttribute("time", testCase.time);
+            // This is not ideal, but it should be enough to mimic gtest's junit output.
+            xml.writeAttribute("status", "run");
 
-                for(const auto& failure : testCase.failures) {
-                    xml.scopedElement("failure")
+            for(const auto& failure : testCase.failures) {
+                xml.scopedElement("failure")
                         .writeAttribute("message", failure.message)
                         .writeAttribute("type", failure.type)
                         .writeText(failure.details, false);
-                }
+            }
 
-                for(const auto& error : testCase.errors) {
-                    xml.scopedElement("error")
+            for(const auto& error : testCase.errors) {
+                xml.scopedElement("error")
                         .writeAttribute("message", error.message)
                         .writeText(error.details);
-                }
-
-                xml.endElement();
             }
-            xml.endElement();
+
             xml.endElement();
         }
+        xml.endElement();
+        xml.endElement();
+    }
 
-        void test_case_start(const TestCaseData& in) override {
-            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
-            timer.start();
-        }
+    void test_case_start(const TestCaseData& in) override {
+        testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+        timer.start();
+    }
 
-        void test_case_reenter(const TestCaseData& in) override {
-            testCaseData.addTime(timer.getElapsedSeconds());
-            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
-            deepestSubcaseStackNames.clear();
+    void test_case_reenter(const TestCaseData& in) override {
+        testCaseData.addTime(timer.getElapsedSeconds());
+        testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+        deepestSubcaseStackNames.clear();
 
-            timer.start();
-            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
-        }
+        timer.start();
+        testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+    }
 
-        void test_case_end(const CurrentTestCaseStats&) override {
-            testCaseData.addTime(timer.getElapsedSeconds());
-            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
-            deepestSubcaseStackNames.clear();
-        }
+    void test_case_end(const CurrentTestCaseStats&) override {
+        testCaseData.addTime(timer.getElapsedSeconds());
+        testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+        deepestSubcaseStackNames.clear();
+    }
 
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-            testCaseData.addError("exception", e.error_string.c_str());
-        }
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+        testCaseData.addError("exception", e.error_string.c_str());
+    }
 
-        void subcase_start(const SubcaseSignature& in) override {
-            deepestSubcaseStackNames.push_back(in.m_name);
-        }
+    void subcase_start(const SubcaseSignature& in) override {
+        deepestSubcaseStackNames.push_back(in.m_name);
+    }
 
-        void subcase_end() override {}
+    void subcase_end() override {}
 
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed) // report only failures & ignore the `success` option
-                return;
+    void log_assert(const AssertData& rb) override {
+        if(!rb.m_failed) // report only failures & ignore the `success` option
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            std::ostringstream os;
-            os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
-              << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+        std::ostringstream os;
+        os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(rb.m_line)
+           << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
-            fulltext_log_assert_to_stream(os, rb);
-            log_contexts(os);
-            testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
-        }
+        fulltext_log_assert_to_stream(os, rb);
+        log_contexts(os);
+        testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
+    }
 
-        void log_message(const MessageData& mb) override {
-            if(mb.m_severity & assertType::is_warn) // report only failures
-                return;
+    void log_message(const MessageData& mb) override {
+        if(mb.m_severity & assertType::is_warn) // report only failures
+            return;
 
-            DOCTEST_LOCK_MUTEX(mutex)
+        DOCTEST_LOCK_MUTEX(mutex)
 
-            std::ostringstream os;
-            os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(")
-              << line(mb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+        std::ostringstream os;
+        os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(mb.m_line)
+           << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
-            os << mb.m_string.c_str() << "\n";
-            log_contexts(os);
+        os << mb.m_string.c_str() << "\n";
+        log_contexts(os);
 
-            testCaseData.addFailure(mb.m_string.c_str(),
-                mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str());
-        }
+        testCaseData.addFailure(mb.m_string.c_str(),
+                                mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL",
+                                os.str());
+    }
 
-        void test_case_skipped(const TestCaseData&) override {}
+    void test_case_skipped(const TestCaseData&) override {}
 
-        void log_contexts(std::ostringstream& s) {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto contexts = get_active_contexts();
+    void log_contexts(std::ostringstream& s) {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto contexts = get_active_contexts();
 
-                s << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
-                    s << (i == 0 ? "" : "          ");
-                    contexts[i]->stringify(&s);
-                    s << std::endl;
-                }
+            s << "  logged: ";
+            for(int i = 0; i < num_contexts; ++i) {
+                s << (i == 0 ? "" : "          ");
+                contexts[i]->stringify(&s);
+                s << std::endl;
             }
         }
-    };
+    }
+};
 
-    DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
 
 } // namespace doctest

--- a/doctest/parts/private/reporters/xml.h
+++ b/doctest/parts/private/reporters/xml.h
@@ -5,242 +5,242 @@
 
 namespace doctest {
 
-    struct XmlReporter : public IReporter
-    {
-        XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
+struct XmlReporter : public IReporter
+{
+    XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions& opt;
+    const TestCaseData*   tc = nullptr;
 
-        XmlReporter(const ContextOptions& co)
-                : xml(*co.cout)
-                , opt(co) {}
+    XmlReporter(const ContextOptions& co)
+            : xml(*co.cout)
+            , opt(co) {}
 
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto              contexts = get_active_contexts();
-                std::stringstream ss;
-                for(int i = 0; i < num_contexts; ++i) {
-                    contexts[i]->stringify(&ss);
-                    xml.scopedElement("Info").writeText(ss.str());
-                    ss.str("");
-                }
+    void log_contexts() {
+        int num_contexts = get_num_active_contexts();
+        if(num_contexts) {
+            auto              contexts = get_active_contexts();
+            std::stringstream ss;
+            for(int i = 0; i < num_contexts; ++i) {
+                contexts[i]->stringify(&ss);
+                xml.scopedElement("Info").writeText(ss.str());
+                ss.str("");
             }
         }
+    }
 
-        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+    unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
 
-        void test_case_start_impl(const TestCaseData& in) {
-            bool open_ts_tag = false;
-            if(tc != nullptr) { // we have already opened a test suite
-                if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
-                    xml.endElement();
-                    open_ts_tag = true;
-                }
+    void test_case_start_impl(const TestCaseData& in) {
+        bool open_ts_tag = false;
+        if(tc != nullptr) { // we have already opened a test suite
+            if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+                xml.endElement();
+                open_ts_tag = true;
             }
-            else {
-                open_ts_tag = true; // first test case ==> first test suite
-            }
-
-            if(open_ts_tag) {
-                xml.startElement("TestSuite");
-                xml.writeAttribute("name", in.m_test_suite);
-            }
-
-            tc = &in;
-            xml.startElement("TestCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
-                    .writeAttribute("line", line(in.m_line))
-                    .writeAttribute("description", in.m_description);
-
-            if(Approx(in.m_timeout) != 0)
-                xml.writeAttribute("timeout", in.m_timeout);
-            if(in.m_may_fail)
-                xml.writeAttribute("may_fail", true);
-            if(in.m_should_fail)
-                xml.writeAttribute("should_fail", true);
+        } else {
+            open_ts_tag = true; // first test case ==> first test suite
         }
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
+        if(open_ts_tag) {
+            xml.startElement("TestSuite");
+            xml.writeAttribute("name", in.m_test_suite);
+        }
 
-        void report_query(const QueryData& in) override {
-            test_run_start();
-            if(opt.list_reporters) {
-                for(auto& curr : getListeners())
-                    xml.scopedElement("Listener")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-                for(auto& curr : getReporters())
-                    xml.scopedElement("Reporter")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-            } else if(opt.count || opt.list_test_cases) {
-                for(unsigned i = 0; i < in.num_data; ++i) {
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+        tc = &in;
+        xml.startElement("TestCase")
+                .writeAttribute("name", in.m_name)
+                .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+                .writeAttribute("line", line(in.m_line))
+                .writeAttribute("description", in.m_description);
+
+        if(Approx(in.m_timeout) != 0)
+            xml.writeAttribute("timeout", in.m_timeout);
+        if(in.m_may_fail)
+            xml.writeAttribute("may_fail", true);
+        if(in.m_should_fail)
+            xml.writeAttribute("should_fail", true);
+    }
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData& in) override {
+        test_run_start();
+        if(opt.list_reporters) {
+            for(auto& curr : getListeners())
+                xml.scopedElement("Listener")
+                        .writeAttribute("priority", curr.first.first)
+                        .writeAttribute("name", curr.first.second);
+            for(auto& curr : getReporters())
+                xml.scopedElement("Reporter")
+                        .writeAttribute("priority", curr.first.first)
+                        .writeAttribute("name", curr.first.second);
+        } else if(opt.count || opt.list_test_cases) {
+            for(unsigned i = 0; i < in.num_data; ++i) {
+                xml.scopedElement("TestCase")
+                        .writeAttribute("name", in.data[i]->m_name)
                         .writeAttribute("testsuite", in.data[i]->m_test_suite)
-                        .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
+                        .writeAttribute("filename",
+                                        skipPathFromFilename(in.data[i]->m_file.c_str()))
                         .writeAttribute("line", line(in.data[i]->m_line))
                         .writeAttribute("skipped", in.data[i]->m_skip);
-                }
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-            } else if(opt.list_test_suites) {
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-                xml.scopedElement("OverallResultsTestSuites")
-                        .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
             }
-            xml.endElement();
+            xml.scopedElement("OverallResultsTestCases")
+                    .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+        } else if(opt.list_test_suites) {
+            for(unsigned i = 0; i < in.num_data; ++i)
+                xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
+            xml.scopedElement("OverallResultsTestCases")
+                    .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+            xml.scopedElement("OverallResultsTestSuites")
+                    .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
         }
+        xml.endElement();
+    }
 
-        void test_run_start() override {
-            xml.writeDeclaration();
+    void test_run_start() override {
+        xml.writeDeclaration();
 
-            // remove .exe extension - mainly to have the same output on UNIX and Windows
-            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+        // remove .exe extension - mainly to have the same output on UNIX and Windows
+        std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-            if(binary_name.rfind(".exe") != std::string::npos)
-                binary_name = binary_name.substr(0, binary_name.length() - 4);
+        if(binary_name.rfind(".exe") != std::string::npos)
+            binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-            xml.startElement("doctest").writeAttribute("binary", binary_name);
-            if(opt.no_version == false)
-                xml.writeAttribute("version", DOCTEST_VERSION_STR);
+        xml.startElement("doctest").writeAttribute("binary", binary_name);
+        if(opt.no_version == false)
+            xml.writeAttribute("version", DOCTEST_VERSION_STR);
 
-            // only the consequential ones (TODO: filters)
-            xml.scopedElement("Options")
-                    .writeAttribute("order_by", opt.order_by.c_str())
-                    .writeAttribute("rand_seed", opt.rand_seed)
-                    .writeAttribute("first", opt.first)
-                    .writeAttribute("last", opt.last)
-                    .writeAttribute("abort_after", opt.abort_after)
-                    .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
-                    .writeAttribute("case_sensitive", opt.case_sensitive)
-                    .writeAttribute("no_throw", opt.no_throw)
-                    .writeAttribute("no_skip", opt.no_skip);
-        }
+        // only the consequential ones (TODO: filters)
+        xml.scopedElement("Options")
+                .writeAttribute("order_by", opt.order_by.c_str())
+                .writeAttribute("rand_seed", opt.rand_seed)
+                .writeAttribute("first", opt.first)
+                .writeAttribute("last", opt.last)
+                .writeAttribute("abort_after", opt.abort_after)
+                .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+                .writeAttribute("case_sensitive", opt.case_sensitive)
+                .writeAttribute("no_throw", opt.no_throw)
+                .writeAttribute("no_skip", opt.no_skip);
+    }
 
-        void test_run_end(const TestRunStats& p) override {
-            if(tc) // the TestSuite tag - only if there has been at least 1 test case
-                xml.endElement();
-
-            xml.scopedElement("OverallResultsAsserts")
-                    .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
-                    .writeAttribute("failures", p.numAssertsFailed);
-
-            xml.startElement("OverallResultsTestCases")
-                    .writeAttribute("successes",
-                                    p.numTestCasesPassingFilters - p.numTestCasesFailed)
-                    .writeAttribute("failures", p.numTestCasesFailed);
-            if(opt.no_skipped_summary == false)
-                xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+    void test_run_end(const TestRunStats& p) override {
+        if(tc) // the TestSuite tag - only if there has been at least 1 test case
             xml.endElement();
 
-            xml.endElement();
-        }
+        xml.scopedElement("OverallResultsAsserts")
+                .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+                .writeAttribute("failures", p.numAssertsFailed);
 
-        void test_case_start(const TestCaseData& in) override {
+        xml.startElement("OverallResultsTestCases")
+                .writeAttribute("successes", p.numTestCasesPassingFilters - p.numTestCasesFailed)
+                .writeAttribute("failures", p.numTestCasesFailed);
+        if(opt.no_skipped_summary == false)
+            xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+        xml.endElement();
+
+        xml.endElement();
+    }
+
+    void test_case_start(const TestCaseData& in) override {
+        test_case_start_impl(in);
+        xml.ensureTagClosed();
+    }
+
+    void test_case_reenter(const TestCaseData&) override {}
+
+    void test_case_end(const CurrentTestCaseStats& st) override {
+        xml.startElement("OverallResultsAsserts")
+                .writeAttribute("successes",
+                                st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+                .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+                .writeAttribute("test_case_success", st.testCaseSuccess);
+        if(opt.duration)
+            xml.writeAttribute("duration", st.seconds);
+        if(tc->m_expected_failures)
+            xml.writeAttribute("expected_failures", tc->m_expected_failures);
+        xml.endElement();
+
+        xml.endElement();
+    }
+
+    void test_case_exception(const TestCaseException& e) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.scopedElement("Exception")
+                .writeAttribute("crash", e.is_crash)
+                .writeText(e.error_string.c_str());
+    }
+
+    void subcase_start(const SubcaseSignature& in) override {
+        xml.startElement("SubCase")
+                .writeAttribute("name", in.m_name)
+                .writeAttribute("filename", skipPathFromFilename(in.m_file))
+                .writeAttribute("line", line(in.m_line));
+        xml.ensureTagClosed();
+    }
+
+    void subcase_end() override { xml.endElement(); }
+
+    void log_assert(const AssertData& rb) override {
+        if(!rb.m_failed && !opt.success)
+            return;
+
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.startElement("Expression")
+                .writeAttribute("success", !rb.m_failed)
+                .writeAttribute("type", assertString(rb.m_at))
+                .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+                .writeAttribute("line", line(rb.m_line));
+
+        xml.scopedElement("Original").writeText(rb.m_expr);
+
+        if(rb.m_threw)
+            xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
+
+        if(rb.m_at & assertType::is_throws_as)
+            xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
+        if(rb.m_at & assertType::is_throws_with)
+            xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+        if((rb.m_at & assertType::is_normal) && !rb.m_threw)
+            xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
+
+        log_contexts();
+
+        xml.endElement();
+    }
+
+    void log_message(const MessageData& mb) override {
+        DOCTEST_LOCK_MUTEX(mutex)
+
+        xml.startElement("Message")
+                .writeAttribute("type", failureString(mb.m_severity))
+                .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+                .writeAttribute("line", line(mb.m_line));
+
+        xml.scopedElement("Text").writeText(mb.m_string.c_str());
+
+        log_contexts();
+
+        xml.endElement();
+    }
+
+    void test_case_skipped(const TestCaseData& in) override {
+        if(opt.no_skipped_summary == false) {
             test_case_start_impl(in);
-            xml.ensureTagClosed();
-        }
-
-        void test_case_reenter(const TestCaseData&) override {}
-
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            xml.startElement("OverallResultsAsserts")
-                    .writeAttribute("successes",
-                                    st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-                    .writeAttribute("failures", st.numAssertsFailedCurrentTest)
-                    .writeAttribute("test_case_success", st.testCaseSuccess);
-            if(opt.duration)
-                xml.writeAttribute("duration", st.seconds);
-            if(tc->m_expected_failures)
-                xml.writeAttribute("expected_failures", tc->m_expected_failures);
-            xml.endElement();
-
+            xml.writeAttribute("skipped", "true");
             xml.endElement();
         }
+    }
+};
 
-        void test_case_exception(const TestCaseException& e) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.scopedElement("Exception")
-                    .writeAttribute("crash", e.is_crash)
-                    .writeText(e.error_string.c_str());
-        }
-
-        void subcase_start(const SubcaseSignature& in) override {
-            xml.startElement("SubCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file))
-                    .writeAttribute("line", line(in.m_line));
-            xml.ensureTagClosed();
-        }
-
-        void subcase_end() override { xml.endElement(); }
-
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt.success)
-                return;
-
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.startElement("Expression")
-                    .writeAttribute("success", !rb.m_failed)
-                    .writeAttribute("type", assertString(rb.m_at))
-                    .writeAttribute("filename", skipPathFromFilename(rb.m_file))
-                    .writeAttribute("line", line(rb.m_line));
-
-            xml.scopedElement("Original").writeText(rb.m_expr);
-
-            if(rb.m_threw)
-                xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
-
-            if(rb.m_at & assertType::is_throws_as)
-                xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-            if(rb.m_at & assertType::is_throws_with)
-                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
-            if((rb.m_at & assertType::is_normal) && !rb.m_threw)
-                xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void log_message(const MessageData& mb) override {
-            DOCTEST_LOCK_MUTEX(mutex)
-
-            xml.startElement("Message")
-                    .writeAttribute("type", failureString(mb.m_severity))
-                    .writeAttribute("filename", skipPathFromFilename(mb.m_file))
-                    .writeAttribute("line", line(mb.m_line));
-
-            xml.scopedElement("Text").writeText(mb.m_string.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void test_case_skipped(const TestCaseData& in) override {
-            if(opt.no_skipped_summary == false) {
-                test_case_start_impl(in);
-                xml.writeAttribute("skipped", "true");
-                xml.endElement();
-            }
-        }
-    };
-
-    DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
+DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
 
 } // namespace doctest
 

--- a/doctest/parts/private/signals.h
+++ b/doctest/parts/private/signals.h
@@ -2,9 +2,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
-namespace {
+namespace doctest { namespace detail { namespace {
 
     using namespace detail;
 
@@ -21,7 +19,7 @@ namespace {
 
     struct SignalDefs
     {
-        DWORD id;
+        DWORD       id;
         const char* name;
     };
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -88,7 +86,8 @@ namespace {
                 reportFatal("Terminate handler called");
                 if(isDebuggerActive() && !g_cs->no_breaks)
                     DOCTEST_BREAK_INTO_DEBUGGER();
-                std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
+                std::exit(
+                        EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
             });
 
             // SIGABRT is raised when:
@@ -119,7 +118,8 @@ namespace {
             // input (e.g. passing an invalid file descriptor). The default handling
             // for these assertions is to pop up a dialog and wait for user input.
             // Instead ask the CRT to dump such assertions to stderr non-interactively.
-            prev_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            prev_report_mode =
+                    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
             prev_report_file = _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
         }
 
@@ -147,10 +147,10 @@ namespace {
         static unsigned int prev_abort_behavior;
         static int          prev_report_mode;
         static _HFILE       prev_report_file;
-        static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
-        static std::terminate_handler original_terminate_handler;
-        static bool isSet;
-        static ULONG guaranteeSize;
+        static void(DOCTEST_CDECL* prev_sigabrt_handler)(int);
+        static std::terminate_handler       original_terminate_handler;
+        static bool                         isSet;
+        static ULONG                        guaranteeSize;
         static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
@@ -159,11 +159,11 @@ namespace {
     unsigned int FatalConditionHandler::prev_abort_behavior;
     int          FatalConditionHandler::prev_report_mode;
     _HFILE       FatalConditionHandler::prev_report_file;
-    void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
-    std::terminate_handler FatalConditionHandler::original_terminate_handler;
-    bool FatalConditionHandler::isSet = false;
-    ULONG FatalConditionHandler::guaranteeSize = 0;
-    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
+    void(DOCTEST_CDECL* FatalConditionHandler::prev_sigabrt_handler)(int);
+    std::terminate_handler       FatalConditionHandler::original_terminate_handler;
+    bool                         FatalConditionHandler::isSet         = false;
+    ULONG                        FatalConditionHandler::guaranteeSize = 0;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop   = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
@@ -201,13 +201,9 @@ namespace {
             raise(sig);
         }
 
-        static void allocateAltStackMem() {
-            altStackMem = new char[altStackSize];
-        }
+        static void allocateAltStackMem() { altStackMem = new char[altStackSize]; }
 
-        static void freeAltStackMem() {
-            delete[] altStackMem;
-        }
+        static void freeAltStackMem() { delete[] altStackMem; }
 
         FatalConditionHandler() {
             isSet = true;
@@ -238,17 +234,15 @@ namespace {
         }
     };
 
-    bool             FatalConditionHandler::isSet = false;
+    bool             FatalConditionHandler::isSet                                      = false;
     struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-    stack_t          FatalConditionHandler::oldSigStack = {};
+    stack_t          FatalConditionHandler::oldSigStack                                = {};
     size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
-    char*            FatalConditionHandler::altStackMem = nullptr;
+    char*            FatalConditionHandler::altStackMem  = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-} // namespace
-} // namespace detail
-} // namespace doctest
+}}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -15,7 +15,7 @@ namespace detail {
         }
 
         String pop() {
-            if (stack.empty())
+            if(stack.empty())
                 DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
 
             std::streampos pos = stack.back();
@@ -26,230 +26,235 @@ namespace detail {
         }
     } g_oss;
 
-    std::ostream* tlssPush() {
-        return g_oss.push();
-    }
+    std::ostream* tlssPush() { return g_oss.push(); }
 
-    String tlssPop() {
-        return g_oss.pop();
-    }
+    String tlssPop() { return g_oss.pop(); }
 
 } // namespace detail
 
-    // case insensitive strcmp
-    static int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
+// case insensitive strcmp
+static int stricmp(const char* a, const char* b) {
+    for(;; a++, b++) {
+        const int d = tolower(*a) - tolower(*b);
+        if(d != 0 || !*a)
+            return d;
     }
+}
 
-    char* String::allocate(size_type sz) {
-        if (sz <= last) {
-            buf[sz] = '\0';
-            setLast(last - sz);
-            return buf;
-        } else {
-            setOnHeap();
-            data.size = sz;
-            data.capacity = data.size + 1;
-            data.ptr = new char[data.capacity];
-            data.ptr[sz] = '\0';
-            return data.ptr;
-        }
+char* String::allocate(size_type sz) {
+    if(sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size     = sz;
+        data.capacity = data.size + 1;
+        data.ptr      = new char[data.capacity];
+        data.ptr[sz]  = '\0';
+        return data.ptr;
     }
+}
 
-    void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-    void String::setLast(size_type in) noexcept { buf[last] = char(in); }
-    void String::setSize(size_type sz) noexcept {
-        if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
-        else { data.ptr[sz] = '\0'; data.size = sz; }
+void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
+void String::setLast(size_type in) noexcept { buf[last] = char(in); }
+void String::setSize(size_type sz) noexcept {
+    if(isOnStack()) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+    } else {
+        data.ptr[sz] = '\0';
+        data.size    = sz;
     }
+}
 
-    void String::copy(const String& other) {
-        if(other.isOnStack()) {
-            memcpy(buf, other.buf, len);
-        } else {
-            memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
-        }
+void String::copy(const String& other) {
+    if(other.isOnStack()) {
+        memcpy(buf, other.buf, len);
+    } else {
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
+}
 
-    String::String() noexcept {
-        buf[0] = '\0';
-        setLast();
-    }
+String::String() noexcept {
+    buf[0] = '\0';
+    setLast();
+}
 
-    String::~String() {
+String::~String() {
+    if(!isOnStack())
+        delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String(const char* in)
+        : String(in, strlen(in)) {}
+
+String::String(const char* in, size_type in_size) { memcpy(allocate(in_size), in, in_size); }
+
+String::String(std::istream& in, size_type in_size) { in.read(allocate(in_size), in_size); }
+
+String::String(const String& other) { copy(other); }
+
+String& String::operator=(const String& other) {
+    if(this != &other) {
         if(!isOnStack())
             delete[] data.ptr;
-    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-    String::String(const char* in)
-            : String(in, strlen(in)) {}
-
-    String::String(const char* in, size_type in_size) {
-        memcpy(allocate(in_size), in, in_size);
+        copy(other);
     }
 
-    String::String(std::istream& in, size_type in_size) {
-        in.read(allocate(in_size), in_size);
-    }
+    return *this;
+}
 
-    String::String(const String& other) { copy(other); }
-
-    String& String::operator=(const String& other) {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-
-            copy(other);
-        }
-
-        return *this;
-    }
-
-    String& String::operator+=(const String& other) {
-        const size_type my_old_size = size();
-        const size_type other_size  = other.size();
-        const size_type total_size  = my_old_size + other_size;
-        if(isOnStack()) {
-            if(total_size < len) {
-                // append to the current stack space
-                memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-                // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-                setLast(last - total_size);
-            } else {
-                // alloc new chunk
-                char* temp = new char[total_size + 1];
-                // copy current data to new location before writing in the union
-                memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-                // update data in union
-                setOnHeap();
-                data.size     = total_size;
-                data.capacity = data.size + 1;
-                data.ptr      = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+String& String::operator+=(const String& other) {
+    const size_type my_old_size = size();
+    const size_type other_size  = other.size();
+    const size_type total_size  = my_old_size + other_size;
+    if(isOnStack()) {
+        if(total_size < len) {
+            // append to the current stack space
+            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            setLast(last - total_size);
         } else {
-            if(data.capacity > total_size) {
-                // append to the current heap block
-                data.size = total_size;
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            } else {
-                // resize
-                data.capacity *= 2;
-                if(data.capacity <= total_size)
-                    data.capacity = total_size + 1;
-                // alloc new chunk
-                char* temp = new char[data.capacity];
-                // copy current data to new location before releasing it
-                memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-                // release old chunk
-                delete[] data.ptr;
-                // update the rest of the union members
-                data.size = total_size;
-                data.ptr  = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+            // alloc new chunk
+            char* temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size     = total_size;
+            data.capacity = data.size + 1;
+            data.ptr      = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
-
-        return *this;
+    } else {
+        if(data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if(data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char* temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr  = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
     }
 
-    String::String(String&& other) noexcept {
+    return *this;
+}
+
+String::String(String&& other) noexcept {
+    memcpy(buf, other.buf, len);
+    other.buf[0] = '\0';
+    other.setLast();
+}
+
+String& String::operator=(String&& other) noexcept {
+    if(this != &other) {
+        if(!isOnStack())
+            delete[] data.ptr;
         memcpy(buf, other.buf, len);
         other.buf[0] = '\0';
         other.setLast();
     }
+    return *this;
+}
 
-    String& String::operator=(String&& other) noexcept {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-            memcpy(buf, other.buf, len);
-            other.buf[0] = '\0';
-            other.setLast();
-        }
-        return *this;
+char String::operator[](size_type i) const { return const_cast<String*>(this)->operator[](i); }
+
+char& String::operator[](size_type i) {
+    if(isOnStack())
+        return reinterpret_cast<char*>(buf)[i];
+    return data.ptr[i];
+}
+
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
+String::size_type String::size() const {
+    if(isOnStack())
+        return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+}
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+String::size_type String::capacity() const {
+    if(isOnStack())
+        return len;
+    return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+    cnt        = std::min(cnt, size() - pos);
+    char* cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const& {
+    cnt = std::min(cnt, size() - pos);
+    return String{c_str() + pos, cnt};
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* end   = begin + size();
+    const char* it    = begin + pos;
+    for(; it < end && *it != ch; it++) {}
+    if(it < end) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char String::operator[](size_type i) const {
-        return const_cast<String*>(this)->operator[](i);
+String::size_type String::rfind(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* it    = begin + std::min(pos, size() - 1);
+    for(; it >= begin && *it != ch; it--) {}
+    if(it >= begin) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char& String::operator[](size_type i) {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf)[i];
-        return data.ptr[i];
-    }
+int String::compare(const char* other, bool no_case) const {
+    if(no_case)
+        return doctest::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
 
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-    String::size_type String::size() const {
-        if(isOnStack())
-            return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
-        return data.size;
-    }
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+int String::compare(const String& other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
 
-    String::size_type String::capacity() const {
-        if(isOnStack())
-            return len;
-        return data.capacity;
-    }
+String operator+(const String& lhs, const String& rhs) { return String(lhs) += rhs; }
 
-    String String::substr(size_type pos, size_type cnt) && {
-        cnt = std::min(cnt, size() - pos);
-        char* cptr = c_str();
-        memmove(cptr, cptr + pos, cnt);
-        setSize(cnt);
-        return std::move(*this);
-    }
+bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
+bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
+bool operator<(const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
+bool operator>(const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
+bool operator<=(const String& lhs, const String& rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) < 0 : true;
+}
+bool operator>=(const String& lhs, const String& rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) > 0 : true;
+}
 
-    String String::substr(size_type pos, size_type cnt) const & {
-        cnt = std::min(cnt, size() - pos);
-        return String{ c_str() + pos, cnt };
-    }
-
-    String::size_type String::find(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* end = begin + size();
-        const char* it = begin + pos;
-        for (; it < end && *it != ch; it++) { }
-        if (it < end) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
-
-    String::size_type String::rfind(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* it = begin + std::min(pos, size() - 1);
-        for (; it >= begin && *it != ch; it--) { }
-        if (it >= begin) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
-
-    int String::compare(const char* other, bool no_case) const {
-        if(no_case)
-            return doctest::stricmp(c_str(), other);
-        return std::strcmp(c_str(), other);
-    }
-
-    int String::compare(const String& other, bool no_case) const {
-        return compare(other.c_str(), no_case);
-    }
-
-    String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
-
-    bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
-    bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
-    bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
-    bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
-    bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
-    bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-
-    std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
 
 namespace detail {
 
@@ -258,8 +263,11 @@ namespace detail {
     }
 
     void filldata<const volatile void*>::fill(std::ostream* stream, const volatile void* in) {
-        if (in) { *stream << in; }
-        else { *stream << "nullptr"; }
+        if(in) {
+            *stream << in;
+        } else {
+            *stream << "nullptr";
+        }
     }
 
     template <typename T>

--- a/doctest/parts/private/subcase.cpp
+++ b/doctest/parts/private/subcase.cpp
@@ -3,28 +3,29 @@
 
 namespace doctest {
 
-    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-        return m_line == other.m_line
-            && std::strcmp(m_file, other.m_file) == 0
-            && m_name == other.m_name;
-    }
+bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+    return m_line == other.m_line && std::strcmp(m_file, other.m_file) == 0 &&
+           m_name == other.m_name;
+}
 
-    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        if(std::strcmp(m_file, other.m_file) != 0)
-            return std::strcmp(m_file, other.m_file) < 0;
-        return m_name.compare(other.m_name) < 0;
-    }
+bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+    if(m_line != other.m_line)
+        return m_line < other.m_line;
+    if(std::strcmp(m_file, other.m_file) != 0)
+        return std::strcmp(m_file, other.m_file) < 0;
+    return m_name.compare(other.m_name) < 0;
+}
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
     bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+        if(g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+            if(!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true,
+                           g_cs->case_sensitive))
                 return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+            if(matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false,
+                          g_cs->case_sensitive))
                 return true;
         }
         return false;
@@ -32,11 +33,13 @@ namespace detail {
 
     Subcase::Subcase(const String& name, const char* file, int line)
             : m_signature({name, file, line}) {
-        if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+        if(!g_cs->reachedLeaf) {
+            if(g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size() ||
+               g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
                 // Going down.
-                if (checkFilters()) { return; }
+                if(checkFilters()) {
+                    return;
+                }
 
                 g_cs->subcaseStack.push_back(m_signature);
                 g_cs->currentSubcaseDepth++;
@@ -44,19 +47,23 @@ namespace detail {
                 DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
             }
         } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+            if(g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
                 // This subcase is reentered via control flow.
                 g_cs->currentSubcaseDepth++;
                 m_entered = true;
                 DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
+            } else if(g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+                      g_cs->fullyTraversedSubcases.find(
+                              hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth),
+                                   hash(m_signature))) == g_cs->fullyTraversedSubcases.end()) {
+                if(checkFilters()) {
+                    return;
+                }
                 // This subcase is part of the one to be executed next.
                 g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+                g_cs->nextSubcaseStack.insert(
+                        g_cs->nextSubcaseStack.end(), g_cs->subcaseStack.begin(),
+                        g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
                 g_cs->nextSubcaseStack.push_back(m_signature);
             }
         }
@@ -67,30 +74,31 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 
     Subcase::~Subcase() {
-        if (m_entered) {
+        if(m_entered) {
             g_cs->currentSubcaseDepth--;
 
-            if (!g_cs->reachedLeaf) {
+            if(!g_cs->reachedLeaf) {
                 // Leaf.
                 g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
                 g_cs->nextSubcaseStack.clear();
                 g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
+            } else if(g_cs->nextSubcaseStack.empty()) {
                 // All children are finished.
                 g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
             }
 
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&          \
+        (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
             if(std::uncaught_exceptions() > 0
-    #else
+#else
             if(std::uncaught_exception()
-    #endif
-                && g_cs->shouldLogCurrentException) {
+#endif
+               && g_cs->shouldLogCurrentException) {
                 DOCTEST_ITERATE_THROUGH_REPORTERS(
                         test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
+                                              "when the whole test case has been exited (cannot "
+                                              "translate while there is an active exception)",
+                                              false});
                 g_cs->shouldLogCurrentException = false;
             }
 

--- a/doctest/parts/private/test_case.cpp
+++ b/doctest/parts/private/test_case.cpp
@@ -3,79 +3,77 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                    const String& type, int template_id) {
-    m_file              = file;
-    m_line              = line;
-    m_name              = nullptr; // will be later overridden in operator*
-    m_test_suite        = test_suite.m_test_suite;
-    m_description       = test_suite.m_description;
-    m_skip              = test_suite.m_skip;
-    m_no_breaks         = test_suite.m_no_breaks;
-    m_no_output         = test_suite.m_no_output;
-    m_may_fail          = test_suite.m_may_fail;
-    m_should_fail       = test_suite.m_should_fail;
-    m_expected_failures = test_suite.m_expected_failures;
-    m_timeout           = test_suite.m_timeout;
+    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+                       const String& type, int template_id) {
+        m_file              = file;
+        m_line              = line;
+        m_name              = nullptr; // will be later overridden in operator*
+        m_test_suite        = test_suite.m_test_suite;
+        m_description       = test_suite.m_description;
+        m_skip              = test_suite.m_skip;
+        m_no_breaks         = test_suite.m_no_breaks;
+        m_no_output         = test_suite.m_no_output;
+        m_may_fail          = test_suite.m_may_fail;
+        m_should_fail       = test_suite.m_should_fail;
+        m_expected_failures = test_suite.m_expected_failures;
+        m_timeout           = test_suite.m_timeout;
 
-    m_test        = test;
-    m_type        = type;
-    m_template_id = template_id;
-}
-
-TestCase::TestCase(const TestCase& other)
-        : TestCaseData() {
-    *this = other;
-}
-
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-TestCase& TestCase::operator=(const TestCase& other) {
-    TestCaseData::operator=(other);
-    m_test        = other.m_test;
-    m_type        = other.m_type;
-    m_template_id = other.m_template_id;
-    m_full_name   = other.m_full_name;
-
-    if(m_template_id != -1)
-        m_name = m_full_name.c_str();
-    return *this;
-}
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-TestCase& TestCase::operator*(const char* in) {
-    m_name = in;
-    // make a new name with an appended type for templated test case
-    if(m_template_id != -1) {
-        m_full_name = String(m_name) + "<" + m_type + ">";
-        // redirect the name to point to the newly constructed full name
-        m_name = m_full_name.c_str();
+        m_test        = test;
+        m_type        = type;
+        m_template_id = template_id;
     }
-    return *this;
-}
 
-bool TestCase::operator<(const TestCase& other) const {
-    // this will be used only to differentiate between test cases - not relevant for sorting
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    const int name_cmp = strcmp(m_name, other.m_name);
-    if(name_cmp != 0)
-        return name_cmp < 0;
-    const int file_cmp = m_file.compare(other.m_file);
-    if(file_cmp != 0)
-        return file_cmp < 0;
-    return m_template_id < other.m_template_id;
-}
+    TestCase::TestCase(const TestCase& other)
+            : TestCaseData() {
+        *this = other;
+    }
 
-// used by the macros for registering tests
-int regTest(const TestCase& tc) {
-    getRegisteredTests().insert(tc);
-    return 0;
-}
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+    TestCase& TestCase::operator=(const TestCase& other) {
+        TestCaseData::operator=(other);
+        m_test        = other.m_test;
+        m_type        = other.m_type;
+        m_template_id = other.m_template_id;
+        m_full_name   = other.m_full_name;
 
-} // namespace detail
-} // namespace doctest
+        if(m_template_id != -1)
+            m_name = m_full_name.c_str();
+        return *this;
+    }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    TestCase& TestCase::operator*(const char* in) {
+        m_name = in;
+        // make a new name with an appended type for templated test case
+        if(m_template_id != -1) {
+            m_full_name = String(m_name) + "<" + m_type + ">";
+            // redirect the name to point to the newly constructed full name
+            m_name = m_full_name.c_str();
+        }
+        return *this;
+    }
+
+    bool TestCase::operator<(const TestCase& other) const {
+        // this will be used only to differentiate between test cases - not relevant for sorting
+        if(m_line != other.m_line)
+            return m_line < other.m_line;
+        const int name_cmp = strcmp(m_name, other.m_name);
+        if(name_cmp != 0)
+            return name_cmp < 0;
+        const int file_cmp = m_file.compare(other.m_file);
+        if(file_cmp != 0)
+            return file_cmp < 0;
+        return m_template_id < other.m_template_id;
+    }
+
+    // used by the macros for registering tests
+    int regTest(const TestCase& tc) {
+        getRegisteredTests().insert(tc);
+        return 0;
+    }
+
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/test_case.h
+++ b/doctest/parts/private/test_case.h
@@ -2,8 +2,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // all the registered tests
     std::set<TestCase>& getRegisteredTests() {
@@ -11,7 +10,6 @@ namespace detail {
         return data;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/test_suite.cpp
+++ b/doctest/parts/private/test_suite.cpp
@@ -2,22 +2,20 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-TestSuite& TestSuite::operator*(const char* in) {
-    m_test_suite = in;
-    return *this;
-}
+    TestSuite& TestSuite::operator*(const char* in) {
+        m_test_suite = in;
+        return *this;
+    }
 
-// sets the current test suite
-int setTestSuite(const TestSuite& ts) {
-    doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
-    return 0;
-}
+    // sets the current test suite
+    int setTestSuite(const TestSuite& ts) {
+        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+        return 0;
+    }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite

--- a/doctest/parts/private/timer.h
+++ b/doctest/parts/private/timer.h
@@ -2,26 +2,24 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-namespace timer_large_integer
-{
+    namespace timer_large_integer {
 
 #if defined(DOCTEST_PLATFORM_WINDOWS)
-    using type = ULONGLONG;
-#else // DOCTEST_PLATFORM_WINDOWS
-    using type = std::uint64_t;
+        using type = ULONGLONG;
+#else  // DOCTEST_PLATFORM_WINDOWS
+        using type = std::uint64_t;
 #endif // DOCTEST_PLATFORM_WINDOWS
-}
+    } // namespace timer_large_integer
 
-using ticks_t = timer_large_integer::type;
+    using ticks_t = timer_large_integer::type;
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
     ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
     ticks_t getCurrentTicks() {
-        static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
+        static LARGE_INTEGER hz = {{0}}, hzo = {{0}};
         if(!hz.QuadPart) {
             QueryPerformanceFrequency(&hz);
             QueryPerformanceCounter(&hzo);
@@ -47,13 +45,14 @@ using ticks_t = timer_large_integer::type;
         //unsigned int getElapsedMilliseconds() const {
         //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
         //}
-        double getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
+        double getElapsedSeconds() const {
+            return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0;
+        }
 
     private:
         ticks_t m_ticks = 0;
     };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/xml.cpp
+++ b/doctest/parts/private/xml.cpp
@@ -3,8 +3,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // clang-format off
 
@@ -296,7 +295,6 @@ namespace {
 
     // clang-format on
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/xml.h
+++ b/doctest/parts/private/xml.h
@@ -2,8 +2,7 @@
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     // clang-format off
 
@@ -105,7 +104,6 @@ namespace detail {
 
     // clang-format on
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/comparator.h
+++ b/doctest/parts/public/assert/comparator.h
@@ -1,7 +1,6 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail  {
+namespace doctest { namespace detail {
 
     // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -87,7 +86,6 @@ namespace detail  {
     DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
     DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/data.h
+++ b/doctest/parts/public/assert/data.h
@@ -1,46 +1,53 @@
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData;
+struct DOCTEST_INTERFACE TestCaseData;
 
-    struct DOCTEST_INTERFACE AssertData
+struct DOCTEST_INTERFACE AssertData
+{
+    // common - for all asserts
+    const TestCaseData* m_test_case;
+    assertType::Enum    m_at;
+    const char*         m_file;
+    int                 m_line;
+    const char*         m_expr;
+    bool                m_failed;
+
+    // exception-related - for all asserts
+    bool   m_threw;
+    String m_exception;
+
+    // for normal asserts
+    String m_decomp;
+
+    // for specific exception-related asserts
+    bool        m_threw_as;
+    const char* m_exception_type;
+
+    class DOCTEST_INTERFACE StringContains
     {
-        // common - for all asserts
-        const TestCaseData* m_test_case;
-        assertType::Enum    m_at;
-        const char*         m_file;
-        int                 m_line;
-        const char*         m_expr;
-        bool                m_failed;
+    private:
+        Contains content;
+        bool     isContains;
 
-        // exception-related - for all asserts
-        bool   m_threw;
-        String m_exception;
+    public:
+        StringContains(const String& str)
+                : content(str)
+                , isContains(false) {}
+        StringContains(Contains cntn)
+                : content(static_cast<Contains&&>(cntn))
+                , isContains(true) {}
 
-        // for normal asserts
-        String m_decomp;
+        bool check(const String& str) {
+            return isContains ? (content == str) : (content.string == str);
+        }
 
-        // for specific exception-related asserts
-        bool           m_threw_as;
-        const char*    m_exception_type;
+        operator const String&() const { return content.string; }
 
-        class DOCTEST_INTERFACE StringContains {
-            private:
-                Contains content;
-                bool isContains;
+        const char* c_str() const { return content.string.c_str(); }
+    } m_exception_string;
 
-            public:
-                StringContains(const String& str) : content(str), isContains(false) { }
-                StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
-
-                bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
-
-                operator const String&() const { return content.string; }
-
-                const char* c_str() const { return content.string.c_str(); }
-        } m_exception_string;
-
-        AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-            const char* exception_type, const StringContains& exception_string);
-    };
+    AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+               const char* exception_type, const StringContains& exception_string);
+};
 
 } // namespace doctest

--- a/doctest/parts/public/assert/expression.h
+++ b/doctest/parts/public/assert/expression.h
@@ -1,10 +1,9 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 #if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 #endif
 
 // This will check if there is any way it could find a operator like member or friend and uses it.
@@ -12,15 +11,17 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
 #ifdef __NVCC__
-#define SFINAE_OP(ret,op) ret
+#define SFINAE_OP(ret, op) ret
 #else
-#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
+#define SFINAE_OP(ret, op)                                                                         \
+    decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()), ret{})
 #endif
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
-    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
+    DOCTEST_NOINLINE SFINAE_OP(Result, op) operator op(R&& rhs) {                                  \
+        bool res = op_macro(doctest::detail::forward<const L>(lhs),                                \
+                            doctest::detail::forward<R>(rhs));                                     \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
         if(!res || doctest::getContextOptions()->success)                                          \
@@ -53,66 +54,66 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-template <typename L>
-// cppcheck-suppress copyCtorAndEqOperator
-struct Expression_lhs
-{
-    L                lhs;
-    assertType::Enum m_at;
+    template <typename L>
+    // cppcheck-suppress copyCtorAndEqOperator
+    struct Expression_lhs
+    {
+        L                lhs;
+        assertType::Enum m_at;
 
-    explicit Expression_lhs(L&& in, assertType::Enum at)
-            : lhs(static_cast<L&&>(in))
-            , m_at(at) {}
+        explicit Expression_lhs(L&& in, assertType::Enum at)
+                : lhs(static_cast<L&&>(in))
+                , m_at(at) {}
 
-    DOCTEST_NOINLINE operator Result() {
-// this is needed only for MSVC 2015
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
-        bool res = static_cast<bool>(lhs);
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
-            res = !res;
+        DOCTEST_NOINLINE operator Result() {
+            // this is needed only for MSVC 2015
+            DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+            bool res = static_cast<bool>(lhs);
+            DOCTEST_MSVC_SUPPRESS_WARNING_POP
+            if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+                res = !res;
+            }
+
+            if(!res || getContextOptions()->success) {
+                return {res, (DOCTEST_STRINGIFY(lhs))};
+            }
+            return {res};
         }
 
-        if(!res || getContextOptions()->success) {
-            return { res, (DOCTEST_STRINGIFY(lhs)) };
-        }
-        return { res };
-    }
+        /* This is required for user-defined conversions from Expression_lhs to L */
+        operator L() const { return lhs; }
 
-    /* This is required for user-defined conversions from Expression_lhs to L */
-    operator L() const { return lhs; }
-
-    // clang-format off
+        // clang-format off
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>,  " >  ", DOCTEST_CMP_GT) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<,  " <  ", DOCTEST_CMP_LT) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE) //!OCLINT bitwise operator in conditional
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
-    // clang-format on
+        // clang-format on
 
-    // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
-    // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-    // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
-    DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
-};
+        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
+        // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
+        // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
+        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
+    };
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
@@ -123,31 +124,33 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 #if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
 #endif
 
-struct DOCTEST_INTERFACE ExpressionDecomposer
-{
-    assertType::Enum m_at;
+    struct DOCTEST_INTERFACE ExpressionDecomposer
+    {
+        assertType::Enum m_at;
 
-    ExpressionDecomposer(assertType::Enum at);
+        ExpressionDecomposer(assertType::Enum at);
 
-    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-    // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
-    // https://github.com/catchorg/Catch2/issues/870
-    // https://github.com/catchorg/Catch2/issues/565
-    template <typename L>
-    Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
-        return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
-    }
+        // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
+        // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+        // https://github.com/catchorg/Catch2/issues/870
+        // https://github.com/catchorg/Catch2/issues/565
+        template <typename L>
+        Expression_lhs<const L&&> operator<<(
+                const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
+            return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
+        }
 
-    template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
-    Expression_lhs<const L&> operator<<(const L &operand) {
-        return Expression_lhs<const L&>(operand, m_at);
-    }
-};
+        template <typename L,
+                  typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,
+                                            void>::type* = nullptr>
+        Expression_lhs<const L&> operator<<(const L& operand) {
+            return Expression_lhs<const L&>(operand, m_at);
+        }
+    };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/handler.h
+++ b/doctest/parts/public/assert/handler.h
@@ -1,7 +1,6 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
     DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
 
@@ -22,8 +21,7 @@ namespace detail {
                     throwException();                                                              \
             }                                                                                      \
             return !failed;                                                                        \
-        }                                                                                          \
-    } while(false)
+    }} while(false)
 
 #define DOCTEST_ASSERT_IN_TESTS(decomp)                                                            \
     ResultBuilder rb(at, file, line, expr);                                                        \
@@ -67,7 +65,6 @@ namespace detail {
         return !failed;
     }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/message.h
+++ b/doctest/parts/public/assert/message.h
@@ -1,12 +1,12 @@
 namespace doctest {
 
-    struct DOCTEST_INTERFACE MessageData
-    {
-        String           m_string;
-        const char*      m_file;
-        int              m_line;
-        assertType::Enum m_severity;
-    };
+struct DOCTEST_INTERFACE MessageData
+{
+    String           m_string;
+    const char*      m_file;
+    int              m_line;
+    assertType::Enum m_severity;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
@@ -19,32 +19,36 @@ namespace detail {
         MessageBuilder(const char* file, int line, assertType::Enum severity);
 
         MessageBuilder(const MessageBuilder&) = delete;
-        MessageBuilder(MessageBuilder&&) = delete;
+        MessageBuilder(MessageBuilder&&)      = delete;
 
         MessageBuilder& operator=(const MessageBuilder&) = delete;
-        MessageBuilder& operator=(MessageBuilder&&) = delete;
+        MessageBuilder& operator=(MessageBuilder&&)      = delete;
 
         ~MessageBuilder();
 
         // the preferred way of chaining parameters for stringification
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
         template <typename T>
         MessageBuilder& operator,(const T& in) {
             *m_stream << (DOCTEST_STRINGIFY(in));
             return *this;
         }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
         // kept here just for backwards-compatibility - the comma operator should be preferred now
         template <typename T>
-        MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
+        MessageBuilder& operator<<(const T& in) {
+            return this->operator,(in);
+        }
 
         // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
         // the `,` operator will be called last which is not what we want and thus the `*` operator
         // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
         // an operator of the MessageBuilder class is called first before the rest of the parameters
         template <typename T>
-        MessageBuilder& operator*(const T& in) { return this->operator,(in); }
+        MessageBuilder& operator*(const T& in) {
+            return this->operator,(in);
+        }
 
         bool log();
         void react();

--- a/doctest/parts/public/assert/result.h
+++ b/doctest/parts/public/assert/result.h
@@ -1,7 +1,6 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
 // more checks could be added - like in Catch:
 // https://github.com/catchorg/Catch2/pull/1480/files
@@ -61,7 +60,7 @@ namespace detail {
         DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
                                             const DOCTEST_REF_WRAP(R) rhs) {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if (m_failed || getContextOptions()->success) {
+            if(m_failed || getContextOptions()->success) {
                 m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
             }
             return !m_failed;
@@ -71,11 +70,11 @@ namespace detail {
         DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
             m_failed = !val;
 
-            if (m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+            if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
                 m_failed = !m_failed;
             }
 
-            if (m_failed || getContextOptions()->success) {
+            if(m_failed || getContextOptions()->success) {
                 m_decomp = (DOCTEST_STRINGIFY(val));
             }
 
@@ -88,7 +87,6 @@ namespace detail {
         void react() const;
     };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/type.h
+++ b/doctest/parts/public/assert/type.h
@@ -93,4 +93,4 @@ namespace assertType {
 DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
 DOCTEST_INTERFACE const char* failureString(assertType::Enum at);
 
-}
+} // namespace doctest

--- a/doctest/parts/public/color.h
+++ b/doctest/parts/public/color.h
@@ -1,5 +1,4 @@
-namespace doctest {
-namespace Color {
+namespace doctest { namespace Color {
     enum Enum
     {
         None = 0,
@@ -20,5 +19,4 @@ namespace Color {
     };
 
     DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
-} // namespace Color
-}
+}} // namespace doctest::Color

--- a/doctest/parts/public/compiler.h
+++ b/doctest/parts/public/compiler.h
@@ -10,7 +10,7 @@
 #define DOCTEST_CPLUSPLUS __cplusplus
 #endif
 
-#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
+#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
 
 // GCC/Clang and GCC/MSVC are mutually exclusive, but Clang/MSVC are not because of clang-cl...
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)

--- a/doctest/parts/public/config.h
+++ b/doctest/parts/public/config.h
@@ -37,8 +37,8 @@
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
-        || defined(__wasi__)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND) ||                \
+        defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS

--- a/doctest/parts/public/context.h
+++ b/doctest/parts/public/context.h
@@ -1,6 +1,6 @@
 namespace doctest {
 
-    DOCTEST_INTERFACE extern bool is_running_in_test;
+DOCTEST_INTERFACE extern bool is_running_in_test;
 
 namespace detail {
     using assert_handler = void (*)(const AssertData&);
@@ -17,10 +17,10 @@ public:
     explicit Context(int argc = 0, const char* const* argv = nullptr);
 
     Context(const Context&) = delete;
-    Context(Context&&) = delete;
+    Context(Context&&)      = delete;
 
     Context& operator=(const Context&) = delete;
-    Context& operator=(Context&&) = delete;
+    Context& operator=(Context&&)      = delete;
 
     ~Context(); // NOLINT(performance-trivially-destructible)
 

--- a/doctest/parts/public/context/options.h
+++ b/doctest/parts/public/context/options.h
@@ -3,55 +3,55 @@ namespace detail {
     struct DOCTEST_INTERFACE TestCase;
 } // namespace detail
 
-    struct ContextOptions //!OCLINT too many fields
-    {
-        std::ostream* cout = nullptr; // stdout stream
-        String        binary_name;    // the test binary name
+struct ContextOptions //!OCLINT too many fields
+{
+    std::ostream* cout = nullptr; // stdout stream
+    String        binary_name;    // the test binary name
 
-        const detail::TestCase* currentTest = nullptr;
+    const detail::TestCase* currentTest = nullptr;
 
-        // == parameters from the command line
-        String   out;       // output filename
-        String   order_by;  // how tests should be ordered
-        unsigned rand_seed; // the seed for rand ordering
+    // == parameters from the command line
+    String   out;       // output filename
+    String   order_by;  // how tests should be ordered
+    unsigned rand_seed; // the seed for rand ordering
 
-        unsigned first; // the first (matching) test to be executed
-        unsigned last;  // the last (matching) test to be executed
+    unsigned first; // the first (matching) test to be executed
+    unsigned last;  // the last (matching) test to be executed
 
-        int abort_after;           // stop tests after this many failed assertions
-        int subcase_filter_levels; // apply the subcase filters for the first N levels
+    int abort_after;           // stop tests after this many failed assertions
+    int subcase_filter_levels; // apply the subcase filters for the first N levels
 
-        bool success;              // include successful assertions in output
-        bool case_sensitive;       // if filtering should be case sensitive
-        bool exit;                 // if the program should be exited after the tests are ran/whatever
-        bool duration;             // print the time duration of each test case
-        bool minimal;              // minimal console output (only test failures)
-        bool quiet;                // no console output
-        bool no_throw;             // to skip exceptions-related assertion macros
-        bool no_exitcode;          // if the framework should return 0 as the exitcode
-        bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-        bool no_intro;             // to not print the intro of the framework
-        bool no_version;           // to not print the version of the framework
-        bool no_colors;            // if output to the console should be colorized
-        bool force_colors;         // forces the use of colors even when a tty cannot be detected
-        bool no_breaks;            // to not break into the debugger
-        bool no_skip;              // don't skip test cases which are marked to be skipped
-        bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-        bool no_path_in_filenames; // if the path to files should be removed from the output
-        String strip_file_prefixes;// remove the longest matching one of these prefixes from any file paths in the output
-        bool no_line_numbers;      // if source code line numbers should be omitted from the output
-        bool no_debug_output;      // no output in the debug console when a debugger is attached
-        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
-        bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
+    bool success;              // include successful assertions in output
+    bool case_sensitive;       // if filtering should be case sensitive
+    bool exit;                 // if the program should be exited after the tests are ran/whatever
+    bool duration;             // print the time duration of each test case
+    bool minimal;              // minimal console output (only test failures)
+    bool quiet;                // no console output
+    bool no_throw;             // to skip exceptions-related assertion macros
+    bool no_exitcode;          // if the framework should return 0 as the exitcode
+    bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;             // to not print the intro of the framework
+    bool no_version;           // to not print the version of the framework
+    bool no_colors;            // if output to the console should be colorized
+    bool force_colors;         // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;            // to not break into the debugger
+    bool no_skip;              // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames; // if the path to files should be removed from the output
+    String strip_file_prefixes; // remove the longest matching one of these prefixes from any file paths in the output
+    bool no_line_numbers;    // if source code line numbers should be omitted from the output
+    bool no_debug_output;    // no output in the debug console when a debugger is attached
+    bool no_skipped_summary; // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;  // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
-        bool help;             // to print the help
-        bool version;          // to print the version
-        bool count;            // if only the count of matching tests is to be retrieved
-        bool list_test_cases;  // to list all tests matching the filters
-        bool list_test_suites; // to list all suites matching the filters
-        bool list_reporters;   // lists all registered reporters
-    };
+    bool help;             // to print the help
+    bool version;          // to print the version
+    bool count;            // if only the count of matching tests is to be retrieved
+    bool list_test_cases;  // to list all tests matching the filters
+    bool list_test_suites; // to list all suites matching the filters
+    bool list_reporters;   // lists all registered reporters
+};
 
-    DOCTEST_INTERFACE const ContextOptions* getContextOptions();
+DOCTEST_INTERFACE const ContextOptions* getContextOptions();
 
 } // namespace doctest

--- a/doctest/parts/public/context_scope.h
+++ b/doctest/parts/public/context_scope.h
@@ -9,51 +9,55 @@ struct DOCTEST_INTERFACE IContextScope
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-  // ContextScope base class used to allow implementing methods of ContextScope
-  // that don't depend on the template parameter in doctest.cpp.
-  struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
-      ContextScopeBase(const ContextScopeBase&) = delete;
+    // ContextScope base class used to allow implementing methods of ContextScope
+    // that don't depend on the template parameter in doctest.cpp.
+    struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope
+    {
+        ContextScopeBase(const ContextScopeBase&) = delete;
 
-      ContextScopeBase& operator=(const ContextScopeBase&) = delete;
-      ContextScopeBase& operator=(ContextScopeBase&&) = delete;
+        ContextScopeBase& operator=(const ContextScopeBase&) = delete;
+        ContextScopeBase& operator=(ContextScopeBase&&)      = delete;
 
-      ~ContextScopeBase() override = default;
+        ~ContextScopeBase() override = default;
 
-  protected:
-      ContextScopeBase();
-      ContextScopeBase(ContextScopeBase&& other) noexcept;
+    protected:
+        ContextScopeBase();
+        ContextScopeBase(ContextScopeBase&& other) noexcept;
 
-      void destroy();
-      bool need_to_destroy{true};
-  };
+        void destroy();
+        bool need_to_destroy{true};
+    };
 
-  template <typename L> class ContextScope : public ContextScopeBase
-  {
-      L lambda_;
+    template <typename L>
+    class ContextScope : public ContextScopeBase
+    {
+        L lambda_;
 
-  public:
-      explicit ContextScope(const L &lambda) : lambda_(lambda) {}
-      explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
+    public:
+        explicit ContextScope(const L& lambda)
+                : lambda_(lambda) {}
+        explicit ContextScope(L&& lambda)
+                : lambda_(static_cast<L&&>(lambda)) {}
 
-      ContextScope(const ContextScope&) = delete;
-      ContextScope(ContextScope&&) noexcept = default;
+        ContextScope(const ContextScope&)     = delete;
+        ContextScope(ContextScope&&) noexcept = default;
 
-      ContextScope& operator=(const ContextScope&) = delete;
-      ContextScope& operator=(ContextScope&&) = delete;
+        ContextScope& operator=(const ContextScope&) = delete;
+        ContextScope& operator=(ContextScope&&)      = delete;
 
-      void stringify(std::ostream* s) const override { lambda_(s); }
+        void stringify(std::ostream* s) const override { lambda_(s); }
 
-      ~ContextScope() override {
-          if (need_to_destroy) {
-              destroy();
-          }
-      }
-  };
+        ~ContextScope() override {
+            if(need_to_destroy) {
+                destroy();
+            }
+        }
+    };
 
-  template <typename L>
-  ContextScope<L> MakeContextScope(const L &lambda) {
-      return ContextScope<L>(lambda);
-  }
+    template <typename L>
+    ContextScope<L> MakeContextScope(const L& lambda) {
+        return ContextScope<L>(lambda);
+    }
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/debugger.h
+++ b/doctest/parts/public/debugger.h
@@ -13,7 +13,11 @@
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
 #elif defined(__ppc__) || defined(__ppc64__)
 // https://www.cocoawithlove.com/2008/03/break-into-debugger.html
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER()                                                              \
+    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n"                                   \
+            :                                                                                      \
+            :                                                                                      \
+            : "memory", "r0", "r3", "r4") // NOLINT(hicpp-no-assembler)
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
@@ -31,10 +35,8 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
     DOCTEST_INTERFACE bool isDebuggerActive();
-} // detail
-} // doctest
+}} // namespace doctest::detail
 
 #endif

--- a/doctest/parts/public/decorators.h
+++ b/doctest/parts/public/decorators.h
@@ -22,6 +22,6 @@ DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
-} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/exceptions.h
+++ b/doctest/parts/public/exceptions.h
@@ -1,20 +1,18 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-  struct DOCTEST_INTERFACE TestFailureException
-  {
-  };
+    struct DOCTEST_INTERFACE TestFailureException
+    {
+    };
 
-  DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+    DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_NORETURN
+    DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_INTERFACE void throwException();
+    DOCTEST_INTERFACE void throwException();
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/macros.h
+++ b/doctest/parts/public/macros.h
@@ -1,11 +1,11 @@
 #ifndef DOCTEST_CONFIG_DISABLE
-namespace doctest {
-namespace detail {
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+namespace doctest { namespace detail {
+    template <typename T>
+    int instantiationHelper(const T&) {
+        return 0;
+    }
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 #endif // DOCTEST_CONFIG_DISABLE
 
 #ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
@@ -29,7 +29,8 @@ namespace detail {
 
 // common code in asserts - for convenience
 #define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
-    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
+    if(b.log())                                                                                    \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
     b.react();                                                                                     \
     DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
@@ -53,7 +54,8 @@ namespace detail {
 
 // registers the test by initializing a dummy var with a function
 #define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(                                                      \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */                                     \
             doctest::detail::regTest(                                                              \
                     doctest::detail::TestCase(                                                     \
                             f, __FILE__, __LINE__,                                                 \
@@ -126,11 +128,12 @@ namespace detail {
         struct iter<std::tuple<Type, Rest...>>                                                     \
         {                                                                                          \
             iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::toString<Type>(),                             \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
+                doctest::detail::regTest(                                                          \
+                        doctest::detail::TestCase(                                                 \
+                                func<Type>, file, line,                                            \
+                                doctest_detail_test_suite_ns::getCurrentTestSuite(),               \
+                                doctest::toString<Type>(), int(line) * 1000 + index) *             \
+                        dec);                                                                      \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
             }                                                                                      \
         };                                                                                         \
@@ -148,16 +151,21 @@ namespace detail {
                                            DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
-        doctest::detail::instantiationHelper(                                                      \
-            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_CAT(                                                                           \
+                    anon,                                                                          \
+                    DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */   \
+            doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ >         \
+                                                 (__FILE__, __LINE__, 0)))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_),          \
+                                                std::tuple<__VA_ARGS__>)                           \
     static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_),          \
+                                                __VA_ARGS__)                                       \
     static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
@@ -171,7 +179,7 @@ namespace detail {
 
 // for subcases
 #define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
+    if(const doctest::detail::Subcase& DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =   \
                doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
@@ -201,20 +209,22 @@ namespace detail {
 
 // for starting a testsuite block
 #define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                     \
             doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
     static_assert(true, "")
 
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END                                                                     \
     DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+                               doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))   \
     using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
     inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */              \
             doctest::registerExceptionTranslator(translatorName))                                  \
     doctest::String translatorName(signature)
 
@@ -224,13 +234,15 @@ namespace detail {
 
 // for registering reporters
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                \
             doctest::registerReporter<reporter>(name, priority, true))                             \
     static_assert(true, "")
 
 // for registering listeners
 #define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                    \
+            DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                \
             doctest::registerReporter<reporter>(name, priority, false))                            \
     static_assert(true, "")
 
@@ -242,12 +254,12 @@ namespace detail {
                       __VA_ARGS__)
 // clang-format on
 
-#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
-    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
-        [&](std::ostream* s_name) {                                                                \
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                                    \
+    auto DOCTEST_ANONYMOUS(                                                                        \
+            DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope([&](std::ostream* s_name) {      \
         doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
         mb_name.m_stream = s_name;                                                                 \
-        mb_name * __VA_ARGS__;                                                                     \
+        mb_name* __VA_ARGS__;                                                                      \
     })
 
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
@@ -255,11 +267,12 @@ namespace detail {
 #define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb * __VA_ARGS__;                                                                          \
+        mb*                             __VA_ARGS__;                                               \
         if(mb.log())                                                                               \
             DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
         mb.react();                                                                                \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
@@ -279,7 +292,7 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
     /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
     doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
-                                               __LINE__, #__VA_ARGS__);                            \
+                                              __LINE__, #__VA_ARGS__);                             \
     DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
             << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
@@ -287,27 +300,28 @@ namespace detail {
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 #define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+    DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__); }             \
+    DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 #define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         DOCTEST_WRAP_IN_TRY(                                                                       \
                 DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
                         __VA_ARGS__))                                                              \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -379,11 +393,12 @@ namespace detail {
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         if(!doctest::getContextOptions()->no_throw) {                                              \
             doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
+                                                      __LINE__, #expr, #__VA_ARGS__, message);     \
             try {                                                                                  \
                 DOCTEST_CAST_TO_VOID(expr)                                                         \
             } catch(const typename doctest::detail::types::remove_const<                           \
-                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
+                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::        \
+                            type&) {                                                               \
                 DOCTEST_RB.translateException();                                                   \
                 DOCTEST_RB.m_threw_as = true;                                                      \
             } catch(...) { DOCTEST_RB.translateException(); }                                      \
@@ -391,31 +406,34 @@ namespace detail {
         } else { /* NOLINT(*-else-after-return) */                                                 \
             DOCTEST_FUNC_SCOPE_RET(false);                                                         \
         }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         if(!doctest::getContextOptions()->no_throw) {                                              \
             doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
+                                                      __LINE__, expr_str, "", __VA_ARGS__);        \
             try {                                                                                  \
                 DOCTEST_CAST_TO_VOID(expr)                                                         \
             } catch(...) { DOCTEST_RB.translateException(); }                                      \
             DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
         } else { /* NOLINT(*-else-after-return) */                                                 \
-           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
         }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 #define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
     DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
+                                                  __LINE__, #__VA_ARGS__);                         \
         try {                                                                                      \
             DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
         } catch(...) { DOCTEST_RB.translateException(); }                                          \
         DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+    }                                                                                              \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
@@ -467,7 +485,9 @@ namespace detail {
     namespace /* NOLINT */ {                                                                       \
         template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
         struct der : public base                                                                   \
-        { void f(); };                                                                             \
+        {                                                                                          \
+            void f();                                                                              \
+        };                                                                                         \
     }                                                                                              \
     template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
@@ -533,8 +553,8 @@ namespace detail {
 #define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
 #define DOCTEST_FAIL(...) (static_cast<void>(0))
 
-#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
- && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED) &&                                 \
+        defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
 
 #define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
 #define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
@@ -550,11 +570,12 @@ namespace detail {
 #define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
 #define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 #define DOCTEST_RELATIONAL_OP(name, op)                                                            \
     template <typename L, typename R>                                                              \
-    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                      \
+        return lhs op rhs;                                                                         \
+    }
 
     DOCTEST_RELATIONAL_OP(eq, ==)
     DOCTEST_RELATIONAL_OP(ne, !=)
@@ -562,8 +583,7 @@ namespace detail {
     DOCTEST_RELATIONAL_OP(gt, >)
     DOCTEST_RELATIONAL_OP(le, <=)
     DOCTEST_RELATIONAL_OP(ge, >=)
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail
 
 #define DOCTEST_WARN_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
 #define DOCTEST_CHECK_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
@@ -592,39 +612,157 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
-#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...)                                                  \
+    [] {                                                                                           \
+        static_assert(false, "Exception translation is not available when doctest is disabled.");  \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_WARN_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_WARN_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_CHECK_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_REQUIRE_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_WARN_THROWS(...)                                                                   \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS(...)                                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS(...)                                                                \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_WARN_THROWS_AS(expr, ...)                                                          \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_AS(expr, ...)                                                         \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...)                                                       \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_WARN_NOTHROW(...)                                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_CHECK_NOTHROW(...)                                                                 \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_REQUIRE_NOTHROW(...)                                                               \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
 
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...)                                                     \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...)                                                    \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...)                                                  \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return false;                                                                          \
+        } catch(...) { return true; }                                                              \
+    }()
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...)                                              \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...)                                             \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...)                                           \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            expr;                                                                                  \
+        } catch(__VA_ARGS__) { return true; } catch(...) {                                         \
+        }                                                                                          \
+        return false;                                                                              \
+    }()
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...)                                                    \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...)                                                   \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...)                                                 \
+    [&] {                                                                                          \
+        try {                                                                                      \
+            __VA_ARGS__;                                                                           \
+            return true;                                                                           \
+        } catch(...) { return false; }                                                             \
+    }()
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
@@ -715,8 +853,13 @@ namespace detail {
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
-    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
+#define DOCTEST_EXCEPTION_EMPTY_FUNC                                                               \
+    [] {                                                                                           \
+        static_assert(false, "Exceptions are disabled! "                                           \
+                             "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want "  \
+                             "to compile with exceptions disabled.");                              \
+        return false;                                                                              \
+    }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -842,8 +985,10 @@ namespace detail {
 #define TEST_SUITE_BEGIN(name) DOCTEST_TEST_SUITE_BEGIN(name)
 #define TEST_SUITE_END DOCTEST_TEST_SUITE_END
 #define REGISTER_EXCEPTION_TRANSLATOR(signature) DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)
-#define REGISTER_REPORTER(name, priority, reporter) DOCTEST_REGISTER_REPORTER(name, priority, reporter)
-#define REGISTER_LISTENER(name, priority, reporter) DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+#define REGISTER_REPORTER(name, priority, reporter)                                                \
+    DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define REGISTER_LISTENER(name, priority, reporter)                                                \
+    DOCTEST_REGISTER_LISTENER(name, priority, reporter)
 #define INFO(...) DOCTEST_INFO(__VA_ARGS__)
 #define CAPTURE(x) DOCTEST_CAPTURE(x)
 #define ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_MESSAGE_AT(file, line, __VA_ARGS__)
@@ -873,29 +1018,38 @@ namespace detail {
 #define REQUIRE_THROWS(...) DOCTEST_REQUIRE_THROWS(__VA_ARGS__)
 #define REQUIRE_THROWS_AS(expr, ...) DOCTEST_REQUIRE_THROWS_AS(expr, __VA_ARGS__)
 #define REQUIRE_THROWS_WITH(expr, ...) DOCTEST_REQUIRE_THROWS_WITH(expr, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS(expr, with, ...)                                                    \
+    DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
 #define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
 #define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
 #define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
 #define WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define WARN_THROWS_WITH_MESSAGE(expr, with, ...)                                                  \
+    DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                           \
+    DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_WARN_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 #define CHECK_MESSAGE(cond, ...) DOCTEST_CHECK_MESSAGE(cond, __VA_ARGS__)
 #define CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_CHECK_THROWS_MESSAGE(expr, __VA_ARGS__)
-#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...)                                                     \
+    DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...)                                                 \
+    DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                          \
+    DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_CHECK_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 #define REQUIRE_MESSAGE(cond, ...) DOCTEST_REQUIRE_MESSAGE(cond, __VA_ARGS__)
 #define REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_REQUIRE_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_REQUIRE_THROWS_MESSAGE(expr, __VA_ARGS__)
-#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
-#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...)                                                   \
+    DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...)                                               \
+    DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...)                                        \
+    DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 
 #define SCENARIO(name) DOCTEST_SCENARIO(name)
@@ -960,6 +1114,7 @@ namespace detail {
 #define FAST_CHECK_UNARY_FALSE(...) DOCTEST_FAST_CHECK_UNARY_FALSE(__VA_ARGS__)
 #define FAST_REQUIRE_UNARY_FALSE(...) DOCTEST_FAST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
-#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                                    \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES

--- a/doctest/parts/public/matchers/approx.h
+++ b/doctest/parts/public/matchers/approx.h
@@ -8,9 +8,10 @@ struct DOCTEST_INTERFACE Approx
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
+    explicit Approx(
+            const T& value,
+            typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
+                    static_cast<T*>(nullptr)) {
         *this = static_cast<double>(value);
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS

--- a/doctest/parts/public/matchers/contains.h
+++ b/doctest/parts/public/matchers/contains.h
@@ -1,6 +1,7 @@
 namespace doctest {
 
-class DOCTEST_INTERFACE Contains {
+class DOCTEST_INTERFACE Contains
+{
 public:
     explicit Contains(const String& string);
 

--- a/doctest/parts/public/matchers/is_nan.h
+++ b/doctest/parts/public/matchers/is_nan.h
@@ -3,10 +3,13 @@ namespace doctest {
 template <typename F>
 struct DOCTEST_INTERFACE_DECL IsNaN
 {
-    F value; bool flipped;
-    IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
-    IsNaN<F> operator!() const { return { value, !flipped }; }
-    operator bool() const;
+    F    value;
+    bool flipped;
+    IsNaN(F f, bool flip = false)
+            : value(f)
+            , flipped(flip) {}
+    IsNaN<F> operator!() const { return {value, !flipped}; }
+             operator bool() const;
 };
 
 #ifndef __MINGW32__

--- a/doctest/parts/public/reporter.h
+++ b/doctest/parts/public/reporter.h
@@ -17,91 +17,92 @@ namespace TestCaseFailureReason {
     };
 } // namespace TestCaseFailureReason
 
-    struct DOCTEST_INTERFACE CurrentTestCaseStats
-    {
-        int    numAssertsCurrentTest;
-        int    numAssertsFailedCurrentTest;
-        double seconds;
-        int    failure_flags; // use TestCaseFailureReason::Enum
-        bool   testCaseSuccess;
-    };
+struct DOCTEST_INTERFACE CurrentTestCaseStats
+{
+    int    numAssertsCurrentTest;
+    int    numAssertsFailedCurrentTest;
+    double seconds;
+    int    failure_flags; // use TestCaseFailureReason::Enum
+    bool   testCaseSuccess;
+};
 
-    struct DOCTEST_INTERFACE TestCaseException
-    {
-        String error_string;
-        bool   is_crash;
-    };
+struct DOCTEST_INTERFACE TestCaseException
+{
+    String error_string;
+    bool   is_crash;
+};
 
-    struct DOCTEST_INTERFACE TestRunStats
-    {
-        unsigned numTestCases;
-        unsigned numTestCasesPassingFilters;
-        unsigned numTestSuitesPassingFilters;
-        unsigned numTestCasesFailed;
-        int      numAsserts;
-        int      numAssertsFailed;
-    };
+struct DOCTEST_INTERFACE TestRunStats
+{
+    unsigned numTestCases;
+    unsigned numTestCasesPassingFilters;
+    unsigned numTestSuitesPassingFilters;
+    unsigned numTestCasesFailed;
+    int      numAsserts;
+    int      numAssertsFailed;
+};
 
-    struct QueryData
-    {
-        const TestRunStats*  run_stats = nullptr;
-        const TestCaseData** data      = nullptr;
-        unsigned             num_data  = 0;
-    };
+struct QueryData
+{
+    const TestRunStats*  run_stats = nullptr;
+    const TestCaseData** data      = nullptr;
+    unsigned             num_data  = 0;
+};
 
-    struct DOCTEST_INTERFACE IReporter
-    {
-        // The constructor has to accept "const ContextOptions&" as a single argument
-        // which has most of the options for the run + a pointer to the stdout stream
-        // Reporter(const ContextOptions& in)
+struct DOCTEST_INTERFACE IReporter
+{
+    // The constructor has to accept "const ContextOptions&" as a single argument
+    // which has most of the options for the run + a pointer to the stdout stream
+    // Reporter(const ContextOptions& in)
 
-        // called when a query should be reported (listing test cases, printing the version, etc.)
-        virtual void report_query(const QueryData&) = 0;
+    // called when a query should be reported (listing test cases, printing the version, etc.)
+    virtual void report_query(const QueryData&) = 0;
 
-        // called when the whole test run starts
-        virtual void test_run_start() = 0;
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const TestRunStats&) = 0;
+    // called when the whole test run starts
+    virtual void test_run_start() = 0;
+    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+    virtual void test_run_end(const TestRunStats&) = 0;
 
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const TestCaseData&) = 0;
-        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const TestCaseData&) = 0;
-        // called when a test case has ended
-        virtual void test_case_end(const CurrentTestCaseStats&) = 0;
+    // called when a test case is started (safe to cache a pointer to the input)
+    virtual void test_case_start(const TestCaseData&) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData&) = 0;
+    // called when a test case has ended
+    virtual void test_case_end(const CurrentTestCaseStats&) = 0;
 
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const TestCaseException&) = 0;
+    // called when an exception is thrown from the test case (or it crashes)
+    virtual void test_case_exception(const TestCaseException&) = 0;
 
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const SubcaseSignature&) = 0;
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() = 0;
+    // called whenever a subcase is entered (don't cache pointers to the input)
+    virtual void subcase_start(const SubcaseSignature&) = 0;
+    // called whenever a subcase is exited (don't cache pointers to the input)
+    virtual void subcase_end() = 0;
 
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const AssertData&) = 0;
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const MessageData&) = 0;
+    // called for each assert (don't cache pointers to the input)
+    virtual void log_assert(const AssertData&) = 0;
+    // called for each message (don't cache pointers to the input)
+    virtual void log_message(const MessageData&) = 0;
 
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const TestCaseData&) = 0;
+    // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
+    // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
+    virtual void test_case_skipped(const TestCaseData&) = 0;
 
-        DOCTEST_DECLARE_INTERFACE(IReporter)
+    DOCTEST_DECLARE_INTERFACE(IReporter)
 
-        // can obtain all currently active contexts and stringify them if one wishes to do so
-        static int                         get_num_active_contexts();
-        static const IContextScope* const* get_active_contexts();
+    // can obtain all currently active contexts and stringify them if one wishes to do so
+    static int                         get_num_active_contexts();
+    static const IContextScope* const* get_active_contexts();
 
-        // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-        static int           get_num_stringified_contexts();
-        static const String* get_stringified_contexts();
-    };
+    // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
+    static int           get_num_stringified_contexts();
+    static const String* get_stringified_contexts();
+};
 
 namespace detail {
-    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
+    using reporterCreatorFunc = IReporter* (*)(const ContextOptions&);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c,
+                                                bool isReporter);
 
     template <typename Reporter>
     IReporter* reporterCreator(const ContextOptions& o) {
@@ -109,9 +110,9 @@ namespace detail {
     }
 } // namespace detail
 
-    template <typename Reporter>
-    int registerReporter(const char* name, int priority, bool isReporter) {
-        detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
-        return 0;
-    }
+template <typename Reporter>
+int registerReporter(const char* name, int priority, bool isReporter) {
+    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+    return 0;
+}
 } // namespace doctest

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -9,17 +9,17 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-namespace std { // NOLINT(cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
-typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
+namespace std {                            // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr)       nullptr_t; // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void*)) size_t;    // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+class basic_ostream;                                    // NOLINT(fuchsia-virtual-inheritance)
 typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
-template<class traits>
+template <class traits>
 // NOLINTNEXTLINE
 basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
 template <class charT, class traits>
@@ -42,5 +42,5 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
 namespace doctest {
-  using std::size_t;
+using std::size_t;
 }

--- a/doctest/parts/public/std/type_traits.h
+++ b/doctest/parts/public/std/type_traits.h
@@ -2,44 +2,97 @@
 #include <type_traits>
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-namespace doctest {
-namespace detail {
-namespace types {
+namespace doctest { namespace detail { namespace types {
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  using namespace std;
+    using namespace std;
 #else
-  template <bool COND, typename T = void>
-  struct enable_if { };
+    template <bool COND, typename T = void>
+    struct enable_if
+    {
+    };
 
-  template <typename T>
-  struct enable_if<true, T> { using type = T; };
+    template <typename T>
+    struct enable_if<true, T>
+    {
+        using type = T;
+    };
 
-  struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
-  struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
+    struct true_type
+    {
+        static DOCTEST_CONSTEXPR bool value = true;
+    };
+    struct false_type
+    {
+        static DOCTEST_CONSTEXPR bool value = false;
+    };
 
-  template <typename T> struct remove_reference { using type = T; };
-  template <typename T> struct remove_reference<T&> { using type = T; };
-  template <typename T> struct remove_reference<T&&> { using type = T; };
+    template <typename T>
+    struct remove_reference
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_reference<T&>
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_reference<T&&>
+    {
+        using type = T;
+    };
 
-  template <typename T> struct is_rvalue_reference : false_type { };
-  template <typename T> struct is_rvalue_reference<T&&> : true_type { };
+    template <typename T>
+    struct is_rvalue_reference : false_type
+    {
+    };
+    template <typename T>
+    struct is_rvalue_reference<T&&> : true_type
+    {
+    };
 
-  template<typename T> struct remove_const { using type = T; };
-  template <typename T> struct remove_const<const T> { using type = T; };
+    template <typename T>
+    struct remove_const
+    {
+        using type = T;
+    };
+    template <typename T>
+    struct remove_const<const T>
+    {
+        using type = T;
+    };
 
-  // Compiler intrinsics
-  template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
-  template <typename T> struct underlying_type { using type = __underlying_type(T); };
+    // Compiler intrinsics
+    template <typename T>
+    struct is_enum
+    {
+        static DOCTEST_CONSTEXPR bool value = __is_enum(T);
+    };
+    template <typename T>
+    struct underlying_type
+    {
+        using type = __underlying_type(T);
+    };
 
-  template <typename T> struct is_pointer : false_type { };
-  template <typename T> struct is_pointer<T*> : true_type { };
+    template <typename T>
+    struct is_pointer : false_type
+    {
+    };
+    template <typename T>
+    struct is_pointer<T*> : true_type
+    {
+    };
 
-  template <typename T> struct is_array : false_type { };
-  // NOLINTNEXTLINE(*-avoid-c-arrays)
-  template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+    template <typename T>
+    struct is_array : false_type
+    {
+    };
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
+    template <typename T, size_t SIZE>
+    struct is_array<T[SIZE]> : true_type
+    {
+    };
 #endif
 
-} // namespace types
-} // namespace detail
-} // namespace doctest
+}}} // namespace doctest::detail::types

--- a/doctest/parts/public/std/utility.h
+++ b/doctest/parts/public/std/utility.h
@@ -1,22 +1,24 @@
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-  // <utility>
-  template <typename T>
-  T&& declval();
+    // <utility>
+    template <typename T>
+    T&& declval();
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t)
+            DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t)
+            DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
 
-  template <typename T>
-  struct deferred_false : types::false_type { };
+    template <typename T>
+    struct deferred_false : types::false_type
+    {
+    };
 
-} // namespace detail
-} // namespace doctest
+}} // namespace doctest::detail

--- a/doctest/parts/public/string.h
+++ b/doctest/parts/public/string.h
@@ -3,135 +3,146 @@ namespace doctest {
 #define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
 #endif
 
-    // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
-    // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
-    // - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
-    // - if small - capacity left before going on the heap - using the lowest 5 bits
-    // - if small - 2 bits are left unused - the second and third highest ones
-    // - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
-    //              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
-    // Idea taken from this lecture about the string implementation of facebook/folly - fbstring
-    // https://www.youtube.com/watch?v=kPR8h4-qZdk
-    // TODO:
-    // - optimizations - like not deleting memory unnecessarily in operator= and etc.
-    // - resize/reserve/clear
-    // - replace
-    // - back/front
-    // - iterator stuff
-    // - find & friends
-    // - push_back/pop_back
-    // - assign/insert/erase
-    // - relational operators as free functions - taking const char* as one of the params
-    class DOCTEST_INTERFACE String
+// A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
+// of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
+// - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
+// - if small - capacity left before going on the heap - using the lowest 5 bits
+// - if small - 2 bits are left unused - the second and third highest ones
+// - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
+//              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
+// Idea taken from this lecture about the string implementation of facebook/folly - fbstring
+// https://www.youtube.com/watch?v=kPR8h4-qZdk
+// TODO:
+// - optimizations - like not deleting memory unnecessarily in operator= and etc.
+// - resize/reserve/clear
+// - replace
+// - back/front
+// - iterator stuff
+// - find & friends
+// - push_back/pop_back
+// - assign/insert/erase
+// - relational operators as free functions - taking const char* as one of the params
+class DOCTEST_INTERFACE String
+{
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
+    static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
+
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
     {
-    public:
-        using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
-
-    private:
-        static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
-        static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
-
-        struct view // len should be more than sizeof(view) - because of the final byte for flags
-        {
-            char*    ptr;
-            size_type size;
-            size_type capacity;
-        };
-
-        union
-        {
-            char buf[len]; // NOLINT(*-avoid-c-arrays)
-            view data;
-        };
-
-        char* allocate(size_type sz);
-
-        bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
-        void setOnHeap() noexcept;
-        void setLast(size_type in = last) noexcept;
-        void setSize(size_type sz) noexcept;
-
-        void copy(const String& other);
-
-    public:
-        static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
-
-        String() noexcept;
-        ~String();
-
-        // cppcheck-suppress noExplicitConstructor
-        String(const char* in);
-        String(const char* in, size_type in_size);
-
-        String(std::istream& in, size_type in_size);
-
-        String(const String& other);
-        String& operator=(const String& other);
-
-        String& operator+=(const String& other);
-
-        String(String&& other) noexcept;
-        String& operator=(String&& other) noexcept;
-
-        char  operator[](size_type i) const;
-        char& operator[](size_type i);
-
-        // the only functions I'm willing to leave in the interface - available for inlining
-        const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-        char*       c_str() {
-            if (isOnStack()) {
-                return reinterpret_cast<char*>(buf);
-            }
-            return data.ptr;
-        }
-
-        size_type size() const;
-        size_type capacity() const;
-
-        String substr(size_type pos, size_type cnt = npos) &&;
-        String substr(size_type pos, size_type cnt = npos) const &;
-
-        size_type find(char ch, size_type pos = 0) const;
-        size_type rfind(char ch, size_type pos = npos) const;
-
-        int compare(const char* other, bool no_case = false) const;
-        int compare(const String& other, bool no_case = false) const;
-
-        friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+        char*     ptr;
+        size_type size;
+        size_type capacity;
     };
 
-    DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+    union
+    {
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
+        view data;
+    };
 
-    DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
+    char* allocate(size_type sz);
+
+    bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
+
+    void copy(const String& other);
+
+public:
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
+    ~String();
+
+    // cppcheck-suppress noExplicitConstructor
+    String(const char* in);
+    String(const char* in, size_type in_size);
+
+    String(std::istream& in, size_type in_size);
+
+    String(const String& other);
+    String& operator=(const String& other);
+
+    String& operator+=(const String& other);
+
+    String(String&& other) noexcept;
+    String& operator=(String&& other) noexcept;
+
+    char  operator[](size_type i) const;
+    char& operator[](size_type i);
+
+    // the only functions I'm willing to leave in the interface - available for inlining
+    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
+    char*       c_str() {
+        if(isOnStack()) {
+            return reinterpret_cast<char*>(buf);
+        }
+        return data.ptr;
+    }
+
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const&;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
+
+    int compare(const char* other, bool no_case = false) const;
+    int compare(const String& other, bool no_case = false) const;
+
+    friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+};
+
+DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+
+DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
 namespace detail {
 
 // MSVS 2015 :(
 #if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
     template <typename T, typename = void>
-    struct has_global_insertion_operator : types::false_type { };
+    struct has_global_insertion_operator : types::false_type
+    {
+    };
 
     template <typename T>
-    struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    struct has_global_insertion_operator<
+            T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())>
+            : types::true_type
+    {
+    };
 
     template <typename T, typename = void>
-    struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+    struct has_insertion_operator
+    {
+        static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value;
+    };
 
     template <typename T, bool global>
     struct insert_hack;
 
     template <typename T>
-    struct insert_hack<T, true> {
+    struct insert_hack<T, true>
+    {
         static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
     };
 
     template <typename T>
-    struct insert_hack<T, false> {
+    struct insert_hack<T, false>
+    {
         static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
     };
 
@@ -139,26 +150,36 @@ namespace detail {
     using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
 #else
     template <typename T, typename = void>
-    struct has_insertion_operator : types::false_type { };
+    struct has_insertion_operator : types::false_type
+    {
+    };
 #endif
 
     template <typename T>
-    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+    struct has_insertion_operator<
+            T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())>
+            : types::true_type
+    {
+    };
 
     template <typename T>
-    struct should_stringify_as_underlying_type {
-        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+    struct should_stringify_as_underlying_type
+    {
+        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value &&
+                                              !doctest::detail::has_insertion_operator<T>::value;
     };
 
     DOCTEST_INTERFACE std::ostream* tlssPush();
-    DOCTEST_INTERFACE String tlssPop();
+    DOCTEST_INTERFACE String        tlssPop();
 
     template <bool C>
-    struct StringMakerBase {
+    struct StringMakerBase
+    {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T)) {
 #ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
-            static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+            static_assert(deferred_false<T>::value,
+                          "No stringification detected for type T. See string conversion manual");
 #endif
             return "{?}";
         }
@@ -187,7 +208,8 @@ namespace detail {
     }
 
     template <>
-    struct StringMakerBase<true> {
+    struct StringMakerBase<true>
+    {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T) in) {
             return toStream(in);
@@ -196,10 +218,12 @@ namespace detail {
 
 } // namespace detail
 
-    template <typename T>
-    struct StringMaker : public detail::StringMakerBase<
-        detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
-    {};
+template <typename T>
+struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value ||
+                                                    detail::types::is_pointer<T>::value ||
+                                                    detail::types::is_array<T>::value>
+{
+};
 
 #ifndef DOCTEST_STRINGIFY
 #ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
@@ -209,84 +233,92 @@ namespace detail {
 #endif
 #endif
 
-    template <typename T>
-    String toString() {
-    #if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
-        String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
-        String::size_type beginPos = ret.find('<');
-        return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
-    #else
-        String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
-        String::size_type begin = ret.find('=') + 2;
-        return ret.substr(begin, ret.size() - begin - 1);
-    #endif // Compiler
-    }
+template <typename T>
+String toString() {
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1,
+                      ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    String            ret   = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif // Compiler
+}
 
-    template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        return StringMaker<T>::convert(value);
-    }
+template <typename T,
+          typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value,
+                                            bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
+}
 
-    inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+inline String&& toString(String&& in) { return static_cast<String&&>(in); }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE String toString(const char* in);
+DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-    // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-    DOCTEST_INTERFACE String toString(const std::string& in);
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string& in);
 #endif // VS 2019
 
-    DOCTEST_INTERFACE String toString(const String& in);
+DOCTEST_INTERFACE String toString(const String& in);
 
-    DOCTEST_INTERFACE String toString(std::nullptr_t);
+DOCTEST_INTERFACE String toString(std::nullptr_t);
 
-    DOCTEST_INTERFACE String toString(bool in);
+DOCTEST_INTERFACE String toString(bool in);
 
-    DOCTEST_INTERFACE String toString(float in);
-    DOCTEST_INTERFACE String toString(double in);
-    DOCTEST_INTERFACE String toString(double long in);
+DOCTEST_INTERFACE String toString(float in);
+DOCTEST_INTERFACE String toString(double in);
+DOCTEST_INTERFACE String toString(double long in);
 
-    DOCTEST_INTERFACE String toString(char in);
-    DOCTEST_INTERFACE String toString(char signed in);
-    DOCTEST_INTERFACE String toString(char unsigned in);
-    DOCTEST_INTERFACE String toString(short in);
-    DOCTEST_INTERFACE String toString(short unsigned in);
-    DOCTEST_INTERFACE String toString(signed in);
-    DOCTEST_INTERFACE String toString(unsigned in);
-    DOCTEST_INTERFACE String toString(long in);
-    DOCTEST_INTERFACE String toString(long unsigned in);
-    DOCTEST_INTERFACE String toString(long long in);
-    DOCTEST_INTERFACE String toString(long long unsigned in);
+DOCTEST_INTERFACE String toString(char in);
+DOCTEST_INTERFACE String toString(char signed in);
+DOCTEST_INTERFACE String toString(char unsigned in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-    template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        using UT = typename detail::types::underlying_type<T>::type;
-        return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
-    }
+template <typename T,
+          typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value,
+                                            bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
 namespace detail {
     template <typename T>
     struct filldata
     {
         static void fill(std::ostream* stream, const T& in) {
-    #if defined(_MSC_VER) && _MSC_VER <= 1900
-        insert_hack_t<T>::insert(*stream, in);
-    #else
-        operator<<(*stream, in);
-    #endif // _MSV_VER
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+            insert_hack_t<T>::insert(*stream, in);
+#else
+            operator<<(*stream, in);
+#endif // _MSV_VER
         }
     };
 
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
     // NOLINTBEGIN(*-avoid-c-arrays)
     template <typename T, size_t N>
-    struct filldata<T[N]> {
-        static void fill(std::ostream* stream, const T(&in)[N]) {
+    struct filldata<T[N]>
+    {
+        static void fill(std::ostream* stream, const T (&in)[N]) {
             *stream << "[";
-            for (size_t i = 0; i < N; i++) {
-                if (i != 0) { *stream << ", "; }
+            for(size_t i = 0; i < N; i++) {
+                if(i != 0) {
+                    *stream << ", ";
+                }
                 *stream << (DOCTEST_STRINGIFY(in[i]));
             }
             *stream << "]";
@@ -298,7 +330,8 @@ namespace detail {
     // Specialized since we don't want the terminating null byte!
     // NOLINTBEGIN(*-avoid-c-arrays)
     template <size_t N>
-    struct filldata<const char[N]> {
+    struct filldata<const char[N]>
+    {
         static void fill(std::ostream* stream, const char (&in)[N]) {
             *stream << String(in, in[N - 1] ? N : N - 1);
         } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
@@ -306,39 +339,42 @@ namespace detail {
     // NOLINTEND(*-avoid-c-arrays)
 
     template <>
-    struct filldata<const void*> {
+    struct filldata<const void*>
+    {
         DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
     };
 
     template <>
-    struct filldata<const volatile void*> {
+    struct filldata<const volatile void*>
+    {
         DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
     };
 
     template <typename T>
-    struct filldata<T*> {
+    struct filldata<T*>
+    {
         DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
         static void fill(std::ostream* stream, const T* in) {
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
+            DOCTEST_MSVC_SUPPRESS_WARNING_POP
+            DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
             filldata<const volatile void*>::fill(stream,
-        #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
-                reinterpret_cast<const volatile void*>(in)
-        #else
-                *reinterpret_cast<const volatile void* const*>(&in)
-        #endif // DOCTEST_GCC
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+                                                 reinterpret_cast<const volatile void*>(in)
+#else
+                                                 *reinterpret_cast<const volatile void* const*>(&in)
+#endif // DOCTEST_GCC
             );
-        DOCTEST_CLANG_SUPPRESS_WARNING_POP
+            DOCTEST_CLANG_SUPPRESS_WARNING_POP
         }
     };
 
-    #ifndef DOCTEST_CONFIG_DISABLE
+#ifndef DOCTEST_CONFIG_DISABLE
     template <typename L, typename R>
     String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
                                const DOCTEST_REF_WRAP(R) rhs) {
         return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
     }
-    #endif // DOCTEST_CONFIG_DISABLE
+#endif // DOCTEST_CONFIG_DISABLE
 } //namespace detail
 
 } // namespace doctest

--- a/doctest/parts/public/subcase.h
+++ b/doctest/parts/public/subcase.h
@@ -12,23 +12,23 @@ struct DOCTEST_INTERFACE SubcaseSignature
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-struct DOCTEST_INTERFACE Subcase
-{
-    SubcaseSignature m_signature;
-    bool             m_entered = false;
+    struct DOCTEST_INTERFACE Subcase
+    {
+        SubcaseSignature m_signature;
+        bool             m_entered = false;
 
-    Subcase(const String& name, const char* file, int line);
-    Subcase(const Subcase&) = delete;
-    Subcase(Subcase&&) = delete;
-    Subcase& operator=(const Subcase&) = delete;
-    Subcase& operator=(Subcase&&) = delete;
-    ~Subcase();
+        Subcase(const String& name, const char* file, int line);
+        Subcase(const Subcase&)            = delete;
+        Subcase(Subcase&&)                 = delete;
+        Subcase& operator=(const Subcase&) = delete;
+        Subcase& operator=(Subcase&&)      = delete;
+        ~Subcase();
 
-    operator bool() const;
+        operator bool() const;
 
     private:
         bool checkFilters();
-};
+    };
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/public/test_case.h
+++ b/doctest/parts/public/test_case.h
@@ -1,20 +1,20 @@
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData
-    {
-        String      m_file;       // the file in which the test was registered (using String - see #350)
-        unsigned    m_line;       // the line where the test was registered
-        const char* m_name;       // name of the test case
-        const char* m_test_suite; // the test suite in which the test was added
-        const char* m_description;
-        bool        m_skip;
-        bool        m_no_breaks;
-        bool        m_no_output;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
-    };
+struct DOCTEST_INTERFACE TestCaseData
+{
+    String      m_file;       // the file in which the test was registered (using String - see #350)
+    unsigned    m_line;       // the line where the test was registered
+    const char* m_name;       // name of the test case
+    const char* m_test_suite; // the test suite in which the test was added
+    const char* m_description;
+    bool        m_skip;
+    bool        m_no_breaks;
+    bool        m_no_output;
+    bool        m_may_fail;
+    bool        m_should_fail;
+    int         m_expected_failures;
+    double      m_timeout;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
@@ -30,7 +30,7 @@ namespace detail {
         String m_full_name; // contains the name (only for templated test cases!) + the template type
 
         TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                  const String& type = String(), int template_id = -1);
+                 const String& type = String(), int template_id = -1);
 
         TestCase(const TestCase& other);
         TestCase(TestCase&&) = delete;

--- a/doctest/parts/public/test_suite.h
+++ b/doctest/parts/public/test_suite.h
@@ -1,35 +1,32 @@
 #ifndef DOCTEST_CONFIG_DISABLE
 
-namespace doctest {
-namespace detail {
+namespace doctest { namespace detail {
 
-struct DOCTEST_INTERFACE TestSuite
-{
-    const char* m_test_suite = nullptr;
-    const char* m_description = nullptr;
-    bool        m_skip = false;
-    bool        m_no_breaks = false;
-    bool        m_no_output = false;
-    bool        m_may_fail = false;
-    bool        m_should_fail = false;
-    int         m_expected_failures = 0;
-    double      m_timeout = 0;
+    struct DOCTEST_INTERFACE TestSuite
+    {
+        const char* m_test_suite        = nullptr;
+        const char* m_description       = nullptr;
+        bool        m_skip              = false;
+        bool        m_no_breaks         = false;
+        bool        m_no_output         = false;
+        bool        m_may_fail          = false;
+        bool        m_should_fail       = false;
+        int         m_expected_failures = 0;
+        double      m_timeout           = 0;
 
-    TestSuite& operator*(const char* in);
+        TestSuite& operator*(const char* in);
 
-    template <typename T>
-    TestSuite& operator*(const T& in) {
-        in.fill(*this);
-        return *this;
-    }
-};
+        template <typename T>
+        TestSuite& operator*(const T& in) {
+            in.fill(*this);
+            return *this;
+        }
+    };
 
-// forward declarations of functions used by the macros
-DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+    // forward declarations of functions used by the macros
+    DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
 
-} // namespace detail
-
-} // namespace doctest
+}} // namespace doctest::detail
 
 // in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden

--- a/doctest/parts/public/utility.h
+++ b/doctest/parts/public/utility.h
@@ -1,13 +1,12 @@
 #define DOCTEST_DECLARE_INTERFACE(name)                                                            \
     virtual ~name();                                                                               \
-    name() = default;                                                                              \
-    name(const name&) = delete;                                                                    \
-    name(name&&) = delete;                                                                         \
+    name()                       = default;                                                        \
+    name(const name&)            = delete;                                                         \
+    name(name&&)                 = delete;                                                         \
     name& operator=(const name&) = delete;                                                         \
-    name& operator=(name&&) = delete;
+    name& operator=(name&&)      = delete;
 
-#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
-    name::~name() = default;
+#define DOCTEST_DEFINE_INTERFACE(name) name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -26,9 +25,9 @@
 
 namespace doctest { namespace detail {
     static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
-}}
+}} // namespace doctest::detail
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
-    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                              \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                            \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP

--- a/doctest/parts/public/version.h
+++ b/doctest/parts/public/version.h
@@ -11,9 +11,8 @@
 #define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 
 #define DOCTEST_VERSION_STR                                                                        \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR)                                                           \
+    "." DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "." DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
 
 #define DOCTEST_VERSION                                                                            \
     (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)


### PR DESCRIPTION
## Description
Applies the current clang-format settings across all current segmented files. Posting as a draft, as this is more of a proof-of-concept. While the ability to actually apply these changes will be very beneficial, there's two major considerations that need to be accounted for first:
- Updating `.clang-format`. A lot of the options specified are rather unconventional, and weren't actually utilized by the repository in the overwhelming majority of cases. A pass applying clang-format would ideally go hand-in-hand with one that decides on what rules we should apply
- Missing headers/metadata. The lack of headers and/or explicitly specified metadata are likely causing formatting quirks. The headers will be accounted for via #1000, but metadata would need to be part of the same pass that updates the clang-format rules