### PR TITLE
fix: Suppress -Wmissing-noreturn in certain tests for clang

### DIFF
--- a/examples/all_features/assert_returns_disabled.cpp
+++ b/examples/all_features/assert_returns_disabled.cpp
@@ -12,6 +12,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define TEST_FAIL() std::cout << "FAILED ON: " << __LINE__ \
     << "(" << (TEST_FLIP ? "EVALUATED" : "DISABLED") << ")" << std::endl
 
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-noreturn")
 static int test_disabled_var_ = [] { // NOLINT
     // none may return true
     if (TEST_FLIP ^ CHECK(0 == 0)) { TEST_FAIL(); }
@@ -28,3 +29,4 @@ static int test_disabled_var_ = [] { // NOLINT
 
     return 0;
 }();
+DOCTEST_CLANG_SUPPRESS_WARNING_POP


### PR DESCRIPTION
## Description

Adds a clang suppression for `-Wmissing-noreturn` in the `assert_retuns_disabled.cpp` test-suite.

Preferably we would use `DOCTEST_NORETURN`, but using `[[noreturn]]` in a lambda is a C++23 extension. 

## GitHub Issues

Fixes #950