### PR TITLE
fix: Suppress -Wnrvo for clang and gcc

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -257,6 +257,7 @@
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                 \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                       \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                   \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                              \
@@ -270,6 +271,7 @@
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                         \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                            \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                         \
                                                                                                    \
     DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */    \
     DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */  \

--- a/doctest/parts/public/warnings.h
+++ b/doctest/parts/public/warnings.h
@@ -139,6 +139,7 @@
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                 \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                     \
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                       \
                                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                   \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                              \
@@ -152,6 +153,7 @@
     DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                              \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                         \
     DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                            \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                         \
                                                                                                    \
     DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */    \
     DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */  \


### PR DESCRIPTION
## Description

Adds `-Wnrvo` to both clang and gcc private-warnings suppressions. While we don't have an actual hit for `-Wnrvo` on `gcc-15` on the CI/CD, it's still reasonable to suppress given that `clang-21` triggers it.

Suppression is better than resolution here since we actually don't _care_ that NRVO isn't being performed.

## GitHub Issues

#928 
