### PR TITLE
chore: Extract path utilities to doctest/parts/path.h

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -2009,13 +2009,11 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_DISABLE
 
 } // namespace doctest
-
 namespace doctest {
 
 DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
 
 } // namespace doctest
-
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
@@ -5848,50 +5846,6 @@ namespace detail {
 #endif
 
 
-namespace doctest {
-
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
-// depending on the current options this will remove the path of filenames
-const char* skipPathFromFilename(const char* file) {
-#ifndef DOCTEST_CONFIG_DISABLE
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
-        auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
-                forward = back;
-            return forward + 1;
-        }
-    } else {
-        const auto prefixes = getContextOptions()->strip_file_prefixes;
-        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
-        String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
-            const auto prefix_start = pos;
-            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
-
-            const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
-                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
-                    longest_match = prefix_size;
-                }
-            }
-        }
-        return &file[longest_match];
-    }
-#endif // DOCTEST_CONFIG_DISABLE
-    return file;
-}
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-
-} // namespace doctest
-
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
@@ -6751,6 +6705,55 @@ String toString(IsNaN<double> in) { return toString<double>(in); }
 String toString(IsNaN<double long> in) { return toString<double long>(in); }
 
 } // namespace doctest
+
+#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
+#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
+#endif
+
+namespace doctest {
+
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+// depending on the current options this will remove the path of filenames
+const char* skipPathFromFilename(const char* file) {
+#ifndef DOCTEST_CONFIG_DISABLE
+    if(getContextOptions()->no_path_in_filenames) {
+        auto back    = std::strrchr(file, '\\');
+        auto forward = std::strrchr(file, '/');
+        if(back || forward) {
+            if(back > forward)
+                forward = back;
+            return forward + 1;
+        }
+    } else {
+        const auto prefixes = getContextOptions()->strip_file_prefixes;
+        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        String::size_type longest_match = 0U;
+        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
+        {
+            const auto prefix_start = pos;
+            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
+
+            const auto prefix_size = pos - prefix_start;
+            if(prefix_size > longest_match)
+            {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
+                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
+                {
+                    longest_match = prefix_size;
+                }
+            }
+        }
+        return &file[longest_match];
+    }
+#endif // DOCTEST_CONFIG_DISABLE
+    return file;
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+} // namespace doctest
+
 
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/doctest_fwd.h
+++ b/doctest/parts/doctest_fwd.h
@@ -82,13 +82,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly define
 #include <doctest/parts/public/exception_translator.h>
 #include <doctest/parts/public/context_scope.h>
 #include <doctest/parts/public/assert/message.h>
-
-namespace doctest {
-
-DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
-
-} // namespace doctest
-
+#include <doctest/parts/public/path.h>
 #include <doctest/parts/public/exceptions.h>
 #include <doctest/parts/public/context.h>
 #include <doctest/parts/public/assert/handler.h>

--- a/doctest/parts/private/doctest.cpp
+++ b/doctest/parts/private/doctest.cpp
@@ -13,50 +13,6 @@
 #include "doctest/parts/private/context_scope.h"
 #include "doctest/parts/private/reporter.h"
 
-namespace doctest {
-
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
-// depending on the current options this will remove the path of filenames
-const char* skipPathFromFilename(const char* file) {
-#ifndef DOCTEST_CONFIG_DISABLE
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
-        auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
-                forward = back;
-            return forward + 1;
-        }
-    } else {
-        const auto prefixes = getContextOptions()->strip_file_prefixes;
-        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
-        String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
-            const auto prefix_start = pos;
-            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
-
-            const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
-                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
-                    longest_match = prefix_size;
-                }
-            }
-        }
-        return &file[longest_match];
-    }
-#endif // DOCTEST_CONFIG_DISABLE
-    return file;
-}
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-
-} // namespace doctest
-
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {

--- a/doctest/parts/private/path.cpp
+++ b/doctest/parts/private/path.cpp
@@ -1,0 +1,50 @@
+#include "doctest/parts/private/prelude.h"
+
+#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
+#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
+#endif
+
+namespace doctest {
+
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
+// depending on the current options this will remove the path of filenames
+const char* skipPathFromFilename(const char* file) {
+#ifndef DOCTEST_CONFIG_DISABLE
+    if(getContextOptions()->no_path_in_filenames) {
+        auto back    = std::strrchr(file, '\\');
+        auto forward = std::strrchr(file, '/');
+        if(back || forward) {
+            if(back > forward)
+                forward = back;
+            return forward + 1;
+        }
+    } else {
+        const auto prefixes = getContextOptions()->strip_file_prefixes;
+        const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
+        String::size_type longest_match = 0U;
+        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
+        {
+            const auto prefix_start = pos;
+            pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
+
+            const auto prefix_size = pos - prefix_start;
+            if(prefix_size > longest_match)
+            {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
+                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
+                {
+                    longest_match = prefix_size;
+                }
+            }
+        }
+        return &file[longest_match];
+    }
+#endif // DOCTEST_CONFIG_DISABLE
+    return file;
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+} // namespace doctest
+

--- a/doctest/parts/public/path.h
+++ b/doctest/parts/public/path.h
@@ -1,0 +1,5 @@
+namespace doctest {
+
+DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
+
+} // namespace doctest


### PR DESCRIPTION
## Description

Extracts path-related functions to `doctest/parts/path.h`. Currently, this is only the `skipPathFromFilename` function which is used by reporters and CLI code.

## GitHub Issues

#941