### PR TITLE
chore: Disable werror outside of CI/CD

### DIFF
--- a/.github/workflows/build_and_test.py
+++ b/.github/workflows/build_and_test.py
@@ -39,6 +39,7 @@ def run_test(build_type, test_mode, flags, test=True):
         f"-B build "
         f"-D CMAKE_BUILD_TYPE={build_type} "
         f"-D DOCTEST_TEST_MODE={test_mode} "
+         "-D DOCTEST_INTERNAL_WERROR=ON "
         + (flags and f'-D CMAKE_CXX_FLAGS="{flags}" ')
         + f"-D CMAKE_CXX_COMPILER={used_cxx}"
     ):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ option(DOCTEST_WITH_MAIN_IN_STATIC_LIB  "Build a static lib (cmake target) with 
 option(DOCTEST_NO_INSTALL  "Skip the installation process" OFF)
 option(DOCTEST_USE_STD_HEADERS  "Use std headers" OFF)
 
+option(DOCTEST_INTERNAL_WERROR "Enables -Werror" OFF)
+
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -83,7 +83,10 @@ macro(add_compiler_flags)
 endmacro()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    add_compiler_flags(-Werror)
+    if(DOCTEST_INTERNAL_WERROR)
+        add_compiler_flags(-Werror)
+    endif()
+
     add_compiler_flags(-fstrict-aliasing)
 
     # The following options are not valid when clang-cl is used.
@@ -198,8 +201,11 @@ endif()
 if(MSVC)
     add_compiler_flags(/std:c++latest) # for post c++14 updates in MSVC
     add_compiler_flags(/permissive-)   # force standard conformance - this is the better flag than /Za
-    add_compiler_flags(/WX)
     add_compiler_flags(/Wall) # turns on warnings from levels 1 through 4 which are off by default - https://msdn.microsoft.com/en-us/library/23k5d385.aspx
+
+    if(DOCTEST_INTERNAL_WERROR)
+        add_compiler_flags(/WX)
+    endif()
 
     add_compiler_flags(
         /wd4514 # unreferenced inline function has been removed


### PR DESCRIPTION
## Description

Quality-of-life change. `-Werror` is only enabled by-default when building on pipeline (but may still be optionally enabled in local dev environments).

Tested by quickly inducing a warning (specifically, an unused parameter warning) and checking that:

* With a regular `cmake ...` setup, warnings do not block the build, and
* When `-D DOCTEST_INTERNAL_WERROR=ON` is set, warnings become errors

## GitHub Issues

#774