### PR TITLE
chore: Extract global entry-point to doctest/parts/main.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,11 @@ if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
         ${doctest_parts_folder}/private/debugger.cpp
         ${doctest_parts_folder}/private/exception_translator.cpp
         ${doctest_parts_folder}/private/exceptions.cpp
+        ${doctest_parts_folder}/private/main.cpp
         ${doctest_parts_folder}/private/matchers/approx.cpp
         ${doctest_parts_folder}/private/matchers/contains.cpp
         ${doctest_parts_folder}/private/matchers/is_nan.cpp
+        ${doctest_parts_folder}/private/path.cpp
         ${doctest_parts_folder}/private/string.cpp
         ${doctest_parts_folder}/private/subcase.cpp
         ${doctest_parts_folder}/private/test_case.cpp

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5841,10 +5841,6 @@ namespace detail {
 
 #endif // DOCTEST_CONFIG_DISABLE
 
-#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
-#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
-#endif
-
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
@@ -6533,12 +6529,6 @@ namespace doctest {
 
 #endif // DOCTEST_CONFIG_DISABLE
 
-#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
-int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
@@ -6620,6 +6610,12 @@ namespace detail {
 } // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
+int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 namespace doctest {
 

--- a/doctest/parts/private/doctest.cpp
+++ b/doctest/parts/private/doctest.cpp
@@ -1,9 +1,5 @@
 #include "doctest/parts/private/prelude.h"
 
-#ifndef DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR
-#define DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR ':'
-#endif
-
 #include "doctest/parts/private/exceptions.h"
 #include "doctest/parts/private/timer.h"
 #include "doctest/parts/private/atomic.h"
@@ -104,9 +100,3 @@ namespace detail {
 #include "doctest/parts/private/reporters/debug_output_window.h"
 
 #endif // DOCTEST_CONFIG_DISABLE
-
-#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
-int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN

--- a/doctest/parts/private/main.cpp
+++ b/doctest/parts/private/main.cpp
@@ -1,0 +1,7 @@
+#include "doctest/parts/private/prelude.h"
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
+int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN


### PR DESCRIPTION
## Description

Extracts the optional `main` method to `doctest/parts/main.cpp`

## GitHub Issues

#941