### PR TITLE
feat: Sync `clang-format` with LLVM

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,82 +1,246 @@
-# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-
-DisableFormat: false
-Language: Cpp
-Standard: Cpp11
-IndentWidth: 4
-TabWidth: 4
-UseTab: Never
-ColumnLimit: 100
-ReflowComments: false
-SortIncludes: false
-
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: false
-AlignOperands: true
-AlignTrailingComments: true
-AlignAfterOpenBracket: true
-DerivePointerAlignment: false
-PointerAlignment: Left
-IndentCaseLabels: true
-ContinuationIndentWidth: 8
-NamespaceIndentation: Inner
-CompactNamespaces: true
-FixNamespaceComments: true
+# Commented out parameters are those with the same value as base LLVM style.
+# We can uncomment them if we want to change their value, or enforce the
+# chosen value in case the base style changes (last sync: Clang 18.1.8).
+BasedOnStyle: LLVM
 AccessModifierOffset: -4
-
-SpaceAfterControlStatementKeyword: false
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: Never
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
-SpacesInContainerLiterals: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Cpp11BracedListStyle: true
-
-KeepEmptyLinesAtTheStartOfBlocks: false
-MaxEmptyLinesToKeep: 1
-BinPackArguments: true
-BinPackParameters: true
-AlwaysBreakAfterReturnType: None
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakTemplateDeclarations: true
-BreakConstructorInitializersBeforeComma: true
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 8
-
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AllowShortBlocksOnASingleLine: true
+AlignAfterOpenBracket: BlockIndent
+# AlignArrayOfStructures: None
+# AlignConsecutiveAssignments:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: true
+# AlignConsecutiveBitFields:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveDeclarations:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveMacros:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: true
+  # AcrossEmptyLines: false
+  # AcrossComments: false
+  # AlignCaseColons: false
+AlignEscapedNewlines: Right
+# AlignOperands: Align
+# AlignTrailingComments:
+#   Kind: Always
+#   OverEmptyLines: 0
+# AllowAllArgumentsOnNextLine: true
+# AllowAllParametersOfDeclarationOnNextLine: true
+# AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortFunctionsOnASingleLine: All
-
-BreakBeforeBinaryOperators: false
-BreakBeforeTernaryOperators: false
-BreakStringLiterals: true
-BreakBeforeBraces: Custom
-BraceWrapping:
-    AfterClass: true
-    AfterEnum: true
-    AfterNamespace: false
-    AfterStruct: true
-    AfterUnion: true
-    
-    BeforeCatch: false
-    BeforeElse: false
-    IndentBraces: false
-    AfterFunction: false
-    AfterControlStatement: false
-
-# penalties not thought of yet
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 60
-PenaltyBreakString: 1000
-PenaltyBreakFirstLessLess: 120
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 1000
+# AllowShortCompoundRequirementOnASingleLine: true
+# AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+# AllowShortIfStatementsOnASingleLine: Never
+# AllowShortLambdasOnASingleLine: All
+# AllowShortLoopsOnASingleLine: false
+# AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakAfterReturnType: None
+# AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+# AttributeMacros:
+#   - __capability
+BinPackArguments: false
+BinPackParameters: false
+# BitFieldColonSpacing: Both
+# BraceWrapping:
+#   AfterCaseLabel: false
+#   AfterClass: false
+#   AfterControlStatement: Never
+#   AfterEnum: false
+#   AfterFunction: false
+#   AfterNamespace: false
+#   AfterObjCDeclaration: false
+#   AfterStruct: false
+#   AfterUnion: false
+#   AfterExternBlock: false
+#   BeforeCatch: false
+#   BeforeElse: false
+#   BeforeLambdaBody: false
+#   BeforeWhile: false
+#   IndentBraces: false
+#   SplitEmptyFunction: true
+#   SplitEmptyRecord: true
+#   SplitEmptyNamespace: true
+# BreakAdjacentStringLiterals: true
+# BreakAfterAttributes: Leave
+# BreakAfterJavaFieldAnnotations: false
+# BreakArrays: true
+# BreakBeforeBinaryOperators: None
+# BreakBeforeBraces: Attach
+# BreakBeforeConceptDeclarations: Always
+# BreakBeforeInlineASMColon: OnlyMultiline
+# BreakBeforeTernaryOperators: true
+# BreakConstructorInitializers: BeforeColon
+# BreakInheritanceList: BeforeColon
+# BreakStringLiterals: true
+ColumnLimit: 120
+# CommentPragmas: "^ IWYU pragma:"
+# CompactNamespaces: false
+# ConstructorInitializerIndentWidth: 4
+# ContinuationIndentWidth: 4
+# Cpp11BracedListStyle: true
+# DerivePointerAlignment: false
+# DisableFormat: false
+# EmptyLineAfterAccessModifier: Never
+# EmptyLineBeforeAccessModifier: LogicalBlock
+# ExperimentalAutoDetectBinPacking: false
+# FixNamespaceComments: true
+# ForEachMacros:
+#   - foreach
+#   - Q_FOREACH
+#   - BOOST_FOREACH
+# IfMacros:
+#   - KJ_IF_MAYBE
+# IncludeBlocks: Preserve
+# IncludeCategories:
+#   - Regex: ^"(llvm|llvm-c|clang|clang-c)/
+#     Priority: 2
+#     SortPriority: 0
+#     CaseSensitive: false
+#   - Regex: ^(<|"(gtest|gmock|isl|json)/)
+#     Priority: 3
+#     SortPriority: 0
+#     CaseSensitive: false
+#   - Regex: .*
+#     Priority: 1
+#     SortPriority: 0
+#     CaseSensitive: false
+# IncludeIsMainRegex: (Test)?$
+# IncludeIsMainSourceRegex: ""
+# IndentAccessModifiers: false
+# IndentCaseBlocks: false
+IndentCaseLabels: true
+# IndentExternBlock: AfterExternBlock
+# IndentGotoLabels: true
+# IndentPPDirectives: None
+# IndentRequiresClause: true
+IndentWidth: 4
+# IndentWrappedFunctionNames: false
+# InsertBraces: false
+# InsertNewlineAtEOF: false
+# InsertTrailingCommas: None
+# IntegerLiteralSeparator:
+#   Binary: 0
+#   BinaryMinDigits: 0
+#   Decimal: 0
+#   DecimalMinDigits: 0
+#   Hex: 0
+#   HexMinDigits: 0
+# JavaScriptQuotes: Leave
+# JavaScriptWrapImports: true
+# KeepEmptyLinesAtEOF: false
+# KeepEmptyLinesAtTheStartOfBlocks: true
+# LambdaBodyIndentation: Signature
+# LineEnding: DeriveLF
+# MacroBlockBegin: ""
+# MacroBlockEnd: ""
+# MaxEmptyLinesToKeep: 1
+# NamespaceIndentation: None
+# ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+# ObjCBreakBeforeNestedBlockParam: true
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
+# PPIndentWidth: -1
+PackConstructorInitializers: NextLineOnly
+# PenaltyBreakAssignment: 2
+# PenaltyBreakBeforeFirstCallParameter: 19
+# PenaltyBreakComment: 300
+# PenaltyBreakFirstLessLess: 120
+# PenaltyBreakOpenParenthesis: 0
+# PenaltyBreakScopeResolution: 500
+# PenaltyBreakString: 1000
+# PenaltyBreakTemplateDeclaration: 10
+# PenaltyExcessCharacter: 1000000
+# PenaltyIndentedWhitespace: 0
+# PenaltyReturnTypeOnItsOwnLine: 60
+# PointerAlignment: Right
+QualifierAlignment: Custom
+QualifierOrder: [static, inline, friend, constexpr, const, volatile, type, restrict]
+# ReferenceAlignment: Pointer
+# ReflowComments: true
+# RemoveBracesLLVM: false
+# RemoveParentheses: Leave
+# RemoveSemicolon: false
+# RequiresClausePosition: OwnLine
+# RequiresExpressionIndentation: OuterScope
+# SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 0
+# SkipMacroDefinitionBody: false
+SortIncludes: Never
+# SortJavaStaticImport: Before
+# SortUsingDeclarations: LexicographicNumeric
+# SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
+# SpaceAfterTemplateKeyword: true
+# SpaceAroundPointerQualifiers: Default
+# SpaceBeforeAssignmentOperators: true
+# SpaceBeforeCaseColon: false
+# SpaceBeforeCpp11BracedList: false
+# SpaceBeforeCtorInitializerColon: true
+# SpaceBeforeInheritanceColon: true
+# SpaceBeforeJsonColon: false
+# SpaceBeforeParens: ControlStatements
+# SpaceBeforeParensOptions:
+#   AfterControlStatements: true
+#   AfterForeachMacros: true
+#   AfterFunctionDeclarationName: false
+#   AfterFunctionDefinitionName: false
+#   AfterIfMacros: true
+#   AfterOverloadedOperator: false
+#   AfterPlacementOperator: true
+#   AfterRequiresInClause: false
+#   AfterRequiresInExpression: false
+#   BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: false
+# SpaceBeforeSquareBrackets: false
+# SpaceInEmptyBlock: false
+# SpacesBeforeTrailingComments: 1
+# SpacesInAngles: Never
+# SpacesInContainerLiterals: true
+# SpacesInLineCommentPrefix:
+#   Minimum: 1
+#   Maximum: -1
+# SpacesInParens: Never
+# SpacesInParensOptions:
+#   InConditionalStatements: false
+#   InCStyleCasts: false
+#   InEmptyParentheses: false
+#   Other: false
+# SpacesInSquareBrackets: false
+Standard: c++11
+# StatementAttributeLikeMacros:
+#   - Q_EMIT
+# StatementMacros:
+#   - Q_UNUSED
+#   - QT_REQUIRE_VERSION
+TabWidth: 4
+# UseTab: Never
+# VerilogBreakBetweenInstancePorts: true
+# WhitespaceSensitiveMacros:
+#   - BOOST_PP_STRINGIZE
+#   - CF_SWIFT_NAME
+#   - NS_SWIFT_NAME
+#   - PP_STRINGIZE
+#   - STRINGIZE

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -57,13 +57,14 @@
 #define DOCTEST_TOSTR_IMPL(x) #x
 #define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 
-#define DOCTEST_VERSION_STR                                                                        \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
+// clang-format off
+#define DOCTEST_VERSION_STR                                                                                            \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                                           \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                                           \
     DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
+// clang-format on
 
-#define DOCTEST_VERSION                                                                            \
-    (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
 
 #endif // DOCTEST_PARTS_PUBLIC_VERSION
 // =================================================================================================
@@ -81,21 +82,19 @@
 #define DOCTEST_CPLUSPLUS __cplusplus
 #endif
 
-#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
+#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
 
 // GCC/Clang and GCC/MSVC are mutually exclusive, but Clang/MSVC are not because of clang-cl...
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
 #if _MSC_VER == _MSC_FULL_VER / 10000
 #define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
 #else // MSVC
-#define DOCTEST_MSVC                                                                               \
-    DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
 #endif // MSVC
 #endif // MSVC
 #if defined(__clang__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
 #define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
-#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) &&              \
-        !defined(__INTEL_COMPILER)
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__INTEL_COMPILER)
 #define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #endif // GCC
 #if defined(__INTEL_COMPILER)
@@ -129,7 +128,7 @@
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
 #define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
 #define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                \
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                                    \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
 #else // DOCTEST_CLANG
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
@@ -143,8 +142,7 @@
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
 #define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
 #define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
 #else // DOCTEST_GCC
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_GCC_SUPPRESS_WARNING(w)
@@ -156,8 +154,7 @@
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
 #define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)                                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
 #else // DOCTEST_MSVC
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w)
@@ -171,139 +168,139 @@
 
 // both the header and the implementation suppress all of these,
 // so it only makes sense to aggregate them like so
-#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                        \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")                                              \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                      \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                       \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                         \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                 \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                     \
-                                                                                                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    /* these 4 also disabled globally via cmake: */                                                \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */        \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                \
-    /* common ones */                                                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */        \
-    /* static analysis */                                                                          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */       \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                                             \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")                                                                  \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                                          \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                                     \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                                         \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    /* these 4 also disabled globally via cmake: */                                                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                                    \
+    /* common ones */                                                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
+    /* static analysis */                                                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
 
-#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \
-    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                               \
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                                   \
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH                                                      \
-    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                          \
-                                                                                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")                                                 \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")                                            \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                             \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")                                                   \
-                                                                                                   \
+#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH                                                                          \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")                                                                     \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")                                                                       \
+                                                                                                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */
 
 #define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
-#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH                                                     \
-    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                          \
-                                                                                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")                                        \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")                              \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")                                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")                                                \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")                                             \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                 \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-function")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                       \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")                                                       \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")                                    \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                         \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                            \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                         \
-                                                                                                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4577) /* 'noexcept' with no exception handling mode specified */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string in argument is not a string literal */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4800) /* forcing value to bool (performance warning) */          \
+#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH                                                                         \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")                                                  \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")                                                                    \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")                                                                 \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                     \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-function")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                                           \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")                                                        \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                                             \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4577) /* 'noexcept' with no exception handling mode specified */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string in argument is not a string literal */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4800) /* forcing value to bool (performance warning) */                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(5245) /* unreferenced function with internal linkage removed */
 
 #define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
-#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */       \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */     \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */      \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */     \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */  \
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5262) /* implicit fall-through */
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
@@ -363,8 +360,8 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #undef DOCTEST_CONFIG_WINDOWS_SEH
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
-#if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) &&             \
-        !defined(__EMSCRIPTEN__) && !defined(__wasi__)
+#if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(__EMSCRIPTEN__) &&     \
+    !defined(__wasi__)
 #define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
@@ -372,8 +369,7 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
-        || defined(__wasi__)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND) || defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
@@ -530,16 +526,15 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
-#define DOCTEST_DECLARE_INTERFACE(name)                                                            \
-    virtual ~name();                                                                               \
-    name() = default;                                                                              \
-    name(const name&) = delete;                                                                    \
-    name(name&&) = delete;                                                                         \
-    name& operator=(const name&) = delete;                                                         \
-    name& operator=(name&&) = delete;
+#define DOCTEST_DECLARE_INTERFACE(name)                                                                                \
+    virtual ~name();                                                                                                   \
+    name() = default;                                                                                                  \
+    name(const name &) = delete;                                                                                       \
+    name(name &&) = delete;                                                                                            \
+    name &operator=(const name &) = delete;                                                                            \
+    name &operator=(name &&) = delete;
 
-#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
-    name::~name() = default;
+#define DOCTEST_DEFINE_INTERFACE(name) name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -551,20 +546,24 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #endif // __COUNTER__
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#define DOCTEST_REF_WRAP(x) x&
+#define DOCTEST_REF_WRAP(x) x &
 #else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x
 #endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 
-namespace doctest { namespace detail {
+namespace doctest {
+namespace detail {
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-function")
-    static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
+static DOCTEST_CONSTEXPR int consume(const int *, int) noexcept {
+    return 0;
+}
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
-}}
+} // namespace detail
+} // namespace doctest
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
-    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                                  \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                                                \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
@@ -579,7 +578,7 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 #ifdef DOCTEST_PLATFORM_LINUX
 #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
 // Break at the location of the failing check if possible
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
 #else
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <signal.h>
@@ -588,10 +587,11 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
 #elif defined(__ppc__) || defined(__ppc64__)
 // https://www.cocoawithlove.com/2008/03/break-into-debugger.html
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() /* NOLINTNEXTLINE(hicpp-no-assembler) */                                         \
+    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" ::: "memory", "r0", "r3", "r4")
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
@@ -611,9 +611,9 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 namespace doctest {
 namespace detail {
-    DOCTEST_INTERFACE bool isDebuggerActive();
-} // detail
-} // doctest
+DOCTEST_INTERFACE bool isDebuggerActive();
+} // namespace detail
+} // namespace doctest
 
 #endif
 
@@ -635,19 +635,19 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-namespace std { // NOLINT(cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
-typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
+namespace std {                          // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr) nullptr_t;     // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void *)) size_t; // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+class basic_ostream;                                    // NOLINT(fuchsia-virtual-inheritance)
 typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
-template<class traits>
+template <class traits>
 // NOLINTNEXTLINE
-basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
+basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const char *);
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
@@ -668,8 +668,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
 namespace doctest {
-  using std::size_t;
-}
+using std::size_t;
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 
@@ -691,37 +691,77 @@ namespace detail {
 namespace types {
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  using namespace std;
+using namespace std;
 #else
-  template <bool COND, typename T = void>
-  struct enable_if { };
+template <bool COND, typename T = void>
+struct enable_if {};
 
-  template <typename T>
-  struct enable_if<true, T> { using type = T; };
+template <typename T>
+struct enable_if<true, T> {
+    using type = T;
+};
 
-  struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
-  struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
+struct true_type {
+    static DOCTEST_CONSTEXPR bool value = true;
+};
 
-  template <typename T> struct remove_reference { using type = T; };
-  template <typename T> struct remove_reference<T&> { using type = T; };
-  template <typename T> struct remove_reference<T&&> { using type = T; };
+struct false_type {
+    static DOCTEST_CONSTEXPR bool value = false;
+};
 
-  template <typename T> struct is_rvalue_reference : false_type { };
-  template <typename T> struct is_rvalue_reference<T&&> : true_type { };
+template <typename T>
+struct remove_reference {
+    using type = T;
+};
 
-  template<typename T> struct remove_const { using type = T; };
-  template <typename T> struct remove_const<const T> { using type = T; };
+template <typename T>
+struct remove_reference<T &> {
+    using type = T;
+};
 
-  // Compiler intrinsics
-  template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
-  template <typename T> struct underlying_type { using type = __underlying_type(T); };
+template <typename T>
+struct remove_reference<T &&> {
+    using type = T;
+};
 
-  template <typename T> struct is_pointer : false_type { };
-  template <typename T> struct is_pointer<T*> : true_type { };
+template <typename T>
+struct is_rvalue_reference : false_type {};
 
-  template <typename T> struct is_array : false_type { };
-  // NOLINTNEXTLINE(*-avoid-c-arrays)
-  template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+template <typename T>
+struct is_rvalue_reference<T &&> : true_type {};
+
+template <typename T>
+struct remove_const {
+    using type = T;
+};
+
+template <typename T>
+struct remove_const<const T> {
+    using type = T;
+};
+
+// Compiler intrinsics
+template <typename T>
+struct is_enum {
+    static DOCTEST_CONSTEXPR bool value = __is_enum(T);
+};
+
+template <typename T>
+struct underlying_type {
+    using type = __underlying_type(T);
+};
+
+template <typename T>
+struct is_pointer : false_type {};
+
+template <typename T>
+struct is_pointer<T *> : true_type {};
+
+template <typename T>
+struct is_array : false_type {};
+// NOLINTNEXTLINE(*-avoid-c-arrays)
+template <typename T, size_t SIZE>
+struct is_array<T[SIZE]> : true_type {};
 #endif
 
 } // namespace types
@@ -740,22 +780,22 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-  // <utility>
-  template <typename T>
-  T&& declval();
+// <utility>
+template <typename T>
+T &&declval();
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &&t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
 
-  template <typename T>
-  struct deferred_false : types::false_type { };
+template <typename T>
+struct deferred_false : types::false_type {};
 
 } // namespace detail
 } // namespace doctest
@@ -774,202 +814,216 @@ namespace doctest {
 #define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
 #endif
 
-    // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
-    // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
-    // - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
-    // - if small - capacity left before going on the heap - using the lowest 5 bits
-    // - if small - 2 bits are left unused - the second and third highest ones
-    // - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
-    //              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
-    // Idea taken from this lecture about the string implementation of facebook/folly - fbstring
-    // https://www.youtube.com/watch?v=kPR8h4-qZdk
-    // TODO:
-    // - optimizations - like not deleting memory unnecessarily in operator= and etc.
-    // - resize/reserve/clear
-    // - replace
-    // - back/front
-    // - iterator stuff
-    // - find & friends
-    // - push_back/pop_back
-    // - assign/insert/erase
-    // - relational operators as free functions - taking const char* as one of the params
-    class DOCTEST_INTERFACE String
+// A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings
+// with length of up to 23 chars on the stack before going on the heap -
+// the last byte of the buffer is used for:
+// - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
+// - if small - capacity left before going on the heap - using the lowest 5 bits
+// - if small - 2 bits are left unused - the second and third highest ones
+// - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
+//              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
+// Idea taken from this lecture about the string implementation of facebook/folly - fbstring
+// https://www.youtube.com/watch?v=kPR8h4-qZdk
+// TODO:
+// - optimizations - like not deleting memory unnecessarily in operator= and etc.
+// - resize/reserve/clear
+// - replace
+// - back/front
+// - iterator stuff
+// - find & friends
+// - push_back/pop_back
+// - assign/insert/erase
+// - relational operators as free functions - taking const char* as one of the params
+class DOCTEST_INTERFACE String {
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len = 24;
+    static DOCTEST_CONSTEXPR size_type last = len - 1;
+
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
     {
-    public:
-        using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
-
-    private:
-        static DOCTEST_CONSTEXPR size_type len  = 24;
-        static DOCTEST_CONSTEXPR size_type last = len - 1;
-
-        struct view // len should be more than sizeof(view) - because of the final byte for flags
-        {
-            char*    ptr;
-            size_type size;
-            size_type capacity;
-        };
-
-        union
-        {
-            char buf[len]; // NOLINT(*-avoid-c-arrays)
-            view data;
-        };
-
-        char* allocate(size_type sz);
-
-        bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
-        void setOnHeap() noexcept;
-        void setLast(size_type in = last) noexcept;
-        void setSize(size_type sz) noexcept;
-
-        void copy(const String& other);
-
-    public:
-        static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
-
-        String() noexcept;
-        ~String();
-
-        String(const char* in);
-        String(const char* in, size_type in_size);
-
-        String(std::istream& in, size_type in_size);
-
-        String(const String& other);
-        String& operator=(const String& other);
-
-        String& operator+=(const String& other);
-
-        String(String&& other) noexcept;
-        String& operator=(String&& other) noexcept;
-
-        char  operator[](size_type i) const;
-        char& operator[](size_type i);
-
-        // the only functions I'm willing to leave in the interface - available for inlining
-        const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-        char*       c_str() {
-            if (isOnStack()) {
-                return reinterpret_cast<char*>(buf);
-            }
-            return data.ptr;
-        }
-
-        size_type size() const;
-        size_type capacity() const;
-
-        String substr(size_type pos, size_type cnt = npos) &&;
-        String substr(size_type pos, size_type cnt = npos) const &;
-
-        size_type find(char ch, size_type pos = 0) const;
-        size_type rfind(char ch, size_type pos = npos) const;
-
-        int compare(const char* other, bool no_case = false) const;
-        int compare(const String& other, bool no_case = false) const;
-
-        friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+        char *ptr;
+        size_type size;
+        size_type capacity;
     };
 
-    DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+    union {
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
+        view data;
+    };
 
-    DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
+    char *allocate(size_type sz);
+
+    bool isOnStack() const noexcept {
+        return (buf[last] & 128) == 0;
+    }
+
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
+
+    void copy(const String &other);
+
+public:
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
+    ~String();
+
+    String(const char *in);
+    String(const char *in, size_type in_size);
+
+    String(std::istream &in, size_type in_size);
+
+    String(const String &other);
+    String &operator=(const String &other);
+
+    String &operator+=(const String &other);
+
+    String(String &&other) noexcept;
+    String &operator=(String &&other) noexcept;
+
+    char operator[](size_type i) const;
+    char &operator[](size_type i);
+
+    // the only functions I'm willing to leave in the interface - available for inlining
+    const char *c_str() const {
+        return const_cast<String *>(this)->c_str(); // NOLINT
+    }
+
+    char *c_str() {
+        if (isOnStack()) {
+            return reinterpret_cast<char *>(buf);
+        }
+        return data.ptr;
+    }
+
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const &;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
+
+    int compare(const char *other, bool no_case = false) const;
+    int compare(const String &other, bool no_case = false) const;
+
+    friend DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, const String &in);
+};
+
+DOCTEST_INTERFACE String operator+(const String &lhs, const String &rhs);
+
+DOCTEST_INTERFACE bool operator==(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>=(const String &lhs, const String &rhs);
 
 namespace detail {
 
 // MSVS 2015 :(
 #if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
-    template <typename T, typename = void>
-    struct has_global_insertion_operator : types::false_type { };
+template <typename T, typename = void>
+struct has_global_insertion_operator : types::false_type {};
 
-    template <typename T>
-    struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+template <typename T>
+struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
 
-    template <typename T, typename = void>
-    struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+template <typename T, typename = void>
+struct has_insertion_operator {
+    static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value;
+};
 
-    template <typename T, bool global>
-    struct insert_hack;
+template <typename T, bool global>
+struct insert_hack;
 
-    template <typename T>
-    struct insert_hack<T, true> {
-        static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
-    };
+template <typename T>
+struct insert_hack<T, true> {
+    static void insert(std::ostream &os, const T &t) {
+        ::operator<<(os, t);
+    }
+};
 
-    template <typename T>
-    struct insert_hack<T, false> {
-        static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
-    };
+template <typename T>
+struct insert_hack<T, false> {
+    static void insert(std::ostream &os, const T &t) {
+        operator<<(os, t);
+    }
+};
 
-    template <typename T>
-    using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
+template <typename T>
+using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
 #else
-    template <typename T, typename = void>
-    struct has_insertion_operator : types::false_type { };
+template <typename T, typename = void>
+struct has_insertion_operator : types::false_type {};
 #endif
 
+template <typename T>
+struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
+
+template <typename T>
+struct should_stringify_as_underlying_type {
+    static DOCTEST_CONSTEXPR bool value =
+        detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+};
+
+DOCTEST_INTERFACE std::ostream *tlssPush();
+DOCTEST_INTERFACE String tlssPop();
+
+template <bool C>
+struct StringMakerBase {
     template <typename T>
-    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
-
-    template <typename T>
-    struct should_stringify_as_underlying_type {
-        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
-    };
-
-    DOCTEST_INTERFACE std::ostream* tlssPush();
-    DOCTEST_INTERFACE String tlssPop();
-
-    template <bool C>
-    struct StringMakerBase {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
+    static String convert(const DOCTEST_REF_WRAP(T)) {
 #ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
-            static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+        static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
 #endif
-            return "{?}";
-        }
-    };
-
-    template <typename T>
-    struct filldata;
-
-    template <typename T>
-    void filloss(std::ostream* stream, const T& in) {
-        filldata<T>::fill(stream, in);
+        return "{?}";
     }
+};
 
-    template <typename T, size_t N>
-    void filloss(std::ostream* stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
-        // T[N], T(&)[N], T(&&)[N] have same behaviour.
-        // Hence remove reference.
-        filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
-    }
+template <typename T>
+struct filldata;
 
+template <typename T>
+void filloss(std::ostream *stream, const T &in) {
+    filldata<T>::fill(stream, in);
+}
+
+template <typename T, size_t N>
+void filloss(std::ostream *stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
+    // T[N], T(&)[N], T(&&)[N] have same behaviour.
+    // Hence remove reference.
+    filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
+}
+
+template <typename T>
+String toStream(const T &in) {
+    std::ostream *stream = tlssPush();
+    filloss(stream, in);
+    return tlssPop();
+}
+
+template <>
+struct StringMakerBase<true> {
     template <typename T>
-    String toStream(const T& in) {
-        std::ostream* stream = tlssPush();
-        filloss(stream, in);
-        return tlssPop();
+    static String convert(const DOCTEST_REF_WRAP(T) in) {
+        return toStream(in);
     }
-
-    template <>
-    struct StringMakerBase<true> {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
-            return toStream(in);
-        }
-    };
+};
 
 } // namespace detail
 
-    template <typename T>
-    struct StringMaker : public detail::StringMakerBase<
-        detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
-    {};
+template <typename T>
+struct StringMaker : public detail::StringMakerBase<
+                         detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value ||
+                         detail::types::is_array<T>::value> {};
 
 #ifndef DOCTEST_STRINGIFY
 #ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
@@ -979,137 +1033,144 @@ namespace detail {
 #endif
 #endif
 
-    template <typename T>
-    String toString() {
-    #if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
-        String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
-        String::size_type beginPos = ret.find('<');
-        return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
-    #else
-        String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
-        String::size_type begin = ret.find('=') + 2;
-        return ret.substr(begin, ret.size() - begin - 1);
-    #endif // Compiler
-    }
+template <typename T>
+String toString() {
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif // Compiler
+}
 
-    template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        return StringMaker<T>::convert(value);
-    }
+template <
+    typename T,
+    typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
+}
 
-    inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+inline String &&toString(String &&in) {
+    return static_cast<String &&>(in);
+}
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE String toString(const char* in);
+DOCTEST_INTERFACE String toString(const char *in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-    // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-    DOCTEST_INTERFACE String toString(const std::string& in);
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string &in);
 #endif // VS 2019
 
-    DOCTEST_INTERFACE String toString(const String& in);
+DOCTEST_INTERFACE String toString(const String &in);
 
-    DOCTEST_INTERFACE String toString(std::nullptr_t);
+DOCTEST_INTERFACE String toString(std::nullptr_t);
 
-    DOCTEST_INTERFACE String toString(bool in);
+DOCTEST_INTERFACE String toString(bool in);
 
-    DOCTEST_INTERFACE String toString(float in);
-    DOCTEST_INTERFACE String toString(double in);
-    DOCTEST_INTERFACE String toString(double long in);
+DOCTEST_INTERFACE String toString(float in);
+DOCTEST_INTERFACE String toString(double in);
+DOCTEST_INTERFACE String toString(double long in);
 
-    DOCTEST_INTERFACE String toString(char in);
-    DOCTEST_INTERFACE String toString(char signed in);
-    DOCTEST_INTERFACE String toString(char unsigned in);
-    DOCTEST_INTERFACE String toString(short in);
-    DOCTEST_INTERFACE String toString(short unsigned in);
-    DOCTEST_INTERFACE String toString(signed in);
-    DOCTEST_INTERFACE String toString(unsigned in);
-    DOCTEST_INTERFACE String toString(long in);
-    DOCTEST_INTERFACE String toString(long unsigned in);
-    DOCTEST_INTERFACE String toString(long long in);
-    DOCTEST_INTERFACE String toString(long long unsigned in);
+DOCTEST_INTERFACE String toString(char in);
+DOCTEST_INTERFACE String toString(char signed in);
+DOCTEST_INTERFACE String toString(char unsigned in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-    template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        using UT = typename detail::types::underlying_type<T>::type;
-        return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
-    }
+template <
+    typename T,
+    typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
 namespace detail {
-    template <typename T>
-    struct filldata
-    {
-        static void fill(std::ostream* stream, const T& in) {
-    #if defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename T>
+struct filldata {
+    static void fill(std::ostream *stream, const T &in) {
+#if defined(_MSC_VER) && _MSC_VER <= 1900
         insert_hack_t<T>::insert(*stream, in);
-    #else
+#else
         operator<<(*stream, in);
-    #endif // _MSV_VER
-        }
-    };
+#endif // _MSV_VER
+    }
+};
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
-    // NOLINTBEGIN(*-avoid-c-arrays)
-    template <typename T, size_t N>
-    struct filldata<T[N]> {
-        static void fill(std::ostream* stream, const T(&in)[N]) {
-            *stream << "[";
-            for (size_t i = 0; i < N; i++) {
-                if (i != 0) { *stream << ", "; }
-                *stream << (DOCTEST_STRINGIFY(in[i]));
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <typename T, size_t N>
+struct filldata<T[N]> {
+    static void fill(std::ostream *stream, const T (&in)[N]) {
+        *stream << "[";
+        for (size_t i = 0; i < N; i++) {
+            if (i != 0) {
+                *stream << ", ";
             }
-            *stream << "]";
+            *stream << (DOCTEST_STRINGIFY(in[i]));
         }
-    };
-    // NOLINTEND(*-avoid-c-arrays)
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        *stream << "]";
+    }
+};
+// NOLINTEND(*-avoid-c-arrays)
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    // Specialized since we don't want the terminating null byte!
-    // NOLINTBEGIN(*-avoid-c-arrays)
-    template <size_t N>
-    struct filldata<const char[N]> {
-        static void fill(std::ostream* stream, const char (&in)[N]) {
-            *stream << String(in, in[N - 1] ? N : N - 1);
-        } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-    };
-    // NOLINTEND(*-avoid-c-arrays)
+// Specialized since we don't want the terminating null byte!
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <size_t N>
+struct filldata<const char[N]> {
+    static void fill(std::ostream *stream, const char (&in)[N]) {
+        *stream << String(in, in[N - 1] ? N : N - 1);
+    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+};
+// NOLINTEND(*-avoid-c-arrays)
 
-    template <>
-    struct filldata<const void*> {
-        DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
-    };
+template <>
+struct filldata<const void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const void *in);
+};
 
-    template <>
-    struct filldata<const volatile void*> {
-        DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
-    };
+template <>
+struct filldata<const volatile void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const volatile void *in);
+};
 
-    template <typename T>
-    struct filldata<T*> {
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
-        static void fill(std::ostream* stream, const T* in) {
+template <typename T>
+struct filldata<T *> {
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
+    static void fill(std::ostream *stream, const T *in) {
         DOCTEST_MSVC_SUPPRESS_WARNING_POP
         DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
-            filldata<const volatile void*>::fill(stream,
-        #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
-                reinterpret_cast<const volatile void*>(in)
-        #else
-                *reinterpret_cast<const volatile void* const*>(&in)
-        #endif // DOCTEST_GCC
-            );
+        filldata<const volatile void *>::fill(
+            stream,
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+            reinterpret_cast<const volatile void *>(in)
+#else
+            *reinterpret_cast<const volatile void *const *>(&in)
+#endif // DOCTEST_GCC
+        );
         DOCTEST_CLANG_SUPPRESS_WARNING_POP
-        }
-    };
-
-    #ifndef DOCTEST_CONFIG_DISABLE
-    template <typename L, typename R>
-    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
-                               const DOCTEST_REF_WRAP(R) rhs) {
-        return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
     }
-    #endif // DOCTEST_CONFIG_DISABLE
-} //namespace detail
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+template <typename L, typename R>
+String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char *op, const DOCTEST_REF_WRAP(R) rhs) {
+    return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
+}
+#endif // DOCTEST_CONFIG_DISABLE
+} // namespace detail
 
 } // namespace doctest
 
@@ -1126,19 +1187,19 @@ namespace doctest {
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const String& string);
+    explicit Contains(const String &string);
 
-    bool checkWith(const String& other) const;
+    bool checkWith(const String &other) const;
 
     String string;
 };
 
-DOCTEST_INTERFACE String toString(const Contains& in);
+DOCTEST_INTERFACE String toString(const Contains &in);
 
-DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
-DOCTEST_INTERFACE bool operator==(const Contains& lhs, const String& rhs);
-DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
-DOCTEST_INTERFACE bool operator!=(const Contains& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator==(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator==(const Contains &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains &lhs, const String &rhs);
 
 } // namespace doctest
 
@@ -1153,84 +1214,84 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE Approx
-{
+struct DOCTEST_INTERFACE Approx {
     Approx(double value);
 
     Approx operator()(double value) const;
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
+    explicit Approx(
+        const T &value,
+        typename detail::types::enable_if<std::is_constructible<double, T>::value>::type * = static_cast<T *>(nullptr)
+    ) {
         *this = static_cast<double>(value);
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& epsilon(double newEpsilon);
+    Approx &epsilon(double newEpsilon);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
-            const T& newEpsilon) {
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type epsilon(const T &newEpsilon) {
         m_epsilon = static_cast<double>(newEpsilon);
         return *this;
     }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& scale(double newScale);
+    Approx &scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
-            const T& newScale) {
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type scale(const T &newScale) {
         m_scale = static_cast<double>(newScale);
         return *this;
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format off
-    DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator==(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator!=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator<=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator<=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator>=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator>=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator< (double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator< (const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator> (const Approx & lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator==(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator!=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator<=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator<=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator>=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator>=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator< (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator< (const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator> (const Approx &lhs, double rhs);
+    // clang-format on
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#define DOCTEST_APPROX_PREFIX \
-    template <typename T> friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
+#define DOCTEST_APPROX_PREFIX                                                                                          \
+    template <typename T>                                                                                              \
+    friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
 
-    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(static_cast<double>(lhs), rhs); }
-    DOCTEST_APPROX_PREFIX operator==(const Approx& lhs, const T& rhs) { return operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator!=(const T& lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
-    DOCTEST_APPROX_PREFIX operator!=(const Approx& lhs, const T& rhs) { return !operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
+    // clang-format off
+    DOCTEST_APPROX_PREFIX operator==(const T &lhs, const Approx &rhs) { return operator==(static_cast<double>(lhs), rhs); }
+    DOCTEST_APPROX_PREFIX operator==(const Approx &lhs, const T &rhs) { return operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const T &lhs, const Approx &rhs) { return !operator==(lhs, rhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const Approx &lhs, const T &rhs) { return !operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator<=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
+    // clang-format off
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-
-    // clang-format on
 
     double m_epsilon;
     double m_scale;
     double m_value;
 };
 
-DOCTEST_INTERFACE String toString(const Approx& in);
+DOCTEST_INTERFACE String toString(const Approx &in);
 
 } // namespace doctest
 
@@ -1246,11 +1307,16 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 
 template <typename F>
-struct DOCTEST_INTERFACE_DECL IsNaN
-{
-    F value; bool flipped;
-    IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
-    IsNaN<F> operator!() const { return { value, !flipped }; }
+struct DOCTEST_INTERFACE_DECL IsNaN {
+    F value;
+    bool flipped;
+    IsNaN(F f, bool flip = false)
+        : value(f), flipped(flip) {}
+
+    IsNaN<F> operator!() const {
+        return {value, !flipped};
+    }
+
     operator bool() const;
 };
 
@@ -1277,59 +1343,58 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    struct DOCTEST_INTERFACE TestCase;
+struct DOCTEST_INTERFACE TestCase;
 } // namespace detail
 
-    struct ContextOptions
-    {
-        std::ostream* cout = nullptr; // stdout stream
-        String        binary_name;    // the test binary name
+struct ContextOptions {
+    std::ostream *cout = nullptr; // stdout stream
+    String binary_name;           // the test binary name
 
-        const detail::TestCase* currentTest = nullptr;
+    const detail::TestCase *currentTest = nullptr;
 
-        // == parameters from the command line
-        String   out;       // output filename
-        String   order_by;  // how tests should be ordered
-        unsigned rand_seed; // the seed for rand ordering
+    // == parameters from the command line
+    String out;         // output filename
+    String order_by;    // how tests should be ordered
+    unsigned rand_seed; // the seed for rand ordering
 
-        unsigned first; // the first (matching) test to be executed
-        unsigned last;  // the last (matching) test to be executed
+    unsigned first; // the first (matching) test to be executed
+    unsigned last;  // the last (matching) test to be executed
 
-        int abort_after;           // stop tests after this many failed assertions
-        int subcase_filter_levels; // apply the subcase filters for the first N levels
+    int abort_after;           // stop tests after this many failed assertions
+    int subcase_filter_levels; // apply the subcase filters for the first N levels
 
-        bool success;              // include successful assertions in output
-        bool case_sensitive;       // if filtering should be case sensitive
-        bool exit;                 // if the program should be exited after the tests are ran/whatever
-        bool duration;             // print the time duration of each test case
-        bool minimal;              // minimal console output (only test failures)
-        bool quiet;                // no console output
-        bool no_throw;             // to skip exceptions-related assertion macros
-        bool no_exitcode;          // if the framework should return 0 as the exitcode
-        bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-        bool no_intro;             // to not print the intro of the framework
-        bool no_version;           // to not print the version of the framework
-        bool no_colors;            // if output to the console should be colorized
-        bool force_colors;         // forces the use of colors even when a tty cannot be detected
-        bool no_breaks;            // to not break into the debugger
-        bool no_skip;              // don't skip test cases which are marked to be skipped
-        bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-        bool no_path_in_filenames; // if the path to files should be removed from the output
-        String strip_file_prefixes;// remove the longest matching one of these prefixes from any file paths in the output
-        bool no_line_numbers;      // if source code line numbers should be omitted from the output
-        bool no_debug_output;      // no output in the debug console when a debugger is attached
-        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
-        bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
+    bool success;               // include successful assertions in output
+    bool case_sensitive;        // if filtering should be case sensitive
+    bool exit;                  // if the program should be exited after the tests are ran/whatever
+    bool duration;              // print the time duration of each test case
+    bool minimal;               // minimal console output (only test failures)
+    bool quiet;                 // no console output
+    bool no_throw;              // to skip exceptions-related assertion macros
+    bool no_exitcode;           // if the framework should return 0 as the exitcode
+    bool no_run;                // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;              // to not print the intro of the framework
+    bool no_version;            // to not print the version of the framework
+    bool no_colors;             // if output to the console should be colorized
+    bool force_colors;          // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;             // to not break into the debugger
+    bool no_skip;               // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;         // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames;  // if the path to files should be removed from the output
+    String strip_file_prefixes; // remove the longest matching one of these prefixes from any file paths in the output
+    bool no_line_numbers;       // if source code line numbers should be omitted from the output
+    bool no_debug_output;       // no output in the debug console when a debugger is attached
+    bool no_skipped_summary;    // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;     // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
-        bool help;             // to print the help
-        bool version;          // to print the version
-        bool count;            // if only the count of matching tests is to be retrieved
-        bool list_test_cases;  // to list all tests matching the filters
-        bool list_test_suites; // to list all suites matching the filters
-        bool list_reporters;   // lists all registered reporters
-    };
+    bool help;             // to print the help
+    bool version;          // to print the version
+    bool count;            // if only the count of matching tests is to be retrieved
+    bool list_test_cases;  // to list all tests matching the filters
+    bool list_test_suites; // to list all suites matching the filters
+    bool list_reporters;   // lists all registered reporters
+};
 
-    DOCTEST_INTERFACE const ContextOptions* getContextOptions();
+DOCTEST_INTERFACE const ContextOptions *getContextOptions();
 
 } // namespace doctest
 
@@ -1344,100 +1409,99 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace assertType {
-    enum Enum
-    {
-        // macro traits
+enum Enum {
+    // macro traits
 
-        is_warn    = 1,
-        is_check   = 2 * is_warn,
-        is_require = 2 * is_check,
+    is_warn = 1,
+    is_check = 2 * is_warn,
+    is_require = 2 * is_check,
 
-        is_normal      = 2 * is_require,
-        is_throws      = 2 * is_normal,
-        is_throws_as   = 2 * is_throws,
-        is_throws_with = 2 * is_throws_as,
-        is_nothrow     = 2 * is_throws_with,
+    is_normal = 2 * is_require,
+    is_throws = 2 * is_normal,
+    is_throws_as = 2 * is_throws,
+    is_throws_with = 2 * is_throws_as,
+    is_nothrow = 2 * is_throws_with,
 
-        is_false = 2 * is_nothrow,
-        is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
+    is_false = 2 * is_nothrow,
+    is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
 
-        is_eq = 2 * is_unary,
-        is_ne = 2 * is_eq,
+    is_eq = 2 * is_unary,
+    is_ne = 2 * is_eq,
 
-        is_lt = 2 * is_ne,
-        is_gt = 2 * is_lt,
+    is_lt = 2 * is_ne,
+    is_gt = 2 * is_lt,
 
-        is_ge = 2 * is_gt,
-        is_le = 2 * is_ge,
+    is_ge = 2 * is_gt,
+    is_le = 2 * is_ge,
 
-        // macro types
+    // macro types
 
-        DT_WARN    = is_normal | is_warn,
-        DT_CHECK   = is_normal | is_check,
-        DT_REQUIRE = is_normal | is_require,
+    DT_WARN = is_normal | is_warn,
+    DT_CHECK = is_normal | is_check,
+    DT_REQUIRE = is_normal | is_require,
 
-        DT_WARN_FALSE    = is_normal | is_false | is_warn,
-        DT_CHECK_FALSE   = is_normal | is_false | is_check,
-        DT_REQUIRE_FALSE = is_normal | is_false | is_require,
+    DT_WARN_FALSE = is_normal | is_false | is_warn,
+    DT_CHECK_FALSE = is_normal | is_false | is_check,
+    DT_REQUIRE_FALSE = is_normal | is_false | is_require,
 
-        DT_WARN_THROWS    = is_throws | is_warn,
-        DT_CHECK_THROWS   = is_throws | is_check,
-        DT_REQUIRE_THROWS = is_throws | is_require,
+    DT_WARN_THROWS = is_throws | is_warn,
+    DT_CHECK_THROWS = is_throws | is_check,
+    DT_REQUIRE_THROWS = is_throws | is_require,
 
-        DT_WARN_THROWS_AS    = is_throws_as | is_warn,
-        DT_CHECK_THROWS_AS   = is_throws_as | is_check,
-        DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+    DT_WARN_THROWS_AS = is_throws_as | is_warn,
+    DT_CHECK_THROWS_AS = is_throws_as | is_check,
+    DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-        DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
-        DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
-        DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
+    DT_WARN_THROWS_WITH = is_throws_with | is_warn,
+    DT_CHECK_THROWS_WITH = is_throws_with | is_check,
+    DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
 
-        DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
-        DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
-        DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
+    DT_WARN_THROWS_WITH_AS = is_throws_with | is_throws_as | is_warn,
+    DT_CHECK_THROWS_WITH_AS = is_throws_with | is_throws_as | is_check,
+    DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
 
-        DT_WARN_NOTHROW    = is_nothrow | is_warn,
-        DT_CHECK_NOTHROW   = is_nothrow | is_check,
-        DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+    DT_WARN_NOTHROW = is_nothrow | is_warn,
+    DT_CHECK_NOTHROW = is_nothrow | is_check,
+    DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-        DT_WARN_EQ    = is_normal | is_eq | is_warn,
-        DT_CHECK_EQ   = is_normal | is_eq | is_check,
-        DT_REQUIRE_EQ = is_normal | is_eq | is_require,
+    DT_WARN_EQ = is_normal | is_eq | is_warn,
+    DT_CHECK_EQ = is_normal | is_eq | is_check,
+    DT_REQUIRE_EQ = is_normal | is_eq | is_require,
 
-        DT_WARN_NE    = is_normal | is_ne | is_warn,
-        DT_CHECK_NE   = is_normal | is_ne | is_check,
-        DT_REQUIRE_NE = is_normal | is_ne | is_require,
+    DT_WARN_NE = is_normal | is_ne | is_warn,
+    DT_CHECK_NE = is_normal | is_ne | is_check,
+    DT_REQUIRE_NE = is_normal | is_ne | is_require,
 
-        DT_WARN_GT    = is_normal | is_gt | is_warn,
-        DT_CHECK_GT   = is_normal | is_gt | is_check,
-        DT_REQUIRE_GT = is_normal | is_gt | is_require,
+    DT_WARN_GT = is_normal | is_gt | is_warn,
+    DT_CHECK_GT = is_normal | is_gt | is_check,
+    DT_REQUIRE_GT = is_normal | is_gt | is_require,
 
-        DT_WARN_LT    = is_normal | is_lt | is_warn,
-        DT_CHECK_LT   = is_normal | is_lt | is_check,
-        DT_REQUIRE_LT = is_normal | is_lt | is_require,
+    DT_WARN_LT = is_normal | is_lt | is_warn,
+    DT_CHECK_LT = is_normal | is_lt | is_check,
+    DT_REQUIRE_LT = is_normal | is_lt | is_require,
 
-        DT_WARN_GE    = is_normal | is_ge | is_warn,
-        DT_CHECK_GE   = is_normal | is_ge | is_check,
-        DT_REQUIRE_GE = is_normal | is_ge | is_require,
+    DT_WARN_GE = is_normal | is_ge | is_warn,
+    DT_CHECK_GE = is_normal | is_ge | is_check,
+    DT_REQUIRE_GE = is_normal | is_ge | is_require,
 
-        DT_WARN_LE    = is_normal | is_le | is_warn,
-        DT_CHECK_LE   = is_normal | is_le | is_check,
-        DT_REQUIRE_LE = is_normal | is_le | is_require,
+    DT_WARN_LE = is_normal | is_le | is_warn,
+    DT_CHECK_LE = is_normal | is_le | is_check,
+    DT_REQUIRE_LE = is_normal | is_le | is_require,
 
-        DT_WARN_UNARY    = is_normal | is_unary | is_warn,
-        DT_CHECK_UNARY   = is_normal | is_unary | is_check,
-        DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
+    DT_WARN_UNARY = is_normal | is_unary | is_warn,
+    DT_CHECK_UNARY = is_normal | is_unary | is_check,
+    DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
 
-        DT_WARN_UNARY_FALSE    = is_normal | is_false | is_unary | is_warn,
-        DT_CHECK_UNARY_FALSE   = is_normal | is_false | is_unary | is_check,
-        DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
-    };
+    DT_WARN_UNARY_FALSE = is_normal | is_false | is_unary | is_warn,
+    DT_CHECK_UNARY_FALSE = is_normal | is_false | is_unary | is_check,
+    DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
+};
 } // namespace assertType
 
-DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
-DOCTEST_INTERFACE const char* failureString(assertType::Enum at);
+DOCTEST_INTERFACE const char *assertString(assertType::Enum at);
+DOCTEST_INTERFACE const char *failureString(assertType::Enum at);
 
-}
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 
@@ -1450,48 +1514,62 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData;
+struct DOCTEST_INTERFACE TestCaseData;
 
-    struct DOCTEST_INTERFACE AssertData
-    {
-        // common - for all asserts
-        const TestCaseData* m_test_case;
-        assertType::Enum    m_at;
-        const char*         m_file;
-        int                 m_line;
-        const char*         m_expr;
-        bool                m_failed;
+struct DOCTEST_INTERFACE AssertData {
+    // common - for all asserts
+    const TestCaseData *m_test_case;
+    assertType::Enum m_at;
+    const char *m_file;
+    int m_line;
+    const char *m_expr;
+    bool m_failed;
 
-        // exception-related - for all asserts
-        bool   m_threw;
-        String m_exception;
+    // exception-related - for all asserts
+    bool m_threw;
+    String m_exception;
 
-        // for normal asserts
-        String m_decomp;
+    // for normal asserts
+    String m_decomp;
 
-        // for specific exception-related asserts
-        bool           m_threw_as;
-        const char*    m_exception_type;
+    // for specific exception-related asserts
+    bool m_threw_as;
+    const char *m_exception_type;
 
-        class DOCTEST_INTERFACE StringContains {
-            private:
-                Contains content;
-                bool isContains;
+    class DOCTEST_INTERFACE StringContains {
+    private:
+        Contains content;
+        bool isContains;
 
-            public:
-                StringContains(const String& str) : content(str), isContains(false) { }
-                StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
+    public:
+        StringContains(const String &str)
+            : content(str), isContains(false) {}
 
-                bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
+        StringContains(Contains cntn)
+            : content(static_cast<Contains &&>(cntn)), isContains(true) {}
 
-                operator const String&() const { return content.string; }
+        bool check(const String &str) {
+            return isContains ? (content == str) : (content.string == str);
+        }
 
-                const char* c_str() const { return content.string.c_str(); }
-        } m_exception_string;
+        operator const String &() const {
+            return content.string;
+        }
 
-        AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-            const char* exception_type, const StringContains& exception_string);
-    };
+        const char *c_str() const {
+            return content.string.c_str();
+        }
+    } m_exception_string;
+
+    AssertData(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const StringContains &exception_string
+    );
+};
 
 } // namespace doctest
 
@@ -1507,49 +1585,48 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
-namespace detail  {
+namespace detail {
 
-    // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    template<class T>               struct decay_array       { using type = T; };
-    template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
-    template<class T>               struct decay_array<T[]>  { using type = T*; };
+// clang-format off
+template<class T>               struct decay_array       { using type = T; };
+template<class T, unsigned N>   struct decay_array<T[N]> { using type = T *; };
+template<class T>               struct decay_array<T[]>  { using type = T *; };
 
-    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR int value = 1; };
-    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR int value = 0; };
-    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR int value = 0; };
+template<class T>   struct not_char_pointer               { static DOCTEST_CONSTEXPR int value = 1; };
+template<>          struct not_char_pointer<char *>       { static DOCTEST_CONSTEXPR int value = 0; };
+template<>          struct not_char_pointer<const char *> { static DOCTEST_CONSTEXPR int value = 0; };
 
-    template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
+template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
+// clang-format on
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
 
-    // clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_COMPARISON_RETURN_TYPE bool
-#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#else  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+// clang-format off
 #define DOCTEST_COMPARISON_RETURN_TYPE typename types::enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
-    inline bool eq(const char* lhs, const char* rhs) { return String(lhs) == String(rhs); }
-    inline bool ne(const char* lhs, const char* rhs) { return String(lhs) != String(rhs); }
-    inline bool lt(const char* lhs, const char* rhs) { return String(lhs) <  String(rhs); }
-    inline bool gt(const char* lhs, const char* rhs) { return String(lhs) >  String(rhs); }
-    inline bool le(const char* lhs, const char* rhs) { return String(lhs) <= String(rhs); }
-    inline bool ge(const char* lhs, const char* rhs) { return String(lhs) >= String(rhs); }
+inline bool eq(const char *lhs, const char *rhs) { return String(lhs) == String(rhs); }
+inline bool ne(const char *lhs, const char *rhs) { return String(lhs) != String(rhs); }
+inline bool lt(const char *lhs, const char *rhs) { return String(lhs) <  String(rhs); }
+inline bool gt(const char *lhs, const char *rhs) { return String(lhs) >  String(rhs); }
+inline bool le(const char *lhs, const char *rhs) { return String(lhs) <= String(rhs); }
+inline bool ge(const char *lhs, const char *rhs) { return String(lhs) >= String(rhs); }
+// clang-format on
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
 
-#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
-    template <typename L, typename R>                                                              \
-    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs,                             \
-                                        const DOCTEST_REF_WRAP(R) rhs) {                           \
-        return lhs op rhs;                                                                         \
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                \
+        return lhs op rhs;                                                                                             \
     }
 
-    DOCTEST_RELATIONAL_OP(eq, ==)
-    DOCTEST_RELATIONAL_OP(ne, !=)
-    DOCTEST_RELATIONAL_OP(lt, <)
-    DOCTEST_RELATIONAL_OP(gt, >)
-    DOCTEST_RELATIONAL_OP(le, <=)
-    DOCTEST_RELATIONAL_OP(ge, >=)
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
 
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_CMP_EQ(l, r) l == r
@@ -1567,31 +1644,23 @@ namespace detail  {
 #define DOCTEST_CMP_LE(l, r) le(l, r)
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
-    namespace binaryAssertComparison {
-        enum Enum
-        {
-            eq = 0,
-            ne,
-            gt,
-            lt,
-            ge,
-            le
-        };
-    } // namespace binaryAssertComparison
+namespace binaryAssertComparison {
+enum Enum { eq = 0, ne, gt, lt, ge, le };
+} // namespace binaryAssertComparison
 
-    // clang-format off
-    template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
+// clang-format off
+template <int, class L, class R>         struct RelationalComparator { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
 
 #define DOCTEST_BINARY_RELATIONAL_OP(n, op) \
     template <class L, class R> struct RelationalComparator<n, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return op(lhs, rhs); } };
-    // clang-format on
+// clang-format on
 
-    DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
-    DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
-    DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
-    DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
-    DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
-    DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
+DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
+DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
+DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
+DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
+DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
+DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
 } // namespace detail
 } // namespace doctest
@@ -1615,87 +1684,97 @@ namespace detail {
 // more checks could be added - like in Catch:
 // https://github.com/catchorg/Catch2/pull/1480/files
 // https://github.com/catchorg/Catch2/pull/1481/files
-#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                          \
-    template <typename R>                                                                          \
-    rt& operator op(const R&) {                                                                    \
-        static_assert(deferred_false<R>::value,                                                    \
-                      "Expression Too Complex Please Rewrite As Binary Comparison!");              \
-        return *this;                                                                              \
+#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                                              \
+    template <typename R>                                                                                              \
+    rt &operator op(const R &) {                                                                                       \
+        static_assert(deferred_false<R>::value, "Expression Too Complex Please Rewrite As Binary Comparison!");        \
+        return *this;                                                                                                  \
     }
 
-    struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
-    {
-        bool   m_passed;
-        String m_decomp;
+struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
+{
+    bool m_passed;
+    String m_decomp;
 
-        Result() = default; // TODO: Why do we need this? (To remove NOLINT)
-        Result(bool passed, const String& decomposition = String());
+    Result() = default; // TODO: Why do we need this? (To remove NOLINT)
+    Result(bool passed, const String &decomposition = String());
 
-        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
-        DOCTEST_FORBIT_EXPRESSION(Result, &)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^)
-        DOCTEST_FORBIT_EXPRESSION(Result, |)
-        DOCTEST_FORBIT_EXPRESSION(Result, &&)
-        DOCTEST_FORBIT_EXPRESSION(Result, ||)
-        DOCTEST_FORBIT_EXPRESSION(Result, ==)
-        DOCTEST_FORBIT_EXPRESSION(Result, !=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <)
-        DOCTEST_FORBIT_EXPRESSION(Result, >)
-        DOCTEST_FORBIT_EXPRESSION(Result, <=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >=)
-        DOCTEST_FORBIT_EXPRESSION(Result, =)
-        DOCTEST_FORBIT_EXPRESSION(Result, +=)
-        DOCTEST_FORBIT_EXPRESSION(Result, -=)
-        DOCTEST_FORBIT_EXPRESSION(Result, *=)
-        DOCTEST_FORBIT_EXPRESSION(Result, /=)
-        DOCTEST_FORBIT_EXPRESSION(Result, %=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <<=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >>=)
-        DOCTEST_FORBIT_EXPRESSION(Result, &=)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^=)
-        DOCTEST_FORBIT_EXPRESSION(Result, |=)
-    };
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
+    DOCTEST_FORBIT_EXPRESSION(Result, &)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^)
+    DOCTEST_FORBIT_EXPRESSION(Result, |)
+    DOCTEST_FORBIT_EXPRESSION(Result, &&)
+    DOCTEST_FORBIT_EXPRESSION(Result, ||)
+    DOCTEST_FORBIT_EXPRESSION(Result, ==)
+    DOCTEST_FORBIT_EXPRESSION(Result, !=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <)
+    DOCTEST_FORBIT_EXPRESSION(Result, >)
+    DOCTEST_FORBIT_EXPRESSION(Result, <=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >=)
+    DOCTEST_FORBIT_EXPRESSION(Result, =)
+    DOCTEST_FORBIT_EXPRESSION(Result, +=)
+    DOCTEST_FORBIT_EXPRESSION(Result, -=)
+    DOCTEST_FORBIT_EXPRESSION(Result, *=)
+    DOCTEST_FORBIT_EXPRESSION(Result, /=)
+    DOCTEST_FORBIT_EXPRESSION(Result, %=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <<=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >>=)
+    DOCTEST_FORBIT_EXPRESSION(Result, &=)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^=)
+    DOCTEST_FORBIT_EXPRESSION(Result, |=)
+};
 
-    struct DOCTEST_INTERFACE ResultBuilder : public AssertData
-    {
-        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type = "", const String& exception_string = "");
+struct DOCTEST_INTERFACE ResultBuilder : public AssertData {
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type = "",
+        const String &exception_string = ""
+    );
 
-        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type, const Contains& exception_string);
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const Contains &exception_string
+    );
 
-        void setResult(const Result& res);
+    void setResult(const Result &res);
 
-        template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
-            m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if (m_failed || getContextOptions()->success) {
-                m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
-            }
-            return !m_failed;
+    template <int comparison, typename L, typename R>
+    DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {
+        m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+        }
+        return !m_failed;
+    }
+
+    template <typename L>
+    DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
+        m_failed = !val;
+
+        if (m_at & assertType::is_false) {
+            m_failed = !m_failed;
         }
 
-        template <typename L>
-        DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
-            m_failed = !val;
-
-            if (m_at & assertType::is_false) {
-                m_failed = !m_failed;
-            }
-
-            if (m_failed || getContextOptions()->success) {
-                m_decomp = (DOCTEST_STRINGIFY(val));
-            }
-
-            return !m_failed;
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = (DOCTEST_STRINGIFY(val));
         }
 
-        void translateException();
+        return !m_failed;
+    }
 
-        bool log();
-        void react() const;
-    };
+    void translateException();
+
+    bool log();
+    void react() const;
+};
 
 } // namespace detail
 } // namespace doctest
@@ -1725,74 +1804,75 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
 #ifdef __NVCC__
-#define SFINAE_OP(ret,op) ret
+#define SFINAE_OP(ret, op) ret
 #else
-#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
+#define SFINAE_OP(ret, op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()), ret{})
 #endif
 
-#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
-    template <typename R>                                                                          \
-    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
-    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
-        if(m_at & assertType::is_false)                                                            \
-            res = !res;                                                                            \
-        if(!res || doctest::getContextOptions()->success)                                          \
-            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
-        return Result(res);                                                                        \
+#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                                                  \
+    template <typename R>                                                                                              \
+    DOCTEST_NOINLINE SFINAE_OP(Result, op) operator op(R &&rhs) {                                                      \
+        bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs));                 \
+        if (m_at & assertType::is_false)                                                                               \
+            res = !res;                                                                                                \
+        if (!res || doctest::getContextOptions()->success)                                                             \
+            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                                                 \
+        return Result(res);                                                                                            \
     }
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    // https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
-    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
-    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+// https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
+DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+// DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in
+// operation
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 template <typename L>
-struct Expression_lhs
-{
-    L                lhs;
+struct Expression_lhs {
+    L lhs;
     assertType::Enum m_at;
 
-    explicit Expression_lhs(L&& in, assertType::Enum at)
-            : lhs(static_cast<L&&>(in))
-            , m_at(at) {}
+    explicit Expression_lhs(L &&in, assertType::Enum at)
+        : lhs(static_cast<L &&>(in)), m_at(at) {}
 
     DOCTEST_NOINLINE operator Result() {
-// this is needed only for MSVC 2015
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+        // this is needed only for MSVC 2015
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
         bool res = static_cast<bool>(lhs);
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        if(m_at & assertType::is_false) {
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        if (m_at & assertType::is_false) {
             res = !res;
         }
 
-        if(!res || getContextOptions()->success) {
-            return { res, (DOCTEST_STRINGIFY(lhs)) };
+        if (!res || getContextOptions()->success) {
+            return {res, (DOCTEST_STRINGIFY(lhs))};
         }
-        return { res };
+        return {res};
     }
 
     /* This is required for user-defined conversions from Expression_lhs to L */
-    operator L() const { return lhs; }
+    operator L() const {
+        return lhs;
+    }
 
     // clang-format off
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ)
@@ -1803,7 +1883,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE)
     // clang-format on
 
-    // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
@@ -1820,17 +1901,18 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
-    // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-    // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+    // these 2 are unfortunate because they should be allowed - they have higher precedence over the
+    // comparisons, but the ExpressionDecomposer class uses the left shift operator to capture the
+    // left operand of the binary expression...
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
 };
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
@@ -1838,24 +1920,27 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 #endif
 
-struct DOCTEST_INTERFACE ExpressionDecomposer
-{
+struct DOCTEST_INTERFACE ExpressionDecomposer {
     assertType::Enum m_at;
 
     ExpressionDecomposer(assertType::Enum at);
 
-    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-    // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator
+    // precedence table) but then there will be warnings from GCC about "-Wparentheses" and since
+    // "_Pragma()" is problematic this will stay for now...
     // https://github.com/catchorg/Catch2/issues/870
     // https://github.com/catchorg/Catch2/issues/565
     template <typename L>
-    Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
-        return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
+    Expression_lhs<const L &&>
+    operator<<(const L &&operand) { // bitfields bind to universal ref but not const rvalue ref
+        return Expression_lhs<const L &&>(static_cast<const L &&>(operand), m_at);
     }
 
-    template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
-    Expression_lhs<const L&> operator<<(const L &operand) {
-        return Expression_lhs<const L&>(operand, m_at);
+    template <
+        typename L,
+        typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value, void>::type * = nullptr>
+    Expression_lhs<const L &> operator<<(const L &operand) {
+        return Expression_lhs<const L &>(operand, m_at);
     }
 };
 
@@ -1875,28 +1960,27 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace Color {
-    enum Enum
-    {
-        None = 0,
-        White,
-        Red,
-        Green,
-        Blue,
-        Cyan,
-        Yellow,
-        Grey,
+enum Enum {
+    None = 0,
+    White,
+    Red,
+    Green,
+    Blue,
+    Cyan,
+    Yellow,
+    Grey,
 
-        Bright = 0x10,
+    Bright = 0x10,
 
-        BrightRed   = Bright | Red,
-        BrightGreen = Bright | Green,
-        LightGrey   = Bright | Grey,
-        BrightWhite = Bright | White
-    };
+    BrightRed = Bright | Red,
+    BrightGreen = Bright | Green,
+    LightGrey = Bright | Grey,
+    BrightWhite = Bright | White
+};
 
-    DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
+DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, Color::Enum code);
 } // namespace Color
-}
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 
@@ -1909,34 +1993,32 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE SubcaseSignature
-{
-    String      m_name;
-    const char* m_file;
-    int         m_line;
+struct DOCTEST_INTERFACE SubcaseSignature {
+    String m_name;
+    const char *m_file;
+    int m_line;
 
-    bool operator==(const SubcaseSignature& other) const;
-    bool operator<(const SubcaseSignature& other) const;
+    bool operator==(const SubcaseSignature &other) const;
+    bool operator<(const SubcaseSignature &other) const;
 };
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-struct DOCTEST_INTERFACE Subcase
-{
+struct DOCTEST_INTERFACE Subcase {
     SubcaseSignature m_signature;
-    bool             m_entered = false;
+    bool m_entered = false;
 
-    Subcase(const String& name, const char* file, int line);
-    Subcase(const Subcase&) = delete;
-    Subcase(Subcase&&) = delete;
-    Subcase& operator=(const Subcase&) = delete;
-    Subcase& operator=(Subcase&&) = delete;
+    Subcase(const String &name, const char *file, int line);
+    Subcase(const Subcase &) = delete;
+    Subcase(Subcase &&) = delete;
+    Subcase &operator=(const Subcase &) = delete;
+    Subcase &operator=(Subcase &&) = delete;
     ~Subcase();
 
     operator bool() const;
 
-    private:
-        bool checkFilters();
+private:
+    bool checkFilters();
 };
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -1957,29 +2039,28 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-struct DOCTEST_INTERFACE TestSuite
-{
-    const char* m_test_suite = nullptr;
-    const char* m_description = nullptr;
-    bool        m_skip = false;
-    bool        m_no_breaks = false;
-    bool        m_no_output = false;
-    bool        m_may_fail = false;
-    bool        m_should_fail = false;
-    int         m_expected_failures = 0;
-    double      m_timeout = 0;
+struct DOCTEST_INTERFACE TestSuite {
+    const char *m_test_suite = nullptr;
+    const char *m_description = nullptr;
+    bool m_skip = false;
+    bool m_no_breaks = false;
+    bool m_no_output = false;
+    bool m_may_fail = false;
+    bool m_should_fail = false;
+    int m_expected_failures = 0;
+    double m_timeout = 0;
 
-    TestSuite& operator*(const char* in);
+    TestSuite &operator*(const char *in);
 
     template <typename T>
-    TestSuite& operator*(const T& in) {
+    TestSuite &operator*(const T &in) {
         in.fill(*this);
         return *this;
     }
 };
 
 // forward declarations of functions used by the macros
-DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+DOCTEST_INTERFACE int setTestSuite(const TestSuite &ts);
 
 } // namespace detail
 
@@ -1988,12 +2069,12 @@ DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
 // in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
 namespace doctest_detail_test_suite_ns {
-DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
+DOCTEST_INTERFACE doctest::detail::TestSuite &getCurrentTestSuite();
 
 // this is here to clear the 'current test suite' for the current translation unit - at the top
-DOCTEST_GLOBAL_NO_WARNINGS( /* NOLINT(cert-err58-cpp) */
-    DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),
-    doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")
+DOCTEST_GLOBAL_NO_WARNINGS(/* NOLINT(cert-err58-cpp) */
+                           DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),
+                           doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")
 )
 
 } // namespace doctest_detail_test_suite_ns
@@ -2011,62 +2092,67 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData
-    {
-        String      m_file;       // the file in which the test was registered (using String - see #350)
-        unsigned    m_line;       // the line where the test was registered
-        const char* m_name;       // name of the test case
-        const char* m_test_suite; // the test suite in which the test was added
-        const char* m_description;
-        bool        m_skip;
-        bool        m_no_breaks;
-        bool        m_no_output;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
-    };
+struct DOCTEST_INTERFACE TestCaseData {
+    String m_file;            // the file in which the test was registered (using String - see #350)
+    unsigned m_line;          // the line where the test was registered
+    const char *m_name;       // name of the test case
+    const char *m_test_suite; // the test suite in which the test was added
+    const char *m_description;
+    bool m_skip;
+    bool m_no_breaks;
+    bool m_no_output;
+    bool m_may_fail;
+    bool m_should_fail;
+    int m_expected_failures;
+    double m_timeout;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    using funcType = void (*)();
+using funcType = void (*)();
 
-    struct DOCTEST_INTERFACE TestCase : public TestCaseData
-    {
-        funcType m_test; // a function pointer to the test case
+struct DOCTEST_INTERFACE TestCase : public TestCaseData {
+    funcType m_test; // a function pointer to the test case
 
-        String m_type; // for templated test cases - gets appended to the real name
-        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
-        String m_full_name; // contains the name (only for templated test cases!) + the template type
+    String m_type;      // for templated test cases - gets appended to the real name
+    int m_template_id;  // an ID used to distinguish between the different versions of a templated
+                        // test case
+    String m_full_name; // contains the name (only for templated test cases!) + the template type
 
-        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                  const String& type = String(), int template_id = -1);
+    TestCase(
+        funcType test,
+        const char *file,
+        unsigned line,
+        const TestSuite &test_suite,
+        const String &type = String(),
+        int template_id = -1
+    );
 
-        TestCase(const TestCase& other);
-        TestCase(TestCase&&) = delete;
+    TestCase(const TestCase &other);
+    TestCase(TestCase &&) = delete;
 
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-        TestCase& operator=(const TestCase& other);
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+    TestCase &operator=(const TestCase &other);
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        TestCase& operator=(TestCase&&) = delete;
+    TestCase &operator=(TestCase &&) = delete;
 
-        TestCase& operator*(const char* in);
+    TestCase &operator*(const char *in);
 
-        template <typename T>
-        TestCase& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
+    template <typename T>
+    TestCase &operator*(const T &in) {
+        in.fill(*this);
+        return *this;
+    }
 
-        bool operator<(const TestCase& other) const;
+    bool operator<(const TestCase &other) const;
 
-        ~TestCase() = default;
-    };
+    ~TestCase() = default;
+};
 
-    // forward declarations of functions used by the macros
-    DOCTEST_INTERFACE int regTest(const TestCase& tc);
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int regTest(const TestCase &tc);
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -2084,18 +2170,21 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 
 namespace doctest {
 
-#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
-    struct name                                                                                    \
-    {                                                                                              \
-        type data;                                                                                 \
-        name(type in = def)                                                                        \
-                : data(in) {}                                                                      \
-        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
-        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                                      \
+    struct name {                                                                                                      \
+        type data;                                                                                                     \
+        name(type in = def)                                                                                            \
+            : data(in) {}                                                                                              \
+        void fill(detail::TestCase &state) const {                                                                     \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
+        void fill(detail::TestSuite &state) const {                                                                    \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
     }
 
-DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
-DOCTEST_DEFINE_DECORATOR(description, const char*, "");
+DOCTEST_DEFINE_DECORATOR(test_suite, const char *, "");
+DOCTEST_DEFINE_DECORATOR(description, const char *, "");
 DOCTEST_DEFINE_DECORATOR(skip, bool, true);
 DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
 DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
@@ -2104,7 +2193,7 @@ DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
-} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -2120,37 +2209,35 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-    struct DOCTEST_INTERFACE IExceptionTranslator
-    {
-        DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
-        virtual bool translate(String&) const = 0;
-    };
+struct DOCTEST_INTERFACE IExceptionTranslator {
+    DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
+    virtual bool translate(String &) const = 0;
+};
 
-    template <typename T>
-    class ExceptionTranslator : public IExceptionTranslator
-    {
-    public:
-        explicit ExceptionTranslator(String (*translateFunction)(T))
-                : m_translateFunction(translateFunction) {}
+template <typename T>
+class ExceptionTranslator : public IExceptionTranslator {
+public:
+    explicit ExceptionTranslator(String (*translateFunction)(T))
+        : m_translateFunction(translateFunction) {}
 
-        bool translate(String& res) const override {
+    bool translate(String &res) const override {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-            try {
-                throw;
-            } catch(const T& ex) {
-                res = m_translateFunction(ex);
-                return true;
-            } catch(...) {}
-#endif                              // DOCTEST_CONFIG_NO_EXCEPTIONS
-            static_cast<void>(res); // to silence -Wunused-parameter
-            return false;
-        }
+        try {
+            throw;
+        } catch (const T &ex) {
+            res = m_translateFunction(ex);
+            return true;
+        } catch (...) {}
+#endif                          // DOCTEST_CONFIG_NO_EXCEPTIONS
+        static_cast<void>(res); // to silence -Wunused-parameter
+        return false;
+    }
 
-    private:
-        String (*m_translateFunction)(T);
-    };
+private:
+    String (*m_translateFunction)(T);
+};
 
-    DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator* et);
+DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator *et);
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -2189,60 +2276,63 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE IContextScope
-{
+struct DOCTEST_INTERFACE IContextScope {
     DOCTEST_DECLARE_INTERFACE(IContextScope)
-    virtual void stringify(std::ostream*) const = 0;
+    virtual void stringify(std::ostream *) const = 0;
 };
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-  // ContextScope base class used to allow implementing methods of ContextScope
-  // that don't depend on the template parameter in doctest.cpp.
-  struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
-      ContextScopeBase(const ContextScopeBase&) = delete;
+// ContextScope base class used to allow implementing methods of ContextScope
+// that don't depend on the template parameter in doctest.cpp.
+struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    ContextScopeBase(const ContextScopeBase &) = delete;
 
-      ContextScopeBase& operator=(const ContextScopeBase&) = delete;
-      ContextScopeBase& operator=(ContextScopeBase&&) = delete;
+    ContextScopeBase &operator=(const ContextScopeBase &) = delete;
+    ContextScopeBase &operator=(ContextScopeBase &&) = delete;
 
-      ~ContextScopeBase() override = default;
+    ~ContextScopeBase() override = default;
 
-  protected:
-      ContextScopeBase();
-      ContextScopeBase(ContextScopeBase&& other) noexcept;
+protected:
+    ContextScopeBase();
+    ContextScopeBase(ContextScopeBase &&other) noexcept;
 
-      void destroy();
-      bool need_to_destroy{true};
-  };
+    void destroy();
+    bool need_to_destroy{true};
+};
 
-  template <typename L> class ContextScope : public ContextScopeBase
-  {
-      L lambda_;
+template <typename L>
+class ContextScope : public ContextScopeBase {
+    L lambda_;
 
-  public:
-      explicit ContextScope(const L &lambda) : lambda_(lambda) {}
-      explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
+public:
+    explicit ContextScope(const L &lambda)
+        : lambda_(lambda) {}
+    explicit ContextScope(L &&lambda)
+        : lambda_(static_cast<L &&>(lambda)) {}
 
-      ContextScope(const ContextScope&) = delete;
-      ContextScope(ContextScope&&) noexcept = default;
+    ContextScope(const ContextScope &) = delete;
+    ContextScope(ContextScope &&) noexcept = default;
 
-      ContextScope& operator=(const ContextScope&) = delete;
-      ContextScope& operator=(ContextScope&&) = delete;
+    ContextScope &operator=(const ContextScope &) = delete;
+    ContextScope &operator=(ContextScope &&) = delete;
 
-      void stringify(std::ostream* s) const override { lambda_(s); }
+    void stringify(std::ostream *s) const override {
+        lambda_(s);
+    }
 
-      ~ContextScope() override {
-          if (need_to_destroy) {
-              destroy();
-          }
-      }
-  };
+    ~ContextScope() override {
+        if (need_to_destroy) {
+            destroy();
+        }
+    }
+};
 
-  template <typename L>
-  ContextScope<L> MakeContextScope(const L &lambda) {
-      return ContextScope<L>(lambda);
-  }
+template <typename L>
+ContextScope<L> MakeContextScope(const L &lambda) {
+    return ContextScope<L>(lambda);
+}
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -2260,55 +2350,57 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE MessageData
-    {
-        String           m_string;
-        const char*      m_file;
-        int              m_line;
-        assertType::Enum m_severity;
-    };
+struct DOCTEST_INTERFACE MessageData {
+    String m_string;
+    const char *m_file;
+    int m_line;
+    assertType::Enum m_severity;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    struct DOCTEST_INTERFACE MessageBuilder : public MessageData
-    {
-        std::ostream* m_stream;
-        bool          logged = false;
+struct DOCTEST_INTERFACE MessageBuilder : public MessageData {
+    std::ostream *m_stream;
+    bool logged = false;
 
-        MessageBuilder(const char* file, int line, assertType::Enum severity);
+    MessageBuilder(const char *file, int line, assertType::Enum severity);
 
-        MessageBuilder(const MessageBuilder&) = delete;
-        MessageBuilder(MessageBuilder&&) = delete;
+    MessageBuilder(const MessageBuilder &) = delete;
+    MessageBuilder(MessageBuilder &&) = delete;
 
-        MessageBuilder& operator=(const MessageBuilder&) = delete;
-        MessageBuilder& operator=(MessageBuilder&&) = delete;
+    MessageBuilder &operator=(const MessageBuilder &) = delete;
+    MessageBuilder &operator=(MessageBuilder &&) = delete;
 
-        ~MessageBuilder();
+    ~MessageBuilder();
 
-        // the preferred way of chaining parameters for stringification
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
-        template <typename T>
-        MessageBuilder& operator,(const T& in) {
-            *m_stream << (DOCTEST_STRINGIFY(in));
-            return *this;
-        }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    // the preferred way of chaining parameters for stringification
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+    template <typename T>
+    MessageBuilder &operator,(const T &in) {
+        *m_stream << (DOCTEST_STRINGIFY(in));
+        return *this;
+    }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        // kept here just for backwards-compatibility - the comma operator should be preferred now
-        template <typename T>
-        MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
+    // kept here just for backwards-compatibility - the comma operator should be preferred now
+    template <typename T>
+    MessageBuilder &operator<<(const T &in) {
+        return this->operator,(in);
+    }
 
-        // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
-        // the `,` operator will be called last which is not what we want and thus the `*` operator
-        // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
-        // an operator of the MessageBuilder class is called first before the rest of the parameters
-        template <typename T>
-        MessageBuilder& operator*(const T& in) { return this->operator,(in); }
+    // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
+    // the `,` operator will be called last which is not what we want and thus the `*` operator
+    // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
+    // an operator of the MessageBuilder class is called first before the rest of the parameters
+    template <typename T>
+    MessageBuilder &operator*(const T &in) {
+        return this->operator,(in);
+    }
 
-        bool log();
-        void react();
-    };
+    bool log();
+    void react();
+};
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -2326,7 +2418,7 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
+DOCTEST_INTERFACE const char *skipPathFromFilename(const char *file);
 
 } // namespace doctest
 
@@ -2344,16 +2436,14 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-  struct DOCTEST_INTERFACE TestFailureException
-  {
-  };
+struct DOCTEST_INTERFACE TestFailureException {};
 
-  DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_NORETURN
+DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_INTERFACE void throwException();
+DOCTEST_INTERFACE void throwException();
 
 } // namespace detail
 } // namespace doctest
@@ -2371,37 +2461,36 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    DOCTEST_INTERFACE extern bool is_running_in_test;
+DOCTEST_INTERFACE extern bool is_running_in_test;
 
 namespace detail {
-    using assert_handler = void (*)(const AssertData&);
-    struct ContextState;
+using assert_handler = void (*)(const AssertData &);
+struct ContextState;
 } // namespace detail
 
-class DOCTEST_INTERFACE Context
-{
-    detail::ContextState* p;
+class DOCTEST_INTERFACE Context {
+    detail::ContextState *p;
 
-    void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
+    void parseArgs(int argc, const char *const *argv, bool withDefaults = false);
 
 public:
-    explicit Context(int argc = 0, const char* const* argv = nullptr);
+    explicit Context(int argc = 0, const char *const *argv = nullptr);
 
-    Context(const Context&) = delete;
-    Context(Context&&) = delete;
+    Context(const Context &) = delete;
+    Context(Context &&) = delete;
 
-    Context& operator=(const Context&) = delete;
-    Context& operator=(Context&&) = delete;
+    Context &operator=(const Context &) = delete;
+    Context &operator=(Context &&) = delete;
 
     ~Context(); // NOLINT(performance-trivially-destructible)
 
-    void applyCommandLine(int argc, const char* const* argv);
+    void applyCommandLine(int argc, const char *const *argv);
 
-    void addFilter(const char* filter, const char* value);
+    void addFilter(const char *filter, const char *value);
     void clearFilters();
-    void setOption(const char* option, bool value);
-    void setOption(const char* option, int value);
-    void setOption(const char* option, const char* value);
+    void setOption(const char *option, bool value);
+    void setOption(const char *option, int value);
+    void setOption(const char *option, const char *value);
 
     bool shouldExit();
 
@@ -2409,7 +2498,7 @@ public:
 
     void setAssertHandler(detail::assert_handler ah);
 
-    void setCout(std::ostream* out);
+    void setCout(std::ostream *out);
 
     int run();
 };
@@ -2429,69 +2518,74 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
+DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData &ad);
 
-    DOCTEST_INTERFACE bool decomp_assert(assertType::Enum at, const char* file, int line,
-                                         const char* expr, const Result& result);
+DOCTEST_INTERFACE bool
+decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result);
 
-#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                        \
-    do {                                                                                           \
-        if(!is_running_in_test) {                                                                  \
-            if(failed) {                                                                           \
-                ResultBuilder rb(at, file, line, expr);                                            \
-                rb.m_failed = failed;                                                              \
-                rb.m_decomp = decomp;                                                              \
-                failed_out_of_a_testing_context(rb);                                               \
-                if(isDebuggerActive() && !getContextOptions()->no_breaks)                          \
-                    DOCTEST_BREAK_INTO_DEBUGGER();                                                 \
-                if(checkIfShouldThrow(at))                                                         \
-                    throwException();                                                              \
-            }                                                                                      \
-            return !failed;                                                                        \
-        }                                                                                          \
-    } while(false)
+#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                                            \
+    do {                                                                                                               \
+        if (!is_running_in_test) {                                                                                     \
+            if (failed) {                                                                                              \
+                ResultBuilder rb(at, file, line, expr);                                                                \
+                rb.m_failed = failed;                                                                                  \
+                rb.m_decomp = decomp;                                                                                  \
+                failed_out_of_a_testing_context(rb);                                                                   \
+                if (isDebuggerActive() && !getContextOptions()->no_breaks)                                             \
+                    DOCTEST_BREAK_INTO_DEBUGGER();                                                                     \
+                if (checkIfShouldThrow(at))                                                                            \
+                    throwException();                                                                                  \
+            }                                                                                                          \
+            return !failed;                                                                                            \
+        }                                                                                                              \
+    } while (false)
 
-#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                            \
-    ResultBuilder rb(at, file, line, expr);                                                        \
-    rb.m_failed = failed;                                                                          \
-    if(rb.m_failed || getContextOptions()->success)                                                \
-        rb.m_decomp = decomp;                                                                      \
-    if(rb.log())                                                                                   \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
-    if(rb.m_failed && checkIfShouldThrow(at))                                                      \
+#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                                                \
+    ResultBuilder rb(at, file, line, expr);                                                                            \
+    rb.m_failed = failed;                                                                                              \
+    if (rb.m_failed || getContextOptions()->success)                                                                   \
+        rb.m_decomp = decomp;                                                                                          \
+    if (rb.log())                                                                                                      \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    if (rb.m_failed && checkIfShouldThrow(at))                                                                         \
     throwException()
 
-    template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE bool binary_assert(assertType::Enum at, const char* file, int line,
-                                        const char* expr, const DOCTEST_REF_WRAP(L) lhs,
-                                        const DOCTEST_REF_WRAP(R) rhs) {
-        bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+template <int comparison, typename L, typename R>
+DOCTEST_NOINLINE bool binary_assert(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const DOCTEST_REF_WRAP(L) lhs,
+    const DOCTEST_REF_WRAP(R) rhs
+) {
+    bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-        DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    return !failed;
+}
 
-    template <typename L>
-    DOCTEST_NOINLINE bool unary_assert(assertType::Enum at, const char* file, int line,
-                                       const char* expr, const DOCTEST_REF_WRAP(L) val) {
-        bool failed = !val;
+template <typename L>
+DOCTEST_NOINLINE bool
+unary_assert(assertType::Enum at, const char *file, int line, const char *expr, const DOCTEST_REF_WRAP(L) val) {
+    bool failed = !val;
 
-        if(at & assertType::is_false)
-            failed = !failed;
+    if (at & assertType::is_false)
+        failed = !failed;
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
-        DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
+    DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
+    return !failed;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -2510,119 +2604,115 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 
 namespace TestCaseFailureReason {
-    enum Enum
-    {
-        None                     = 0,
-        AssertFailure            = 1,   // an assertion has failed in the test case
-        Exception                = 2,   // test case threw an exception
-        Crash                    = 4,   // a crash...
-        TooManyFailedAsserts     = 8,   // the abort-after option
-        Timeout                  = 16,  // see the timeout decorator
-        ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
-        ShouldHaveFailedAndDid   = 64,  // see the should_fail decorator
-        DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
-        FailedExactlyNumTimes    = 256, // see the expected_failures decorator
-        CouldHaveFailedAndDid    = 512  // see the may_fail decorator
-    };
+enum Enum {
+    None = 0,
+    AssertFailure = 1,              // an assertion has failed in the test case
+    Exception = 2,                  // test case threw an exception
+    Crash = 4,                      // a crash...
+    TooManyFailedAsserts = 8,       // the abort-after option
+    Timeout = 16,                   // see the timeout decorator
+    ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
+    ShouldHaveFailedAndDid = 64,    // see the should_fail decorator
+    DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
+    FailedExactlyNumTimes = 256,    // see the expected_failures decorator
+    CouldHaveFailedAndDid = 512     // see the may_fail decorator
+};
 } // namespace TestCaseFailureReason
 
-    struct DOCTEST_INTERFACE CurrentTestCaseStats
-    {
-        int    numAssertsCurrentTest;
-        int    numAssertsFailedCurrentTest;
-        double seconds;
-        int    failure_flags; // use TestCaseFailureReason::Enum
-        bool   testCaseSuccess;
-    };
+struct DOCTEST_INTERFACE CurrentTestCaseStats {
+    int numAssertsCurrentTest;
+    int numAssertsFailedCurrentTest;
+    double seconds;
+    int failure_flags; // use TestCaseFailureReason::Enum
+    bool testCaseSuccess;
+};
 
-    struct DOCTEST_INTERFACE TestCaseException
-    {
-        String error_string;
-        bool   is_crash;
-    };
+struct DOCTEST_INTERFACE TestCaseException {
+    String error_string;
+    bool is_crash;
+};
 
-    struct DOCTEST_INTERFACE TestRunStats
-    {
-        unsigned numTestCases;
-        unsigned numTestCasesPassingFilters;
-        unsigned numTestSuitesPassingFilters;
-        unsigned numTestCasesFailed;
-        int      numAsserts;
-        int      numAssertsFailed;
-    };
+struct DOCTEST_INTERFACE TestRunStats {
+    unsigned numTestCases;
+    unsigned numTestCasesPassingFilters;
+    unsigned numTestSuitesPassingFilters;
+    unsigned numTestCasesFailed;
+    int numAsserts;
+    int numAssertsFailed;
+};
 
-    struct QueryData
-    {
-        const TestRunStats*  run_stats = nullptr;
-        const TestCaseData** data      = nullptr;
-        unsigned             num_data  = 0;
-    };
+struct QueryData {
+    const TestRunStats *run_stats = nullptr;
+    const TestCaseData **data = nullptr;
+    unsigned num_data = 0;
+};
 
-    struct DOCTEST_INTERFACE IReporter
-    {
-        // The constructor has to accept "const ContextOptions&" as a single argument
-        // which has most of the options for the run + a pointer to the stdout stream
-        // Reporter(const ContextOptions& in)
+struct DOCTEST_INTERFACE IReporter {
+    // The constructor has to accept "const ContextOptions&" as a single argument
+    // which has most of the options for the run + a pointer to the stdout stream
+    // Reporter(const ContextOptions& in)
 
-        // called when a query should be reported (listing test cases, printing the version, etc.)
-        virtual void report_query(const QueryData&) = 0;
+    // called when a query should be reported (listing test cases, printing the version, etc.)
+    virtual void report_query(const QueryData &) = 0;
 
-        // called when the whole test run starts
-        virtual void test_run_start() = 0;
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const TestRunStats&) = 0;
+    // called when the whole test run starts
+    virtual void test_run_start() = 0;
+    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+    virtual void test_run_end(const TestRunStats &) = 0;
 
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const TestCaseData&) = 0;
-        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const TestCaseData&) = 0;
-        // called when a test case has ended
-        virtual void test_case_end(const CurrentTestCaseStats&) = 0;
+    // called when a test case is started (safe to cache a pointer to the input)
+    virtual void test_case_start(const TestCaseData &) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData &) = 0;
+    // called when a test case has ended
+    virtual void test_case_end(const CurrentTestCaseStats &) = 0;
 
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const TestCaseException&) = 0;
+    // called when an exception is thrown from the test case (or it crashes)
+    virtual void test_case_exception(const TestCaseException &) = 0;
 
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const SubcaseSignature&) = 0;
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() = 0;
+    // called whenever a subcase is entered (don't cache pointers to the input)
+    virtual void subcase_start(const SubcaseSignature &) = 0;
+    // called whenever a subcase is exited (don't cache pointers to the input)
+    virtual void subcase_end() = 0;
 
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const AssertData&) = 0;
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const MessageData&) = 0;
+    // called for each assert (don't cache pointers to the input)
+    virtual void log_assert(const AssertData &) = 0;
+    // called for each message (don't cache pointers to the input)
+    virtual void log_message(const MessageData &) = 0;
 
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const TestCaseData&) = 0;
+    // called when a test case is skipped either because it doesn't pass the filters,
+    // has a skip decorator or isn't in the execution range (between first and last)
+    // (safe to cache a pointer to the input)
+    virtual void test_case_skipped(const TestCaseData &) = 0;
 
-        DOCTEST_DECLARE_INTERFACE(IReporter)
+    DOCTEST_DECLARE_INTERFACE(IReporter)
 
-        // can obtain all currently active contexts and stringify them if one wishes to do so
-        static int                         get_num_active_contexts();
-        static const IContextScope* const* get_active_contexts();
+    // can obtain all currently active contexts and stringify them if one wishes to do so
+    static int get_num_active_contexts();
+    static const IContextScope *const *get_active_contexts();
 
-        // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-        static int           get_num_stringified_contexts();
-        static const String* get_stringified_contexts();
-    };
+    // can iterate through contexts which have been stringified automatically
+    // in their destructors when an exception has been thrown
+    static int get_num_stringified_contexts();
+    static const String *get_stringified_contexts();
+};
 
 namespace detail {
-    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
+using reporterCreatorFunc = IReporter *(*)(const ContextOptions &);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+DOCTEST_INTERFACE void registerReporterImpl(const char *name, int prio, reporterCreatorFunc c, bool isReporter);
 
-    template <typename Reporter>
-    IReporter* reporterCreator(const ContextOptions& o) {
-        return new Reporter(o);
-    }
+template <typename Reporter>
+IReporter *reporterCreator(const ContextOptions &o) {
+    return new Reporter(o);
+}
 } // namespace detail
 
-    template <typename Reporter>
-    int registerReporter(const char* name, int priority, bool isReporter) {
-        detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
-        return 0;
-    }
+template <typename Reporter>
+int registerReporter(const char *name, int priority, bool isReporter) {
+    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+    return 0;
+}
 } // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
@@ -2637,8 +2727,10 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace doctest {
 namespace detail {
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+template <typename T>
+int instantiationHelper(const T &) {
+    return 0;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -2659,249 +2751,261 @@ namespace detail {
 #define DOCTEST_FUNC_SCOPE_RET(v) return v
 #else
 #define DOCTEST_FUNC_SCOPE_BEGIN do
-#define DOCTEST_FUNC_SCOPE_END while(false)
+#define DOCTEST_FUNC_SCOPE_END while (false)
 #define DOCTEST_FUNC_SCOPE_RET(v) (void)0
 #endif
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
-    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
-    b.react();                                                                                     \
+#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                                             \
+    if (b.log())                                                                                                       \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    b.react();                                                                                                         \
     DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
 #ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #define DOCTEST_WRAP_IN_TRY(x) x;
 #else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#define DOCTEST_WRAP_IN_TRY(x)                                                                     \
-    try {                                                                                          \
-        x;                                                                                         \
-    } catch(...) { DOCTEST_RB.translateException(); }
+#define DOCTEST_WRAP_IN_TRY(x)                                                                                         \
+    try {                                                                                                              \
+        x;                                                                                                             \
+    } catch (...) { DOCTEST_RB.translateException(); }
 #endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #ifdef DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(...)                                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
-    static_cast<void>(__VA_ARGS__);                                                                \
+#define DOCTEST_CAST_TO_VOID(...)                                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                                           \
+    static_cast<void>(__VA_ARGS__);                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_POP
 #else // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 #define DOCTEST_CAST_TO_VOID(...) __VA_ARGS__;
 #endif // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 
 // registers the test by initializing a dummy var with a function
-#define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
-            doctest::detail::regTest(                                                              \
-                    doctest::detail::TestCase(                                                     \
-                            f, __FILE__, __LINE__,                                                 \
-                            doctest_detail_test_suite_ns::getCurrentTestSuite()) *                 \
-                    decorators))
+#define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                                        \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(                                                                          \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */                                                             \
+        doctest::detail::regTest(                                                                                      \
+            doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) *    \
+            decorators                                                                                                 \
+        )                                                                                                              \
+    )
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace { /* NOLINT */                                                                       \
-        struct der : public base                                                                   \
-        {                                                                                          \
-            void f();                                                                              \
-        };                                                                                         \
-        static DOCTEST_INLINE_NOINLINE void func() {                                               \
-            der v;                                                                                 \
-            v.f();                                                                                 \
-        }                                                                                          \
-        DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                 \
-    }                                                                                              \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                                         \
+    namespace { /* NOLINT */                                                                                           \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    static DOCTEST_INLINE_NOINLINE void func() {                                                                       \
+        der v;                                                                                                         \
+        v.f();                                                                                                         \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                                         \
+    }                                                                                                                  \
     DOCTEST_INLINE_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
-    static void f();                                                                               \
-    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, f, decorators)                                        \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                                            \
+    static void f();                                                                                                   \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, f, decorators)                                                            \
     static void f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                        \
-    static doctest::detail::funcType proxy() { return f; }                                         \
-    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                         \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                                            \
+    static doctest::detail::funcType proxy() {                                                                         \
+        return f;                                                                                                      \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                                             \
     static void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(decorators)                                                              \
+#define DOCTEST_TEST_CASE(decorators)                                                                                  \
     DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests in classes - requires C++17 for inline variables!
 #if DOCTEST_CPLUSPLUS >= 201703L
-#define DOCTEST_TEST_CASE_CLASS(decorators)                                                        \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_),           \
-                                                  DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_),          \
-                                                  decorators)
+#define DOCTEST_TEST_CASE_CLASS(decorators)                                                                            \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(                                                                     \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_), decorators                      \
+    )
 #else // DOCTEST_TEST_CASE_CLASS
-#define DOCTEST_TEST_CASE_CLASS(...)                                                               \
-    TEST_CASES_CAN_BE_REGISTERED_IN_CLASSES_ONLY_IN_CPP17_MODE_OR_WITH_VS_2017_OR_NEWER
+#define DOCTEST_TEST_CASE_CLASS(...) TEST_CASES_CAN_BE_REGISTERED_IN_CLASSES_ONLY_IN_CPP17_MODE_OR_WITH_VS_2017_OR_NEWER
 #endif // DOCTEST_TEST_CASE_CLASS
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c,                           \
-                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
+#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                       \
+    DOCTEST_IMPLEMENT_FIXTURE(                                                                                         \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators                   \
+    )
 
 // for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                        \
-    namespace doctest {                                                                            \
-        template <>                                                                                \
-        inline String toString<__VA_ARGS__>() {                                                    \
-            return str;                                                                            \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                                            \
+    namespace doctest {                                                                                                \
+    template <>                                                                                                        \
+    inline String toString<__VA_ARGS__>() {                                                                            \
+        return str;                                                                                                    \
+    }                                                                                                                  \
+    }                                                                                                                  \
     static_assert(true, "")
 
 #define DOCTEST_TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING_AS(#__VA_ARGS__, __VA_ARGS__)
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                 \
-    template <typename T>                                                                          \
-    static void func();                                                                            \
-    namespace { /* NOLINT */                                                                       \
-        template <typename Tuple>                                                                  \
-        struct iter;                                                                               \
-        template <typename Type, typename... Rest>                                                 \
-        struct iter<std::tuple<Type, Rest...>>                                                     \
-        {                                                                                          \
-            iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::toString<Type>(),                             \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
-                iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
-            }                                                                                      \
-        };                                                                                         \
-        template <>                                                                                \
-        struct iter<std::tuple<>>                                                                  \
-        {                                                                                          \
-            iter(const char*, unsigned, int) {}                                                    \
-        };                                                                                         \
-    }                                                                                              \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                                     \
+    template <typename T>                                                                                              \
+    static void func();                                                                                                \
+    namespace { /* NOLINT */                                                                                           \
+    template <typename Tuple>                                                                                          \
+    struct iter;                                                                                                       \
+    template <typename Type, typename... Rest>                                                                         \
+    struct iter<std::tuple<Type, Rest...>> {                                                                           \
+        iter(const char *file, unsigned line, int index) {                                                             \
+            doctest::detail::regTest(                                                                                  \
+                doctest::detail::TestCase(                                                                             \
+                    func<Type>,                                                                                        \
+                    file,                                                                                              \
+                    line,                                                                                              \
+                    doctest_detail_test_suite_ns::getCurrentTestSuite(),                                               \
+                    doctest::toString<Type>(),                                                                         \
+                    int(line) * 1000 + index                                                                           \
+                ) *                                                                                                    \
+                dec                                                                                                    \
+            );                                                                                                         \
+            iter<std::tuple<Rest...>>(file, line, index + 1);                                                          \
+        }                                                                                                              \
+    };                                                                                                                 \
+    template <>                                                                                                        \
+    struct iter<std::tuple<>> {                                                                                        \
+        iter(const char *, unsigned, int) {}                                                                           \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename T>                                                                                              \
     static void func()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                              \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR),                      \
-                                           DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                                                  \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR), DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
-        doctest::detail::instantiationHelper(                                                      \
-            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                                     \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */                 \
+        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ > (__FILE__, __LINE__, 0))        \
+    )
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                                     \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>)     \
     static_assert(true, "")
 
-#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                                      \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)                 \
     static_assert(true, "")
 
-#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);             \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, std::tuple<__VA_ARGS__>)               \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                                             \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);                                 \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, std::tuple<__VA_ARGS__>)                                   \
+    template <typename T>                                                                                              \
     static void anon()
 
-#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                    \
+#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                                        \
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
-               doctest::detail::Subcase(name, __FILE__, __LINE__))
+#define DOCTEST_SUBCASE(name)                                                                                          \
+    if (const doctest::detail::Subcase &DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =                      \
+            doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
-#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
-    namespace ns_name { namespace doctest_detail_test_suite_ns {                                   \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() noexcept {   \
-                DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                      \
-                DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                \
-                DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")             \
-                static doctest::detail::TestSuite data{};                                          \
-                static bool                       inited = false;                                  \
-                DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                  \
-                DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                 \
-                DOCTEST_GCC_SUPPRESS_WARNING_POP                                                   \
-                if(!inited) {                                                                      \
-                    data* decorators;                                                              \
-                    inited = true;                                                                 \
-                }                                                                                  \
-                return data;                                                                       \
-            }                                                                                      \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                                                   \
+    namespace ns_name {                                                                                                \
+    namespace doctest_detail_test_suite_ns {                                                                           \
+    static DOCTEST_NOINLINE doctest::detail::TestSuite &getCurrentTestSuite() noexcept {                               \
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                                                  \
+        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                                            \
+        DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")                                         \
+        static doctest::detail::TestSuite data{};                                                                      \
+        static bool inited = false;                                                                                    \
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                                              \
+        DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                             \
+        DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                               \
+        if (!inited) {                                                                                                 \
+            data *decorators;                                                                                          \
+            inited = true;                                                                                             \
+        }                                                                                                              \
+        return data;                                                                                                   \
+    }                                                                                                                  \
+    }                                                                                                                  \
+    }                                                                                                                  \
     namespace ns_name
 
-#define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
+#define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
+#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                                           \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators)                                       \
+    )                                                                                                                  \
     static_assert(true, "")
 
 // for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+#define DOCTEST_TEST_SUITE_END                                                                                         \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")                                               \
+    )                                                                                                                  \
     using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
-    inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerExceptionTranslator(translatorName))                                  \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                                          \
+    inline doctest::String translatorName(signature);                                                                  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */                                      \
+        doctest::registerExceptionTranslator(translatorName)                                                           \
+    )                                                                                                                  \
     doctest::String translatorName(signature)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_),        \
-                                               signature)
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), signature)
 
 // for registering reporters
-#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerReporter<reporter>(name, priority, true))                             \
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                                        \
+        doctest::registerReporter<reporter>(name, priority, true)                                                      \
+    )                                                                                                                  \
     static_assert(true, "")
 
 // for registering listeners
-#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerReporter<reporter>(name, priority, false))                            \
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                                        \
+        doctest::registerReporter<reporter>(name, priority, false)                                                     \
+    )                                                                                                                  \
     static_assert(true, "")
 
-// clang-format off
-// for logging - disabling formatting because it's important to have these on 2 separate lines - see PR #557
-#define DOCTEST_INFO(...)                                                                          \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
-                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
-                      __VA_ARGS__)
-// clang-format on
+#define DOCTEST_INFO(...)                                                                                              \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_), __VA_ARGS__)
 
-#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
-    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
-        [&](std::ostream* s_name) {                                                                \
-        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
-        mb_name.m_stream = s_name;                                                                 \
-        mb_name * __VA_ARGS__;                                                                     \
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                                                        \
+    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope([&](std::ostream *s_name) {           \
+        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn);                     \
+        mb_name.m_stream = s_name;                                                                                     \
+        mb_name *__VA_ARGS__;                                                                                          \
     })
 
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
 
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb * __VA_ARGS__;                                                                          \
-        if(mb.log())                                                                               \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        mb.react();                                                                                \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                                                 \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                                     \
+        mb *__VA_ARGS__;                                                                                               \
+        if (mb.log())                                                                                                  \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                                             \
+        mb.react();                                                                                                    \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-// clang-format off
-#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-#define DOCTEST_ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-// clang-format on
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...)                                                                        \
+    DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...)                                                                     \
+    DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_AT(file, line, ...)                                                                           \
+    DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
 
 #define DOCTEST_MESSAGE(...) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, __VA_ARGS__)
 #define DOCTEST_FAIL_CHECK(...) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, __VA_ARGS__)
@@ -2911,59 +3015,60 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
-    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
-                                               __LINE__, #__VA_ARGS__);                            \
-    DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-            << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
-    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                    \
+#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                      \
+    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__);     \
+    DOCTEST_WRAP_IN_TRY(                                                                                               \
+        DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__)   \
+    ) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                    \
+    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                                        \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                                          \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
-                        __VA_ARGS__))                                                              \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                                                  \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(__VA_ARGS__))      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                                      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 // necessary for <ASSERT>_MESSAGE
 #define DOCTEST_ASSERT_IMPLEMENT_2 DOCTEST_ASSERT_IMPLEMENT_1
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::decomp_assert(                                                                \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__,                    \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-                    << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    doctest::detail::decomp_assert(                                                                                    \
+        doctest::assertType::assert_type,                                                                              \
+        __FILE__,                                                                                                      \
+        __LINE__,                                                                                                      \
+        #__VA_ARGS__,                                                                                                  \
+        doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__                         \
+    ) DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
-    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                                            \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(                               \
+        doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__                                \
+    )
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
-                                  #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -3011,47 +3116,51 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                  \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(const typename doctest::detail::types::remove_const<                           \
-                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
-                DOCTEST_RB.translateException();                                                   \
-                DOCTEST_RB.m_threw_as = true;                                                      \
-            } catch(...) { DOCTEST_RB.translateException(); }                                      \
-            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
-        } else { /* NOLINT(*-else-after-return) */                                                 \
-            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
-        }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                                      \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, #expr, #__VA_ARGS__, message                     \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (const typename doctest::detail::types::remove_const<                                              \
+                     typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type &) {                  \
+                DOCTEST_RB.translateException();                                                                       \
+                DOCTEST_RB.m_threw_as = true;                                                                          \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(...) { DOCTEST_RB.translateException(); }                                      \
-            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
-        } else { /* NOLINT(*-else-after-return) */                                                 \
-           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
-        }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, expr_str, "", __VA_ARGS__                        \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        try {                                                                                      \
-            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
-        } catch(...) { DOCTEST_RB.translateException(); }                                          \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                                       \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        try {                                                                                                          \
+            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                                          \
+        } catch (...) { DOCTEST_RB.translateException(); }                                                             \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
@@ -3099,43 +3208,41 @@ namespace detail {
 // =================================================================================================
 #else // DOCTEST_CONFIG_DISABLE
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace /* NOLINT */ {                                                                       \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : public base                                                                   \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                                               \
+    namespace /* NOLINT */ {                                                                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     static inline void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for registering tests in classes
-#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_CLASS(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x,                           \
-                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                                             \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for converting types to strings without the <typeinfo> header and demangling
 #define DOCTEST_TYPE_TO_STRING_AS(str, ...) static_assert(true, "")
 #define DOCTEST_TYPE_TO_STRING(...) static_assert(true, "")
 
 // for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                                    \
+    template <typename type>                                                                                           \
     inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                                              \
+    template <typename type>                                                                                           \
     inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...) static_assert(true, "")
@@ -3153,8 +3260,8 @@ namespace detail {
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     static inline doctest::String DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_)(signature)
 
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
@@ -3169,8 +3276,7 @@ namespace detail {
 #define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
 #define DOCTEST_FAIL(...) (static_cast<void>(0))
 
-#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
- && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED) && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
 
 #define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
 #define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
@@ -3188,16 +3294,18 @@ namespace detail {
 
 namespace doctest {
 namespace detail {
-#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
-    template <typename L, typename R>                                                              \
-    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                                          \
+        return lhs op rhs;                                                                                             \
+    }
 
-    DOCTEST_RELATIONAL_OP(eq, ==)
-    DOCTEST_RELATIONAL_OP(ne, !=)
-    DOCTEST_RELATIONAL_OP(lt, <)
-    DOCTEST_RELATIONAL_OP(gt, >)
-    DOCTEST_RELATIONAL_OP(le, <=)
-    DOCTEST_RELATIONAL_OP(ge, >=)
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
 } // namespace detail
 } // namespace doctest
 
@@ -3228,20 +3336,25 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
-#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...)                                                                      \
+    [] {                                                                                                               \
+        static_assert(false, "Exception translation is not available when doctest is disabled.");                      \
+        return false;                                                                                                  \
+    }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
+// clang-format off
 #define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
 #define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
 #define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
@@ -3261,6 +3374,7 @@ namespace detail {
 #define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
 #define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
 #define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+// clang-format on
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
@@ -3351,8 +3465,16 @@ namespace detail {
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
-    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
+#define DOCTEST_EXCEPTION_EMPTY_FUNC                                                                                   \
+    [] {                                                                                                               \
+        static_assert(                                                                                                 \
+            false,                                                                                                     \
+            "Exceptions are disabled! "                                                                                \
+            "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want "                                       \
+            "to compile with exceptions disabled."                                                                     \
+        );                                                                                                             \
+        return false;                                                                                                  \
+    }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -3416,49 +3538,47 @@ namespace detail {
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
-// clang-format off
 // KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
-#define DOCTEST_FAST_WARN_EQ             DOCTEST_WARN_EQ
-#define DOCTEST_FAST_CHECK_EQ            DOCTEST_CHECK_EQ
-#define DOCTEST_FAST_REQUIRE_EQ          DOCTEST_REQUIRE_EQ
-#define DOCTEST_FAST_WARN_NE             DOCTEST_WARN_NE
-#define DOCTEST_FAST_CHECK_NE            DOCTEST_CHECK_NE
-#define DOCTEST_FAST_REQUIRE_NE          DOCTEST_REQUIRE_NE
-#define DOCTEST_FAST_WARN_GT             DOCTEST_WARN_GT
-#define DOCTEST_FAST_CHECK_GT            DOCTEST_CHECK_GT
-#define DOCTEST_FAST_REQUIRE_GT          DOCTEST_REQUIRE_GT
-#define DOCTEST_FAST_WARN_LT             DOCTEST_WARN_LT
-#define DOCTEST_FAST_CHECK_LT            DOCTEST_CHECK_LT
-#define DOCTEST_FAST_REQUIRE_LT          DOCTEST_REQUIRE_LT
-#define DOCTEST_FAST_WARN_GE             DOCTEST_WARN_GE
-#define DOCTEST_FAST_CHECK_GE            DOCTEST_CHECK_GE
-#define DOCTEST_FAST_REQUIRE_GE          DOCTEST_REQUIRE_GE
-#define DOCTEST_FAST_WARN_LE             DOCTEST_WARN_LE
-#define DOCTEST_FAST_CHECK_LE            DOCTEST_CHECK_LE
-#define DOCTEST_FAST_REQUIRE_LE          DOCTEST_REQUIRE_LE
+#define DOCTEST_FAST_WARN_EQ DOCTEST_WARN_EQ
+#define DOCTEST_FAST_CHECK_EQ DOCTEST_CHECK_EQ
+#define DOCTEST_FAST_REQUIRE_EQ DOCTEST_REQUIRE_EQ
+#define DOCTEST_FAST_WARN_NE DOCTEST_WARN_NE
+#define DOCTEST_FAST_CHECK_NE DOCTEST_CHECK_NE
+#define DOCTEST_FAST_REQUIRE_NE DOCTEST_REQUIRE_NE
+#define DOCTEST_FAST_WARN_GT DOCTEST_WARN_GT
+#define DOCTEST_FAST_CHECK_GT DOCTEST_CHECK_GT
+#define DOCTEST_FAST_REQUIRE_GT DOCTEST_REQUIRE_GT
+#define DOCTEST_FAST_WARN_LT DOCTEST_WARN_LT
+#define DOCTEST_FAST_CHECK_LT DOCTEST_CHECK_LT
+#define DOCTEST_FAST_REQUIRE_LT DOCTEST_REQUIRE_LT
+#define DOCTEST_FAST_WARN_GE DOCTEST_WARN_GE
+#define DOCTEST_FAST_CHECK_GE DOCTEST_CHECK_GE
+#define DOCTEST_FAST_REQUIRE_GE DOCTEST_REQUIRE_GE
+#define DOCTEST_FAST_WARN_LE DOCTEST_WARN_LE
+#define DOCTEST_FAST_CHECK_LE DOCTEST_CHECK_LE
+#define DOCTEST_FAST_REQUIRE_LE DOCTEST_REQUIRE_LE
 
-#define DOCTEST_FAST_WARN_UNARY          DOCTEST_WARN_UNARY
-#define DOCTEST_FAST_CHECK_UNARY         DOCTEST_CHECK_UNARY
-#define DOCTEST_FAST_REQUIRE_UNARY       DOCTEST_REQUIRE_UNARY
-#define DOCTEST_FAST_WARN_UNARY_FALSE    DOCTEST_WARN_UNARY_FALSE
-#define DOCTEST_FAST_CHECK_UNARY_FALSE   DOCTEST_CHECK_UNARY_FALSE
+#define DOCTEST_FAST_WARN_UNARY DOCTEST_WARN_UNARY
+#define DOCTEST_FAST_CHECK_UNARY DOCTEST_CHECK_UNARY
+#define DOCTEST_FAST_REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
+#define DOCTEST_FAST_WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
+#define DOCTEST_FAST_CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
 #define DOCTEST_FAST_REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id,__VA_ARGS__)
-// clang-format on
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
 
 // BDD style macros
 // clang-format off
-#define DOCTEST_SCENARIO(name) DOCTEST_TEST_CASE("  Scenario: " name)
-#define DOCTEST_SCENARIO_CLASS(name) DOCTEST_TEST_CASE_CLASS("  Scenario: " name)
-#define DOCTEST_SCENARIO_TEMPLATE(name, T, ...)  DOCTEST_TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
+#define DOCTEST_SCENARIO(name)                                        DOCTEST_TEST_CASE("  Scenario: " name)
+#define DOCTEST_SCENARIO_CLASS(name)                            DOCTEST_TEST_CASE_CLASS("  Scenario: " name)
+#define DOCTEST_SCENARIO_TEMPLATE(name, T, ...)              DOCTEST_TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
 #define DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE("  Scenario: " name, T, id)
 
-#define DOCTEST_GIVEN(name)     DOCTEST_SUBCASE("   Given: " name)
-#define DOCTEST_WHEN(name)      DOCTEST_SUBCASE("    When: " name)
-#define DOCTEST_AND_WHEN(name)  DOCTEST_SUBCASE("And when: " name)
-#define DOCTEST_THEN(name)      DOCTEST_SUBCASE("    Then: " name)
-#define DOCTEST_AND_THEN(name)  DOCTEST_SUBCASE("     And: " name)
+#define DOCTEST_GIVEN(name)    DOCTEST_SUBCASE("   Given: " name)
+#define DOCTEST_WHEN(name)     DOCTEST_SUBCASE("    When: " name)
+#define DOCTEST_AND_WHEN(name) DOCTEST_SUBCASE("And when: " name)
+#define DOCTEST_THEN(name)     DOCTEST_SUBCASE("    Then: " name)
+#define DOCTEST_AND_THEN(name) DOCTEST_SUBCASE("     And: " name)
 // clang-format on
 
 // == SHORT VERSIONS OF THE MACROS
@@ -3512,6 +3632,7 @@ namespace detail {
 #define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
 #define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
+// clang-format off
 #define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
 #define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
@@ -3533,6 +3654,7 @@ namespace detail {
 #define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
 #define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+// clang-format on
 
 #define SCENARIO(name) DOCTEST_SCENARIO(name)
 #define SCENARIO_CLASS(name) DOCTEST_SCENARIO_CLASS(name)
@@ -3626,7 +3748,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <ctime>
 #include <cmath>
 #include <climits>
-// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/doctest/doctest/pull/37
+// borland (Embarcadero) compiler requires math.h and not cmath -
+// https://github.com/doctest/doctest/pull/37
 #ifdef __BORLANDC__
 #include <math.h>
 #endif // __BORLANDC__
@@ -3766,29 +3889,27 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-namespace timer_large_integer
-{
+namespace timer_large_integer {
 
 #if defined(DOCTEST_PLATFORM_WINDOWS)
-    using type = ULONGLONG;
-#else // DOCTEST_PLATFORM_WINDOWS
-    using type = std::uint64_t;
+using type = ULONGLONG;
+#else  // DOCTEST_PLATFORM_WINDOWS
+using type = std::uint64_t;
 #endif // DOCTEST_PLATFORM_WINDOWS
-}
+} // namespace timer_large_integer
 
 using ticks_t = timer_large_integer::type;
 
-    ticks_t getCurrentTicks();
+ticks_t getCurrentTicks();
 
-    struct Timer
-    {
-        void         start();
-        unsigned int getElapsedMicroseconds() const;
-        double getElapsedSeconds() const;
+struct Timer {
+    void start();
+    unsigned int getElapsedMicroseconds() const;
+    double getElapsedSeconds() const;
 
-    private:
-        ticks_t m_ticks = 0;
-    };
+private:
+    ticks_t m_ticks = 0;
+};
 
 } // namespace detail
 } // namespace doctest
@@ -3810,99 +3931,103 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_CONFIG_NO_MULTITHREADING
-    template <typename T>
-    using Atomic = T;
-#else // DOCTEST_CONFIG_NO_MULTITHREADING
-    template <typename T>
-    using Atomic = std::atomic<T>;
+template <typename T>
+using Atomic = T;
+#else  // DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = std::atomic<T>;
 #endif // DOCTEST_CONFIG_NO_MULTITHREADING
 
 #if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
-    template <typename T>
-    using MultiLaneAtomic = Atomic<T>;
-#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
-    // Provides a multilane implementation of an atomic variable that supports add, sub, load,
-    // store. Instead of using a single atomic variable, this splits up into multiple ones,
-    // each sitting on a separate cache line. The goal is to provide a speedup when most
-    // operations are modifying. It achieves this with two properties:
-    //
-    // * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
-    // * Each atomic sits on a separate cache line, so false sharing is reduced.
-    //
-    // The disadvantage is that there is a small overhead due to the use of TLS, and load/store
-    // is slower because all atomics have to be accessed.
-    template <typename T>
-    class MultiLaneAtomic
-    {
-        struct CacheLineAlignedAtomic
-        {
-            Atomic<T> atomic{};
-            char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
-        };
-        CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
-
-        static_assert(sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
-                      "guarantee one atomic takes exactly one cache line");
-
-    public:
-        T operator++() DOCTEST_NOEXCEPT { return fetch_add(1) + 1; }
-
-        T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
-
-        T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_add(arg, order);
-        }
-
-        T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_sub(arg, order);
-        }
-
-        operator T() const DOCTEST_NOEXCEPT { return load(); }
-
-        T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
-            auto result = T();
-            for(auto const& c : m_atomics) {
-                result += c.atomic.load(order);
-            }
-            return result;
-        }
-
-        T operator=(T desired) DOCTEST_NOEXCEPT {
-            store(desired);
-            return desired;
-        }
-
-        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            // first value becomes desired", all others become 0.
-            for(auto& c : m_atomics) {
-                c.atomic.store(desired, order);
-                desired = {};
-            }
-        }
-
-    private:
-        // Each thread has a different atomic that it operates on. If more than NumLanes threads
-        // use this, some will use the same atomic. So performance will degrade a bit, but still
-        // everything will work.
-        //
-        // The logic here is a bit tricky. The call should be as fast as possible, so that there
-        // is minimal to no overhead in determining the correct atomic for the current thread.
-        //
-        // 1. A global static counter laneCounter counts continuously up.
-        // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
-        //    assigned in a round-robin fashion.
-        // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
-        //    little overhead.
-        Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
-            static Atomic<size_t> laneCounter;
-            DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
-                    laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
-
-            return m_atomics[tlsLaneIdx].atomic;
-        }
+template <typename T>
+using MultiLaneAtomic = Atomic<T>;
+#else  // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+// Provides a multilane implementation of an atomic variable that supports add, sub, load,
+// store. Instead of using a single atomic variable, this splits up into multiple ones,
+// each sitting on a separate cache line. The goal is to provide a speedup when most
+// operations are modifying. It achieves this with two properties:
+//
+// * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
+// * Each atomic sits on a separate cache line, so false sharing is reduced.
+//
+// The disadvantage is that there is a small overhead due to the use of TLS, and load/store
+// is slower because all atomics have to be accessed.
+template <typename T>
+class MultiLaneAtomic {
+    struct CacheLineAlignedAtomic {
+        Atomic<T> atomic{};
+        char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
     };
-#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+    CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
 
+    static_assert(
+        sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
+        "guarantee one atomic takes exactly one cache line"
+    );
+
+public:
+    T operator++() DOCTEST_NOEXCEPT {
+        return fetch_add(1) + 1;
+    }
+
+    T operator++(int) DOCTEST_NOEXCEPT {
+        return fetch_add(1);
+    }
+
+    T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_add(arg, order);
+    }
+
+    T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_sub(arg, order);
+    }
+
+    operator T() const DOCTEST_NOEXCEPT {
+        return load();
+    }
+
+    T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+        auto result = T();
+        for (const auto &c: m_atomics) {
+            result += c.atomic.load(order);
+        }
+        return result;
+    }
+
+    T operator=(T desired) DOCTEST_NOEXCEPT {
+        store(desired);
+        return desired;
+    }
+
+    void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        // first value becomes desired", all others become 0.
+        for (auto &c: m_atomics) {
+            c.atomic.store(desired, order);
+            desired = {};
+        }
+    }
+
+private:
+    // Each thread has a different atomic that it operates on. If more than NumLanes threads
+    // use this, some will use the same atomic. So performance will degrade a bit, but still
+    // everything will work.
+    //
+    // The logic here is a bit tricky. The call should be as fast as possible, so that there
+    // is minimal to no overhead in determining the correct atomic for the current thread.
+    //
+    // 1. A global static counter laneCounter counts continuously up.
+    // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
+    //    assigned in a round-robin fashion.
+    // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
+    //    little overhead.
+    Atomic<T> &myAtomic() DOCTEST_NOEXCEPT {
+        static Atomic<size_t> laneCounter;
+        DOCTEST_THREAD_LOCAL size_t tlsLaneIdx = laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
+
+        return m_atomics[tlsLaneIdx].atomic;
+    }
+};
+#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
 } // namespace detail
 } // namespace doctest
@@ -3920,41 +4045,40 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // this holds both parameters from the command line and runtime data for tests
-    struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
-    {
-        MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
-        MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
+// this holds both parameters from the command line and runtime data for tests
+struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats {
+    MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
+    MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
-        std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+    std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
 
-        std::vector<IReporter*> reporters_currently_used;
+    std::vector<IReporter *> reporters_currently_used;
 
-        assert_handler ah = nullptr;
+    assert_handler ah = nullptr;
 
-        Timer timer;
+    Timer timer;
 
-        std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+    std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
 
-        // stuff for subcases
-        bool reachedLeaf;
-        std::vector<SubcaseSignature> subcaseStack;
-        std::vector<SubcaseSignature> nextSubcaseStack;
-        std::unordered_set<unsigned long long> fullyTraversedSubcases;
-        size_t currentSubcaseDepth;
-        Atomic<bool> shouldLogCurrentException;
+    // stuff for subcases
+    bool reachedLeaf;
+    std::vector<SubcaseSignature> subcaseStack;
+    std::vector<SubcaseSignature> nextSubcaseStack;
+    std::unordered_set<unsigned long long> fullyTraversedSubcases;
+    size_t currentSubcaseDepth;
+    Atomic<bool> shouldLogCurrentException;
 
-        void resetRunData();
+    void resetRunData();
 
-        void finalizeTestCaseData();
-    };
+    void finalizeTestCaseData();
+};
 
-    extern ContextState* g_cs;
+extern ContextState *g_cs;
 
-    // used to avoid locks for the debug output
-    // TODO: figure out if this is indeed necessary/correct - seems like either there still
-    // could be a race or that there wouldn't be a race even if using the context directly
-    extern DOCTEST_THREAD_LOCAL bool g_no_colors;
+// used to avoid locks for the debug output
+// TODO: figure out if this is indeed necessary/correct - seems like either there still
+// could be a race or that there wouldn't be a race even if using the context directly
+extern DOCTEST_THREAD_LOCAL bool g_no_colors;
 
 } // namespace detail
 } // namespace doctest
@@ -3971,18 +4095,31 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    using detail::g_cs;
+using detail::g_cs;
 
-    AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const StringContains& exception_string)
-        : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
-        m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
-        m_exception_string(exception_string) {
-    #if DOCTEST_MSVC
-        if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-    #endif // MSVC
-    }
+AssertData::AssertData(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const StringContains &exception_string
+)
+    : m_test_case(g_cs->currentTest),
+      m_at(at),
+      m_file(file),
+      m_line(line),
+      m_expr(expr),
+      m_failed(true),
+      m_threw(false),
+      m_threw_as(false),
+      m_exception_type(exception_type),
+      m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
 
 } // namespace doctest
 
@@ -3998,7 +4135,7 @@ namespace doctest {
 namespace detail {
 
 ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-        : m_at(at) {}
+    : m_at(at) {}
 
 } // namespace detail
 } // namespace doctest
@@ -4016,16 +4153,16 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    // the int (priority) is part of the key for automatic sorting - sadly one can register a
-    // reporter with a duplicate name and a different priority but hopefully that won't happen often :|
-    using reporterMap = std::map<std::pair<int, String>, detail::reporterCreatorFunc>;
+// the int (priority) is part of the key for automatic sorting - sadly one can register a
+// reporter with a duplicate name and a different priority but hopefully that won't happen often :|
+using reporterMap = std::map<std::pair<int, String>, detail::reporterCreatorFunc>;
 
-    reporterMap& getReporters();
-    reporterMap& getListeners();
+reporterMap &getReporters();
+reporterMap &getListeners();
 } // namespace detail
 
-#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                           \
-    for(auto& curr_rep : g_cs->reporters_currently_used)                                           \
+#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                                               \
+    for (auto &curr_rep: g_cs->reporters_currently_used)                                                               \
     curr_rep->function(__VA_ARGS__)
 
 } // namespace doctest
@@ -4046,12 +4183,12 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    void addAssert(assertType::Enum at);
+void addAssert(assertType::Enum at);
 
-    void addFailedAssert(assertType::Enum at);
+void addFailedAssert(assertType::Enum at);
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message);
+void reportFatal(const std::string &message);
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
 } // namespace detail
@@ -4070,55 +4207,53 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    void addAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0)
-            g_cs->numAssertsCurrentTest_atomic++;
-    }
+void addAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsCurrentTest_atomic++;
+}
 
-    void addFailedAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0)
-            g_cs->numAssertsFailedCurrentTest_atomic++;
-    }
+void addFailedAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsFailedCurrentTest_atomic++;
+}
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message) {
-        g_cs->failure_flags |= TestCaseFailureReason::Crash;
+void reportFatal(const std::string &message) {
+    g_cs->failure_flags |= TestCaseFailureReason::Crash;
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
-            g_cs->subcaseStack.pop_back();
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
-
-        g_cs->finalizeTestCaseData();
-
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    while (g_cs->subcaseStack.size()) {
+        g_cs->subcaseStack.pop_back();
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
+
+    g_cs->finalizeTestCaseData();
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+}
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
+void failed_out_of_a_testing_context(const AssertData &ad) {
+    if (g_cs->ah)
+        g_cs->ah(ad);
+    else
+        std::abort();
+}
 
-    void failed_out_of_a_testing_context(const AssertData& ad) {
-        if(g_cs->ah)
-            g_cs->ah(ad);
-        else
-            std::abort();
-    }
+bool decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result) {
+    bool failed = !result.m_passed;
 
-    bool decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
-                       const Result& result) {
-        bool failed = !result.m_passed;
-
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
-        DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
+    DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
+    return !failed;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -4134,42 +4269,42 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
-        m_stream   = tlssPush();
-        m_file     = file;
-        m_line     = line;
-        m_severity = severity;
+MessageBuilder::MessageBuilder(const char *file, int line, assertType::Enum severity) {
+    m_stream = tlssPush();
+    m_file = file;
+    m_line = line;
+    m_severity = severity;
+}
+
+MessageBuilder::~MessageBuilder() {
+    if (!logged)
+        tlssPop();
+}
+
+bool MessageBuilder::log() {
+    if (!logged) {
+        m_string = tlssPop();
+        logged = true;
     }
 
-    MessageBuilder::~MessageBuilder() {
-        if (!logged)
-            tlssPop();
+    DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
+
+    const bool isWarn = m_severity & assertType::is_warn;
+
+    // warn is just a message in this context so we don't treat it as an assert
+    if (!isWarn) {
+        addAssert(m_severity);
+        addFailedAssert(m_severity);
     }
 
-    bool MessageBuilder::log() {
-        if (!logged) {
-            m_string = tlssPop();
-            logged = true;
-        }
+    return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
-
-        const bool isWarn = m_severity & assertType::is_warn;
-
-        // warn is just a message in this context so we don't treat it as an assert
-        if(!isWarn) {
-            addAssert(m_severity);
-            addFailedAssert(m_severity);
-        }
-
-        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
-    }
-
-    void MessageBuilder::react() {
-        if(m_severity & assertType::is_require)
-            throwException();
-    }
+void MessageBuilder::react() {
+    if (m_severity & assertType::is_require)
+        throwException();
+}
 
 } // namespace detail
 } // namespace doctest
@@ -4188,8 +4323,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators();
-    String translateActiveException();
+std::vector<const IExceptionTranslator *> &getExceptionTranslators();
+String translateActiveException();
 
 } // namespace detail
 } // namespace doctest
@@ -4207,62 +4342,73 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    Result::Result(bool passed, const String& decomposition)
-            : m_passed(passed)
-            , m_decomp(decomposition) {}
+Result::Result(bool passed, const String &decomposition)
+    : m_passed(passed), m_decomp(decomposition) {}
 
-    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const String& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const String &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
-    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const Contains& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const Contains &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
-    void ResultBuilder::setResult(const Result& res) {
-        m_decomp = res.m_decomp;
-        m_failed = !res.m_passed;
+void ResultBuilder::setResult(const Result &res) {
+    m_decomp = res.m_decomp;
+    m_failed = !res.m_passed;
+}
+
+void ResultBuilder::translateException() {
+    m_threw = true;
+    m_exception = translateActiveException();
+}
+
+bool ResultBuilder::log() {
+    if (m_at & assertType::is_throws) {
+        m_failed = !m_threw;
+    } else if ((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) {
+        m_failed = !m_threw_as || !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_throws_as) {
+        m_failed = !m_threw_as;
+    } else if (m_at & assertType::is_throws_with) {
+        m_failed = !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_nothrow) {
+        m_failed = m_threw;
     }
 
-    void ResultBuilder::translateException() {
-        m_threw     = true;
-        m_exception = translateActiveException();
+    if (m_exception.size())
+        m_exception = "\"" + m_exception + "\"";
+
+    if (is_running_in_test) {
+        addAssert(m_at);
+        DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
+
+        if (m_failed)
+            addFailedAssert(m_at);
+    } else if (m_failed) {
+        failed_out_of_a_testing_context(*this);
     }
 
-    bool ResultBuilder::log() {
-        if(m_at & assertType::is_throws) {
-            m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) {
-            m_failed = !m_threw_as || !m_exception_string.check(m_exception);
-        } else if(m_at & assertType::is_throws_as) {
-            m_failed = !m_threw_as;
-        } else if(m_at & assertType::is_throws_with) {
-            m_failed = !m_exception_string.check(m_exception);
-        } else if(m_at & assertType::is_nothrow) {
-            m_failed = m_threw;
-        }
+    return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
 
-        if(m_exception.size())
-            m_exception = "\"" + m_exception + "\"";
-
-        if(is_running_in_test) {
-            addAssert(m_at);
-            DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
-
-            if(m_failed)
-                addFailedAssert(m_at);
-        } else if(m_failed) {
-            failed_out_of_a_testing_context(*this);
-        }
-
-        return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
-    }
-
-    void ResultBuilder::react() const {
-        if(m_failed && checkIfShouldThrow(m_at))
-            throwException();
-    }
+void ResultBuilder::react() const {
+    if (m_failed && checkIfShouldThrow(m_at))
+        throwException();
+}
 
 } // namespace detail
 } // namespace doctest
@@ -4279,27 +4425,26 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    template <typename Ex>
-    DOCTEST_NORETURN void throw_exception(Ex const& e) {
+template <typename Ex>
+DOCTEST_NORETURN void throw_exception(const Ex &e) {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+    throw e;
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS
 #ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
-        DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
+    DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
 #else // DOCTEST_CONFIG_HANDLE_EXCEPTION
 #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-        std::cerr << "doctest will terminate because it needed to throw an exception.\n"
-                  << "The message was: " << e.what() << '\n';
+    std::cerr << "doctest will terminate because it needed to throw an exception.\n"
+              << "The message was: " << e.what() << '\n';
 #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
 #endif // DOCTEST_CONFIG_HANDLE_EXCEPTION
-        std::terminate();
+    std::terminate();
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+}
 
 #ifndef DOCTEST_INTERNAL_ERROR
-#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
-    detail::throw_exception(std::logic_error(                                                              \
-            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
+#define DOCTEST_INTERNAL_ERROR(msg)                                                                                    \
+    detail::throw_exception(std::logic_error(__FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
 #endif // DOCTEST_INTERNAL_ERROR
 } // namespace detail
 
@@ -4313,19 +4458,19 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-// clang-format off
-const char* assertString(assertType::Enum at) {
+const char *assertString(assertType::Enum at) {
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitly handled
-    #define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type) case assertType::DT_ ## assert_type: return #assert_type
-    #define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type) \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_ ## assert_type); \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_ ## assert_type); \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_ ## assert_type)
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type)                                                                 \
+    case assertType::DT_##assert_type: return #assert_type
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type)                                                                \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_##assert_type);                                                             \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_##assert_type);                                                            \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_##assert_type)
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH
     DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")
-    switch(at) {
+    switch (at) {
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN);
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK);
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE);
@@ -4358,14 +4503,13 @@ const char* assertString(assertType::Enum at) {
     DOCTEST_GCC_SUPPRESS_WARNING_POP
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 }
-// clang-format on
 
-const char* failureString(assertType::Enum at) {
-    if(at & assertType::is_warn)
+const char *failureString(assertType::Enum at) {
+    if (at & assertType::is_warn)
         return "WARNING";
-    if(at & assertType::is_check)
+    if (at & assertType::is_check)
         return "ERROR";
-    if(at & assertType::is_require)
+    if (at & assertType::is_require)
         return "FATAL ERROR";
     return "";
 }
@@ -4389,96 +4533,92 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 
 namespace detail {
-    void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
+void color_to_stream(std::ostream &, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
 } // namespace detail
 
 namespace Color {
-    std::ostream& operator<<(std::ostream& s, Color::Enum code) {
-        detail::color_to_stream(s, code);
-        return s;
-    }
+std::ostream &operator<<(std::ostream &s, Color::Enum code) {
+    detail::color_to_stream(s, code);
+    return s;
+}
 } // namespace Color
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    void color_to_stream(std::ostream& s, Color::Enum code) {
-        static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
-        static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
-    #ifdef DOCTEST_CONFIG_COLORS_ANSI
-        if(g_no_colors ||
-            (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
-            return;
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+void color_to_stream(std::ostream &s, Color::Enum code) {
+    static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+    static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
+    if (g_no_colors || (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+        return;
 
-        auto col = "";
-        // clang-format off
-            DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-            DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
-            switch(code) {
-                case Color::Red:         col = "[0;31m"; break;
-                case Color::Green:       col = "[0;32m"; break;
-                case Color::Blue:        col = "[0;34m"; break;
-                case Color::Cyan:        col = "[0;36m"; break;
-                case Color::Yellow:      col = "[0;33m"; break;
-                case Color::Grey:        col = "[1;30m"; break;
-                case Color::LightGrey:   col = "[0;37m"; break;
-                case Color::BrightRed:   col = "[1;31m"; break;
-                case Color::BrightGreen: col = "[1;32m"; break;
-                case Color::BrightWhite: col = "[1;37m"; break;
-                case Color::Bright: // invalid
-                case Color::None:
-                case Color::White:
-                default:                 col = "[0m";
-            }
-            DOCTEST_CLANG_SUPPRESS_WARNING_POP
-        // clang-format on
-        s << "\033" << col;
-    #endif // DOCTEST_CONFIG_COLORS_ANSI
-
-    #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(g_no_colors ||
-            (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
-            return;
-
-        static struct ConsoleHelper {
-            HANDLE stdoutHandle;
-            WORD   origFgAttrs;
-            WORD   origBgAttrs;
-
-            ConsoleHelper() {
-                stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-                CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-                GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
-                origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                    BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-                origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                    FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-            }
-        } ch;
-
-    #define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
-
-        // clang-format off
-        switch (code) {
-            case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
-            case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
-            case Color::Green:       DOCTEST_SET_ATTR(FOREGROUND_GREEN);                                    break;
-            case Color::Blue:        DOCTEST_SET_ATTR(FOREGROUND_BLUE);                                     break;
-            case Color::Cyan:        DOCTEST_SET_ATTR(FOREGROUND_BLUE | FOREGROUND_GREEN);                  break;
-            case Color::Yellow:      DOCTEST_SET_ATTR(FOREGROUND_RED | FOREGROUND_GREEN);                   break;
-            case Color::Grey:        DOCTEST_SET_ATTR(0);                                                   break;
-            case Color::LightGrey:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY);                                break;
-            case Color::BrightRed:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_RED);               break;
-            case Color::BrightGreen: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN);             break;
-            case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
-            case Color::None:
-            case Color::Bright: // invalid
-            default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
-        }
-            // clang-format on
-    #endif // DOCTEST_CONFIG_COLORS_WINDOWS
+    auto col = "";
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
+    switch (code) {
+        case Color::Red:         col = "[0;31m"; break;
+        case Color::Green:       col = "[0;32m"; break;
+        case Color::Blue:        col = "[0;34m"; break;
+        case Color::Cyan:        col = "[0;36m"; break;
+        case Color::Yellow:      col = "[0;33m"; break;
+        case Color::Grey:        col = "[1;30m"; break;
+        case Color::LightGrey:   col = "[0;37m"; break;
+        case Color::BrightRed:   col = "[1;31m"; break;
+        case Color::BrightGreen: col = "[1;32m"; break;
+        case Color::BrightWhite: col = "[1;37m"; break;
+        case Color::Bright:      // invalid
+        case Color::None:
+        case Color::White:
+        default:                 col = "[0m";
     }
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    s << "\033" << col;
+#endif // DOCTEST_CONFIG_COLORS_ANSI
+
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+    if (g_no_colors || (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+        return;
+
+    static struct ConsoleHelper {
+        HANDLE stdoutHandle;
+        WORD origFgAttrs;
+        WORD origBgAttrs;
+
+        ConsoleHelper() {
+            stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+            GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+            origFgAttrs =
+                csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+            origBgAttrs =
+                csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+        }
+    } ch;
+
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+
+    // clang-format off
+    switch (code) {
+        case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
+        case Color::Green:       DOCTEST_SET_ATTR(FOREGROUND_GREEN);                                    break;
+        case Color::Blue:        DOCTEST_SET_ATTR(FOREGROUND_BLUE);                                     break;
+        case Color::Cyan:        DOCTEST_SET_ATTR(FOREGROUND_BLUE | FOREGROUND_GREEN);                  break;
+        case Color::Yellow:      DOCTEST_SET_ATTR(FOREGROUND_RED | FOREGROUND_GREEN);                   break;
+        case Color::Grey:        DOCTEST_SET_ATTR(0);                                                   break;
+        case Color::LightGrey:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY);                                break;
+        case Color::BrightRed:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_RED);               break;
+        case Color::BrightGreen: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN);             break;
+        case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::None:
+        case Color::Bright:      // invalid
+        default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
+    }
+        // clang-format on
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLED
 } // namespace doctest
@@ -4489,7 +4629,9 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs); }
+const ContextOptions *getContextOptions() {
+    return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs);
+}
 
 } // namespace doctest
 
@@ -4508,7 +4650,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb);
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb);
 
 } // namespace doctest
 
@@ -4536,29 +4678,27 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-struct Whitespace
-{
+struct Whitespace {
     int nrSpaces;
     explicit Whitespace(int nr);
 };
 
-std::ostream& operator<<(std::ostream& out, const Whitespace& ws);
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws);
 
-struct ConsoleReporter : public IReporter
-{
-    std::ostream&                 s;
-    bool                          hasLoggedCurrentTestStart;
+struct ConsoleReporter : public IReporter {
+    std::ostream &s;
+    bool hasLoggedCurrentTestStart;
     std::vector<SubcaseSignature> subcasesStack;
-    size_t                        currentSubcaseLevel;
+    size_t currentSubcaseLevel;
     DOCTEST_DECLARE_MUTEX(mutex)
 
     // caching pointers/references to objects of these types - safe to do
-    const ContextOptions& opt;
-    const TestCaseData*   tc;
+    const ContextOptions &opt;
+    const TestCaseData *tc;
 
-    ConsoleReporter(const ContextOptions& co);
+    ConsoleReporter(const ContextOptions &co);
 
-    ConsoleReporter(const ContextOptions& co, std::ostream& ostr);
+    ConsoleReporter(const ContextOptions &co, std::ostream &ostr);
 
     // =========================================================================================
     // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
@@ -4566,16 +4706,16 @@ struct ConsoleReporter : public IReporter
 
     void separator_to_stream();
 
-    const char* getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str);
+    const char *getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str);
 
     Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at);
 
-    void successOrFailColoredStringToStream(bool success, assertType::Enum at, const char* success_str = "SUCCESS");
+    void successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str = "SUCCESS");
 
     void log_contexts();
 
     // this was requested to be made virtual so users could override it
-    virtual void file_line_to_stream(const char* file, int line, const char* tail = "");
+    virtual void file_line_to_stream(const char *file, int line, const char *tail = "");
 
     void logTestStart();
 
@@ -4591,29 +4731,29 @@ struct ConsoleReporter : public IReporter
     // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
     // =========================================================================================
 
-    void report_query(const QueryData& in) override;
+    void report_query(const QueryData &in) override;
 
     void test_run_start() override;
 
-    void test_run_end(const TestRunStats& p) override;
+    void test_run_end(const TestRunStats &p) override;
 
-    void test_case_start(const TestCaseData& in) override;
+    void test_case_start(const TestCaseData &in) override;
 
-    void test_case_reenter(const TestCaseData&) override;
+    void test_case_reenter(const TestCaseData &) override;
 
-    void test_case_end(const CurrentTestCaseStats& st) override;
+    void test_case_end(const CurrentTestCaseStats &st) override;
 
-    void test_case_exception(const TestCaseException& e) override;
+    void test_case_exception(const TestCaseException &e) override;
 
-    void subcase_start(const SubcaseSignature& subc) override;
+    void subcase_start(const SubcaseSignature &subc) override;
 
     void subcase_end() override;
 
-    void log_assert(const AssertData& rb) override;
+    void log_assert(const AssertData &rb) override;
 
-    void log_message(const MessageData& mb) override;
+    void log_message(const MessageData &mb) override;
 
-    void test_case_skipped(const TestCaseData&) override;
+    void test_case_skipped(const TestCaseData &) override;
 };
 
 DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
@@ -4634,24 +4774,23 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    struct DebugOutputWindowReporter : public ConsoleReporter
-    {
-        DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+struct DebugOutputWindowReporter : public ConsoleReporter {
+    DOCTEST_THREAD_LOCAL static std::ostringstream oss;
 
-        DebugOutputWindowReporter(const ContextOptions& co);
+    DebugOutputWindowReporter(const ContextOptions &co);
 
-        void test_run_start() override;
-        void test_run_end(const TestRunStats& in) override;
-        void test_case_start(const TestCaseData& in) override;
-        void test_case_reenter(const TestCaseData& in) override;
-        void test_case_end(const CurrentTestCaseStats& in) override;
-        void test_case_exception(const TestCaseException& in) override;
-        void subcase_start(const SubcaseSignature& in) override;
-        void subcase_end(DOCTEST_EMPTY DOCTEST_EMPTY) override;
-        void log_assert(const AssertData& in) override;
-        void log_message(const MessageData& in) override;
-        void test_case_skipped(const TestCaseData& in) override;
-    };
+    void test_run_start() override;
+    void test_run_end(const TestRunStats &in) override;
+    void test_case_start(const TestCaseData &in) override;
+    void test_case_reenter(const TestCaseData &in) override;
+    void test_case_end(const CurrentTestCaseStats &in) override;
+    void test_case_exception(const TestCaseException &in) override;
+    void subcase_start(const SubcaseSignature &in) override;
+    void subcase_end(DOCTEST_EMPTY DOCTEST_EMPTY) override;
+    void log_assert(const AssertData &in) override;
+    void log_message(const MessageData &in) override;
+    void test_case_skipped(const TestCaseData &in) override;
+};
 #endif // DOCTEST_PLATFORM_WINDOWS
 
 } // namespace detail
@@ -4673,8 +4812,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // all the registered tests
-    std::set<TestCase>& getRegisteredTests();
+// all the registered tests
+std::set<TestCase> &getRegisteredTests();
 
 } // namespace detail
 } // namespace doctest
@@ -4695,14 +4834,14 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // matching of a string against a wildcard mask (case sensitivity configurable) taken from
-    // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
-    int wildcmp(const char* str, const char* wild, bool caseSensitive);
+// matching of a string against a wildcard mask (case sensitivity configurable) taken from
+// https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
+int wildcmp(const char *str, const char *wild, bool caseSensitive);
 
-    // checks if the name matches any of the filters (and can be configured what to do when empty)
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty, bool caseSensitive);
+// checks if the name matches any of the filters (and can be configured what to do when empty)
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive);
 
-} // namespace
+} // namespace detail
 } // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
@@ -4722,74 +4861,69 @@ namespace doctest {
 namespace detail {
 
 #if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    struct FatalConditionHandler
-    {
-        static void reset();
-        static void allocateAltStackMem();
-        static void freeAltStackMem();
-    };
+struct FatalConditionHandler {
+    static void reset();
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
+};
 #else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
-    {
-        DWORD id;
-        const char* name;
-    };
+struct SignalDefs {
+    DWORD id;
+    const char *name;
+};
 
-    struct FatalConditionHandler
-    {
-        static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo);
-        static void allocateAltStackMem();
-        static void freeAltStackMem();
+struct FatalConditionHandler {
+    static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo);
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
 
-        FatalConditionHandler();
+    FatalConditionHandler();
 
-        static void reset();
+    static void reset();
 
-        ~FatalConditionHandler();
+    ~FatalConditionHandler();
 
-    private:
-        static UINT         prev_error_mode_1;
-        static int          prev_error_mode_2;
-        static unsigned int prev_abort_behavior;
-        static int          prev_report_mode;
-        static _HFILE       prev_report_file;
-        static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
-        static std::terminate_handler original_terminate_handler;
-        static bool isSet;
-        static ULONG guaranteeSize;
-        static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
-    };
+private:
+    static UINT prev_error_mode_1;
+    static int prev_error_mode_2;
+    static unsigned int prev_abort_behavior;
+    static int prev_report_mode;
+    static _HFILE prev_report_file;
+    static void(DOCTEST_CDECL *prev_sigabrt_handler)(int);
+    static std::terminate_handler original_terminate_handler;
+    static bool isSet;
+    static ULONG guaranteeSize;
+    static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
+};
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
-    {
-        int         id;
-        const char* name;
-    };
+struct SignalDefs {
+    int id;
+    const char *name;
+};
 
-    struct FatalConditionHandler
-    {
-        static bool             isSet;
-        static struct sigaction oldSigActions[6];
-        static stack_t          oldSigStack;
-        static size_t           altStackSize;
-        static char*            altStackMem;
+struct FatalConditionHandler {
+    static bool isSet;
+    static struct sigaction oldSigActions[6];
+    static stack_t oldSigStack;
+    static size_t altStackSize;
+    static char *altStackMem;
 
-        static void handleSignal(int sig);
+    static void handleSignal(int sig);
 
-        static void allocateAltStackMem();
+    static void allocateAltStackMem();
 
-        static void freeAltStackMem();
+    static void freeAltStackMem();
 
-        FatalConditionHandler();
+    FatalConditionHandler();
 
-        ~FatalConditionHandler();
-        static void reset();
-    };
+    ~FatalConditionHandler();
+    static void reset();
+};
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
@@ -4807,671 +4941,680 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    bool is_running_in_test = false;
+bool is_running_in_test = false;
 
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    Context::Context(int, const char* const*) {}
-    Context::~Context() = default;
-    void Context::applyCommandLine(int, const char* const*) {}
-    void Context::addFilter(const char*, const char*) {}
-    void Context::clearFilters() {}
-    void Context::setOption(const char*, bool) {}
-    void Context::setOption(const char*, int) {}
-    void Context::setOption(const char*, const char*) {}
-    bool Context::shouldExit() { return false; }
-    void Context::setAsDefaultForAssertsOutOfTestCases() {}
-    void Context::setAssertHandler(detail::assert_handler) {}
-    void Context::setCout(std::ostream*) {}
-    int  Context::run() { return 0; }
+Context::Context(int, const char *const *) {}
+Context::~Context() = default;
+void Context::applyCommandLine(int, const char *const *) {}
+void Context::addFilter(const char *, const char *) {}
+void Context::clearFilters() {}
+void Context::setOption(const char *, bool) {}
+void Context::setOption(const char *, int) {}
+void Context::setOption(const char *, const char *) {}
+bool Context::shouldExit() {
+    return false;
+}
+void Context::setAsDefaultForAssertsOutOfTestCases() {}
+void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream *) {}
+int Context::run() {
+    return 0;
+}
 
 #else
 
 namespace detail {
-    // for sorting tests by file/line
-    bool fileOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        // this is needed because MSVC gives different case for drive letters
-        // for __FILE__ when evaluated in a header and a source file
-        const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
-        if(res != 0)
-            return res < 0;
-        if(lhs->m_line != rhs->m_line)
-            return lhs->m_line < rhs->m_line;
-        return lhs->m_template_id < rhs->m_template_id;
-    }
+// for sorting tests by file/line
+bool fileOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    // this is needed because MSVC gives different case for drive letters
+    // for __FILE__ when evaluated in a header and a source file
+    const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
+    if (res != 0)
+        return res < 0;
+    if (lhs->m_line != rhs->m_line)
+        return lhs->m_line < rhs->m_line;
+    return lhs->m_template_id < rhs->m_template_id;
+}
 
-    // for sorting tests by suite/file/line
-    bool suiteOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-        if(res != 0)
-            return res < 0;
-        return fileOrderComparator(lhs, rhs);
-    }
+// for sorting tests by suite/file/line
+bool suiteOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+    if (res != 0)
+        return res < 0;
+    return fileOrderComparator(lhs, rhs);
+}
 
-    // for sorting tests by name/suite/file/line
-    bool nameOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_name, rhs->m_name);
-        if(res != 0)
-            return res < 0;
-        return suiteOrderComparator(lhs, rhs);
-    }
+// for sorting tests by name/suite/file/line
+bool nameOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_name, rhs->m_name);
+    if (res != 0)
+        return res < 0;
+    return suiteOrderComparator(lhs, rhs);
+}
 
-    // the implementation of parseOption()
-    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String* value) {
-        // going from the end to the beginning and stopping on the first occurrence from the end
-        for(int i = argc; i > 0; --i) {
-            auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) {
-                // eliminate matches in which the chars before the option are not '-'
-                bool noBadCharsFound = true;
-                auto curr            = argv[index];
-                while(curr != temp) {
-                    if(*curr++ != '-') {
-                        noBadCharsFound = false;
-                        break;
-                    }
+// the implementation of parseOption()
+bool parseOptionImpl(int argc, const char *const *argv, const char *pattern, String *value) {
+    // going from the end to the beginning and stopping on the first occurrence from the end
+    for (int i = argc; i > 0; --i) {
+        auto index = i - 1;
+        auto temp = std::strstr(argv[index], pattern);
+        if (temp && (value || strlen(temp) == strlen(pattern))) {
+            // eliminate matches in which the chars before the option are not '-'
+            bool noBadCharsFound = true;
+            auto curr = argv[index];
+            while (curr != temp) {
+                if (*curr++ != '-') {
+                    noBadCharsFound = false;
+                    break;
                 }
-                if(noBadCharsFound && argv[index][0] == '-') {
-                    if(value) {
-                        // parsing the value of an option
-                        temp += strlen(pattern);
-                        const unsigned len = strlen(temp);
-                        if(len) {
-                            *value = temp;
-                            return true;
-                        }
-                    } else {
-                        // just a flag - no value
+            }
+            if (noBadCharsFound && argv[index][0] == '-') {
+                if (value) {
+                    // parsing the value of an option
+                    temp += strlen(pattern);
+                    const unsigned len = strlen(temp);
+                    if (len) {
+                        *value = temp;
                         return true;
                     }
+                } else {
+                    // just a flag - no value
+                    return true;
                 }
             }
         }
-        return false;
     }
+    return false;
+}
 
-    // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
-        if(value)
-            *value = defaultVal;
+// parses an option and returns the string after the '=' character
+bool parseOption(
+    int argc, const char *const *argv, const char *pattern, String *value = nullptr, const String &defaultVal = String()
+) {
+    if (value)
+        *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        // offset (normally 3 for "dt-") to skip prefix
-        if(parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
-            return true;
+    // offset (normally 3 for "dt-") to skip prefix
+    if (parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
+        return true;
 #endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        return parseOptionImpl(argc, argv, pattern, value);
-    }
+    return parseOptionImpl(argc, argv, pattern, value);
+}
 
-    // locates a flag on the command line
-    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
-        return parseOption(argc, argv, pattern);
-    }
+// locates a flag on the command line
+bool parseFlag(int argc, const char *const *argv, const char *pattern) {
+    return parseOption(argc, argv, pattern);
+}
 
-    // parses a comma separated list of words after a pattern in one of the arguments in argv
-    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
-                           std::vector<String>& res) {
-        String filtersString;
-        if(parseOption(argc, argv, pattern, &filtersString)) {
-            // tokenize with "," as a separator, unless escaped with backslash
-            std::ostringstream s;
-            auto flush = [&s, &res]() {
-                auto string = s.str();
-                if(string.size() > 0) {
-                    res.push_back(string.c_str());
-                }
-                s.str("");
-            };
-
-            bool seenBackslash = false;
-            const char* current = filtersString.c_str();
-            const char* end = current + strlen(current);
-            while(current != end) {
-                char character = *current++;
-                if(seenBackslash) {
-                    seenBackslash = false;
-                    if(character == ',' || character == '\\') {
-                        s.put(character);
-                        continue;
-                    }
-                    s.put('\\');
-                }
-                if(character == '\\') {
-                    seenBackslash = true;
-                } else if(character == ',') {
-                    flush();
-                } else {
-                    s.put(character);
-                }
+// parses a comma separated list of words after a pattern in one of the arguments in argv
+bool parseCommaSepArgs(int argc, const char *const *argv, const char *pattern, std::vector<String> &res) {
+    String filtersString;
+    if (parseOption(argc, argv, pattern, &filtersString)) {
+        // tokenize with "," as a separator, unless escaped with backslash
+        std::ostringstream s;
+        auto flush = [&s, &res]() {
+            auto string = s.str();
+            if (string.size() > 0) {
+                res.push_back(string.c_str());
             }
+            s.str("");
+        };
 
-            if(seenBackslash) {
+        bool seenBackslash = false;
+        const char *current = filtersString.c_str();
+        const char *end = current + strlen(current);
+        while (current != end) {
+            char character = *current++;
+            if (seenBackslash) {
+                seenBackslash = false;
+                if (character == ',' || character == '\\') {
+                    s.put(character);
+                    continue;
+                }
                 s.put('\\');
             }
-            flush();
+            if (character == '\\') {
+                seenBackslash = true;
+            } else if (character == ',') {
+                flush();
+            } else {
+                s.put(character);
+            }
+        }
+
+        if (seenBackslash) {
+            s.put('\\');
+        }
+        flush();
+        return true;
+    }
+    return false;
+}
+
+enum optionType { option_bool, option_int };
+
+// parses an int/bool option from the command line
+bool parseIntOption(int argc, const char *const *argv, const char *pattern, optionType type, int &res) {
+    String parsedValue;
+    if (!parseOption(argc, argv, pattern, &parsedValue))
+        return false;
+
+    if (type) {
+        // integer
+        // TODO: change this to use std::stoi or something else! currently it uses undefined
+        // behavior - assumes '0' on failed parse...
+        int theInt = std::atoi(parsedValue.c_str());
+        if (theInt != 0) {
+            res = theInt;
             return true;
         }
-        return false;
-    }
+    } else {
+        // boolean
+        const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+        const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
 
-    enum optionType
-    {
-        option_bool,
-        option_int
-    };
-
-    // parses an int/bool option from the command line
-    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
-                        int& res) {
-        String parsedValue;
-        if(!parseOption(argc, argv, pattern, &parsedValue))
-            return false;
-
-        if(type) {
-            // integer
-            // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
-            int theInt = std::atoi(parsedValue.c_str());
-            if (theInt != 0) {
-                res = theInt;
+        // if the value matches any of the positive/negative possibilities
+        for (unsigned i = 0; i < 4; i++) {
+            if (parsedValue.compare(positive[i], true) == 0) {
+                res = 1;
                 return true;
             }
-        } else {
-            // boolean
-            const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
-            const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
-
-            // if the value matches any of the positive/negative possibilities
-            for (unsigned i = 0; i < 4; i++) {
-                if (parsedValue.compare(positive[i], true) == 0) {
-                    res = 1;
-                    return true;
-                }
-                if (parsedValue.compare(negative[i], true) == 0) {
-                    res = 0;
-                    return true;
-                }
+            if (parsedValue.compare(negative[i], true) == 0) {
+                res = 0;
+                return true;
             }
         }
-        return false;
     }
+    return false;
+}
 
 } // namespace detail
 
-    Context::Context(int argc, const char* const* argv)
-            : p(new detail::ContextState) {
-        parseArgs(argc, argv, true);
-        if(argc)
-            p->binary_name = argv[0];
+Context::Context(int argc, const char *const *argv)
+    : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+Context::~Context() {
+    if (detail::g_cs == p)
+        detail::g_cs = nullptr;
+    delete p;
+}
+
+void Context::applyCommandLine(int argc, const char *const *argv) {
+    parseArgs(argc, argv);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+// parses args
+void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
+    using namespace detail;
+
+    // clang-format off
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sfe=",                p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite=",         p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ts=",                 p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite-exclude=", p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tse=",                p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case=",          p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tc=",                 p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case-exclude=",  p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tce=",                p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase=",            p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sc=",                 p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase-exclude=",    p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
+    // clang-format on
+
+    int intRes = 0;
+    String strRes;
+
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                                       \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||                     \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))                      \
+        p->var = static_cast<bool>(intRes);                                                                            \
+    else if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                              \
+             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                                               \
+        p->var = true;                                                                                                 \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                                            \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||                      \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))                       \
+        p->var = intRes;                                                                                               \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                                            \
+    if (parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||                           \
+        parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) || withDefaults)            \
+    p->var = strRes
+
+    DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
+    DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
+    DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
+
+    DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);
+    DOCTEST_PARSE_INT_OPTION("last", "l", last, UINT_MAX);
+
+    DOCTEST_PARSE_INT_OPTION("abort-after", "aa", abort_after, 0);
+    DOCTEST_PARSE_INT_OPTION("subcase-filter-levels", "scfl", subcase_filter_levels, INT_MAX);
+
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("success", "s", success, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-breaks", "nb", no_breaks, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
+    DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
+
+    if (withDefaults) {
+        p->help = false;
+        p->version = false;
+        p->count = false;
+        p->list_test_cases = false;
+        p->list_test_suites = false;
+        p->list_reporters = false;
     }
-
-    Context::~Context() {
-        if(detail::g_cs == p)
-            detail::g_cs = nullptr;
-        delete p;
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+        p->help = true;
+        p->exit = true;
     }
-
-    void Context::applyCommandLine(int argc, const char* const* argv) {
-        parseArgs(argc, argv);
-        if(argc)
-            p->binary_name = argv[0];
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+        p->version = true;
+        p->exit = true;
     }
-
-    // parses args
-    void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-        using namespace detail;
-
-        // clang-format off
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sfe=",                p->filters[1]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite=",         p->filters[2]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ts=",                 p->filters[2]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite-exclude=", p->filters[3]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tse=",                p->filters[3]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case=",          p->filters[4]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tc=",                 p->filters[4]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case-exclude=",  p->filters[5]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tce=",                p->filters[5]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase=",            p->filters[6]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sc=",                 p->filters[6]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase-exclude=",    p->filters[7]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
-        // clang-format on
-
-        int    intRes = 0;
-        String strRes;
-
-    #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-            p->var = static_cast<bool>(intRes);                                                        \
-        else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
-                parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
-            p->var = true;                                                                             \
-        else if(withDefaults)                                                                          \
-        p->var = default
-
-    #define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
-            p->var = intRes;                                                                           \
-        else if(withDefaults)                                                                          \
-        p->var = default
-
-    #define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-        if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
-           parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
-           withDefaults)                                                                               \
-        p->var = strRes
-
-        // clang-format off
-        DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
-        DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
-        DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
-
-        DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);
-        DOCTEST_PARSE_INT_OPTION("last", "l", last, UINT_MAX);
-
-        DOCTEST_PARSE_INT_OPTION("abort-after", "aa", abort_after, 0);
-        DOCTEST_PARSE_INT_OPTION("subcase-filter-levels", "scfl", subcase_filter_levels, INT_MAX);
-
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("success", "s", success, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-breaks", "nb", no_breaks, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
-        DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
-        // clang-format on
-
-        if(withDefaults) {
-            p->help             = false;
-            p->version          = false;
-            p->count            = false;
-            p->list_test_cases  = false;
-            p->list_test_suites = false;
-            p->list_reporters   = false;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
-            p->help = true;
-            p->exit = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
-            p->version = true;
-            p->exit    = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
-            p->count = true;
-            p->exit  = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
-            p->list_test_cases = true;
-            p->exit            = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
-            p->list_test_suites = true;
-            p->exit             = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
-            p->list_reporters = true;
-            p->exit           = true;
-        }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+        p->count = true;
+        p->exit = true;
     }
-
-    // allows the user to add procedurally to the filters from the command line
-    void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
-
-    // allows the user to clear all filters from the command line
-    void Context::clearFilters() {
-        for(auto& curr : p->filters)
-            curr.clear();
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+        p->list_test_cases = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the bool options from the command line
-    void Context::setOption(const char* option, bool value) {
-        setOption(option, value ? "true" : "false");
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+        p->list_test_suites = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the int options from the command line
-    void Context::setOption(const char* option, int value) {
-        setOption(option, toString(value).c_str());
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+        p->list_reporters = true;
+        p->exit = true;
     }
+}
 
-    // allows the user to override procedurally the string options from the command line
-    void Context::setOption(const char* option, const char* value) {
-        auto argv   = String("-") + option + "=" + value;
-        auto lvalue = argv.c_str();
-        parseArgs(1, &lvalue);
-    }
+// allows the user to add procedurally to the filters from the command line
+void Context::addFilter(const char *filter, const char *value) {
+    setOption(filter, value);
+}
 
-    // users should query this in their main() and exit the program if true
-    bool Context::shouldExit() { return p->exit; }
+// allows the user to clear all filters from the command line
+void Context::clearFilters() {
+    for (auto &curr: p->filters)
+        curr.clear();
+}
 
-    void Context::setAsDefaultForAssertsOutOfTestCases() { detail::g_cs = p; }
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char *option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
 
-    void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+// allows the user to override procedurally the int options from the command line
+void Context::setOption(const char *option, int value) {
+    setOption(option, toString(value).c_str());
+}
 
-    void Context::setCout(std::ostream* out) { p->cout = out; }
+// allows the user to override procedurally the string options from the command line
+void Context::setOption(const char *option, const char *value) {
+    auto argv = String("-") + option + "=" + value;
+    auto lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
+}
 
-    static class DiscardOStream : public std::ostream
-    {
+// users should query this in their main() and exit the program if true
+bool Context::shouldExit() {
+    return p->exit;
+}
+
+void Context::setAsDefaultForAssertsOutOfTestCases() {
+    detail::g_cs = p;
+}
+
+void Context::setAssertHandler(detail::assert_handler ah) {
+    p->ah = ah;
+}
+
+void Context::setCout(std::ostream *out) {
+    p->cout = out;
+}
+
+static class DiscardOStream : public std::ostream {
+private:
+    class : public std::streambuf {
     private:
-        class : public std::streambuf
-        {
-        private:
-            // allowing some buffering decreases the amount of calls to overflow
-            char buf[1024];
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
 
-        protected:
-            std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+    protected:
+        std::streamsize xsputn(const char_type *, std::streamsize count) override {
+            return count;
+        }
 
-            int_type overflow(int_type ch) override {
-                setp(std::begin(buf), std::end(buf));
-                return traits_type::not_eof(ch);
-            }
-        } discardBuf;
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
 
-    public:
-        DiscardOStream()
-                : std::ostream(&discardBuf) {}
-    } discardOut;
+public:
+    DiscardOStream()
+        : std::ostream(&discardBuf) {}
+} discardOut;
 
-    // the main function that does all the filtering and test running
-    int Context::run() {
-        using namespace detail;
+// the main function that does all the filtering and test running
+int Context::run() {
+    using namespace detail;
 
-        // save the old context state in case such was setup - for using asserts out of a testing context
-        auto old_cs = g_cs;
-        // this is the current contest
-        g_cs               = p;
-        is_running_in_test = true;
+    // save the old context state in case such was setup - for using asserts out of a testing context
+    auto old_cs = g_cs;
+    // this is the current contest
+    g_cs = p;
+    is_running_in_test = true;
 
-        g_no_colors = p->no_colors;
-        p->resetRunData();
+    g_no_colors = p->no_colors;
+    p->resetRunData();
 
-        std::fstream fstr;
-        if(p->cout == nullptr) {
-            if(p->quiet) {
-                p->cout = &discardOut;
-            } else if(p->out.size()) {
-                // to a file if specified
-                fstr.open(p->out.c_str(), std::fstream::out);
-                p->cout = &fstr;
-                if (!fstr.is_open()) {
-                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
-                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
-                    p->cout = &std::cout;
-                }
-
-            } else {
-    #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                // stdout by default
+    std::fstream fstr;
+    if (p->cout == nullptr) {
+        if (p->quiet) {
+            p->cout = &discardOut;
+        } else if (p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+            if (!fstr.is_open()) {
+                // clang-format off
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
                 p->cout = &std::cout;
-    #else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                return EXIT_FAILURE;
-    #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-            }
-        }
-
-        FatalConditionHandler::allocateAltStackMem();
-
-        auto cleanup_and_return = [&]() {
-            FatalConditionHandler::freeAltStackMem();
-
-            if(fstr.is_open())
-                fstr.close();
-
-            // restore context
-            g_cs               = old_cs;
-            is_running_in_test = false;
-
-            // we have to free the reporters which were allocated when the run started
-            for(auto& curr : p->reporters_currently_used)
-                delete curr;
-            p->reporters_currently_used.clear();
-
-            if(p->numTestCasesFailed && !p->no_exitcode)
-                return EXIT_FAILURE;
-            return EXIT_SUCCESS;
-        };
-
-        // setup default reporter if none is given through the command line
-        if(p->filters[8].empty())
-            p->filters[8].push_back("console");
-
-        // check to see if any of the registered reporters has been selected
-        for(auto& curr : getReporters()) {
-            if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-                p->reporters_currently_used.push_back(curr.second(*g_cs));
-        }
-
-        // TODO: check if there is nothing in reporters_currently_used
-
-        // prepend all listeners
-        for(auto& curr : getListeners())
-            p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
-
-    #ifdef DOCTEST_PLATFORM_WINDOWS
-        if(isDebuggerActive() && p->no_debug_output == false)
-            p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
-    #endif // DOCTEST_PLATFORM_WINDOWS
-
-        // handle version, help and no_run
-        if(p->no_run || p->version || p->help || p->list_reporters) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
-
-            return cleanup_and_return();
-        }
-
-        std::vector<const TestCase*> testArray;
-        for(auto& curr : getRegisteredTests())
-            testArray.push_back(&curr);
-        p->numTestCases = testArray.size();
-
-        // sort the collected records
-        if(!testArray.empty()) {
-            if(p->order_by.compare("file", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
-            } else if(p->order_by.compare("suite", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
-            } else if(p->order_by.compare("name", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
-            } else if(p->order_by.compare("rand", true) == 0) {
-                std::srand(p->rand_seed);
-
-                // random_shuffle implementation
-                const auto first = &testArray[0];
-                for(size_t i = testArray.size() - 1; i > 0; --i) {
-                    int idxToSwap = std::rand() % (i + 1);
-
-                    const auto temp = first[i];
-
-                    first[i]         = first[idxToSwap];
-                    first[idxToSwap] = temp;
-                }
-            } else if(p->order_by.compare("none", true) == 0) {
-                // means no sorting - beneficial for death tests which call into the executable
-                // with a specific test case in mind - we don't want to slow down the startup times
-            }
-        }
-
-        std::set<String> testSuitesPassingFilt;
-
-        bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
-        std::vector<const TestCaseData*> queryResults;
-
-        if(!query_mode)
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
-
-        // invoke the registered functions if they match the filter criteria (or just count them)
-        for(auto& curr : testArray) {
-            const auto& tc = *curr;
-
-            bool skip_me = false;
-            if(tc.m_skip && !p->no_skip)
-                skip_me = true;
-
-            if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-                skip_me = true;
-
-            if(!skip_me)
-                p->numTestCasesPassingFilters++;
-
-            // skip the test if it is not in the execution range
-            if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-               (p->first > p->numTestCasesPassingFilters))
-                skip_me = true;
-
-            if(skip_me) {
-                if(!query_mode)
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
-                continue;
+                // clang-format on
             }
 
-            // do not execute the test if we are to only count the number of filter passing tests
-            if(p->count)
-                continue;
-
-            // print the name of the test and don't execute it
-            if(p->list_test_cases) {
-                queryResults.push_back(&tc);
-                continue;
-            }
-
-            // print the name of the test suite if not done already and don't execute it
-            if(p->list_test_suites) {
-                if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                    queryResults.push_back(&tc);
-                    testSuitesPassingFilt.insert(tc.m_test_suite);
-                    p->numTestSuitesPassingFilters++;
-                }
-                continue;
-            }
-
-            // execute the test if it passes all the filtering
-            {
-                p->currentTest = &tc;
-
-                p->failure_flags = TestCaseFailureReason::None;
-                p->seconds       = 0;
-
-                // reset atomic counters
-                p->numAssertsFailedCurrentTest_atomic = 0;
-                p->numAssertsCurrentTest_atomic       = 0;
-
-                p->fullyTraversedSubcases.clear();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
-
-                p->timer.start();
-
-                bool run_test = true;
-
-                do {
-                    // reset some of the fields for subcases (except for the set of fully passed ones)
-                    p->reachedLeaf = false;
-                    // May not be empty if previous subcase exited via exception.
-                    p->subcaseStack.clear();
-                    p->currentSubcaseDepth = 0;
-
-                    p->shouldLogCurrentException = true;
-
-                    // reset stuff for logging with INFO()
-                    p->stringifiedContexts.clear();
-
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    try {
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
-                        FatalConditionHandler fatalConditionHandler; // Handle signals
-                        // execute the test
-                        tc.m_test();
-                        fatalConditionHandler.reset();
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    } catch(const TestFailureException&) {
-                        p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                    } catch(...) {
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
-                                                          {translateActiveException(), false});
-                        p->failure_flags |= TestCaseFailureReason::Exception;
-                    }
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                    // exit this loop if enough assertions have failed - even if there are more subcases
-                    if(p->abort_after > 0 &&
-                       p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                        run_test = false;
-                        p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
-                    }
-
-                    if(!p->nextSubcaseStack.empty() && run_test)
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
-                    if(p->nextSubcaseStack.empty())
-                        run_test = false;
-                } while(run_test);
-
-                p->finalizeTestCaseData();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-                p->currentTest = nullptr;
-
-                // stop executing tests if enough assertions have failed
-                if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                    break;
-            }
-        }
-
-        if(!query_mode) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
         } else {
-            QueryData qdata;
-            qdata.run_stats = g_cs;
-            qdata.data      = queryResults.data();
-            qdata.num_data  = unsigned(queryResults.size());
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            // stdout by default
+            p->cout = &std::cout;
+#else  // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         }
+    }
+
+    FatalConditionHandler::allocateAltStackMem();
+
+    auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
+        if (fstr.is_open())
+            fstr.close();
+
+        // restore context
+        g_cs = old_cs;
+        is_running_in_test = false;
+
+        // we have to free the reporters which were allocated when the run started
+        for (auto &curr: p->reporters_currently_used)
+            delete curr;
+        p->reporters_currently_used.clear();
+
+        if (p->numTestCasesFailed && !p->no_exitcode)
+            return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    };
+
+    // setup default reporter if none is given through the command line
+    if (p->filters[8].empty())
+        p->filters[8].push_back("console");
+
+    // check to see if any of the registered reporters has been selected
+    for (auto &curr: getReporters()) {
+        if (matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+            p->reporters_currently_used.push_back(curr.second(*g_cs));
+    }
+
+    // TODO: check if there is nothing in reporters_currently_used
+
+    // prepend all listeners
+    for (auto &curr: getListeners())
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if (isDebuggerActive() && p->no_debug_output == false)
+        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    // handle version, help and no_run
+    if (p->no_run || p->version || p->help || p->list_reporters) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
 
         return cleanup_and_return();
     }
+
+    std::vector<const TestCase *> testArray;
+    for (auto &curr: getRegisteredTests())
+        testArray.push_back(&curr);
+    p->numTestCases = testArray.size();
+
+    // sort the collected records
+    if (!testArray.empty()) {
+        if (p->order_by.compare("file", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+        } else if (p->order_by.compare("suite", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+        } else if (p->order_by.compare("name", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+        } else if (p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const auto first = &testArray[0];
+            for (size_t i = testArray.size() - 1; i > 0; --i) {
+                int idxToSwap = std::rand() % (i + 1);
+
+                const auto temp = first[i];
+
+                first[i] = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        } else if (p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
+        }
+    }
+
+    std::set<String> testSuitesPassingFilt;
+
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData *> queryResults;
+
+    if (!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for (auto &curr: testArray) {
+        const auto &tc = *curr;
+
+        bool skip_me = false;
+        if (tc.m_skip && !p->no_skip)
+            skip_me = true;
+
+        if (!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+
+        if (!skip_me)
+            p->numTestCasesPassingFilters++;
+
+        // skip the test if it is not in the execution range
+        if ((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+            (p->first > p->numTestCasesPassingFilters))
+            skip_me = true;
+
+        if (skip_me) {
+            if (!query_mode)
+                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+            continue;
+        }
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if (p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if (p->list_test_cases) {
+            queryResults.push_back(&tc);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if (p->list_test_suites) {
+            if ((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+                queryResults.push_back(&tc);
+                testSuitesPassingFilt.insert(tc.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &tc;
+
+            p->failure_flags = TestCaseFailureReason::None;
+            p->seconds = 0;
+
+            // reset atomic counters
+            p->numAssertsFailedCurrentTest_atomic = 0;
+            p->numAssertsCurrentTest_atomic = 0;
+
+            p->fullyTraversedSubcases.clear();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+            p->timer.start();
+
+            bool run_test = true;
+
+            do {
+                // reset some of the fields for subcases (except for the set of fully passed ones)
+                p->reachedLeaf = false;
+                // May not be empty if previous subcase exited via exception.
+                p->subcaseStack.clear();
+                p->currentSubcaseDepth = 0;
+
+                p->shouldLogCurrentException = true;
+
+                // reset stuff for logging with INFO()
+                p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+       // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a
+       // static method)
+                    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
+                    FatalConditionHandler fatalConditionHandler;  // Handle signals
+                    // execute the test
+                    tc.m_test();
+                    fatalConditionHandler.reset();
+                    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch (const TestFailureException &) {
+                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
+                } catch (...) {
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {translateActiveException(), false});
+                    p->failure_flags |= TestCaseFailureReason::Exception;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                // exit this loop if enough assertions have failed - even if there are more subcases
+                if (p->abort_after > 0 &&
+                    p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+                    run_test = false;
+                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+                }
+
+                if (!p->nextSubcaseStack.empty() && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if (p->nextSubcaseStack.empty())
+                    run_test = false;
+            } while (run_test);
+
+            p->finalizeTestCaseData();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+            p->currentTest = nullptr;
+
+            // stop executing tests if enough assertions have failed
+            if (p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                break;
+        }
+    }
+
+    if (!query_mode) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    } else {
+        QueryData qdata;
+        qdata.run_stats = g_cs;
+        qdata.data = queryResults.data();
+        qdata.num_data = unsigned(queryResults.size());
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+    }
+
+    return cleanup_and_return();
+}
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5488,8 +5631,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
-}
+extern DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+} // namespace detail
 } // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
@@ -5506,41 +5649,42 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-    DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
+DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+ContextScopeBase::ContextScopeBase() {
+    g_infoContexts.push_back(this);
+}
 
-    ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
-        if (other.need_to_destroy) {
-            other.destroy();
-        }
-        other.need_to_destroy = false;
-        g_infoContexts.push_back(this);
+ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
+    if (other.need_to_destroy) {
+        other.destroy();
     }
+    other.need_to_destroy = false;
+    g_infoContexts.push_back(this);
+}
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    // destroy cannot be inlined into the destructor because that would mean calling stringify after
-    // ContextScope has been destroyed (base class destructors run after derived class destructors).
-    // Instead, ContextScope calls this method directly from its destructor.
-    void ContextScopeBase::destroy() {
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-        if(std::uncaught_exceptions() > 0) {
-    #else
-        if(std::uncaught_exception()) {
-    #endif
-            std::ostringstream s;
-            this->stringify(&s);
-            g_cs->stringifiedContexts.push_back(s.str().c_str());
-        }
-        g_infoContexts.pop_back();
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+// destroy cannot be inlined into the destructor because that would mean calling stringify after
+// ContextScope has been destroyed (base class destructors run after derived class destructors).
+// Instead, ContextScope calls this method directly from its destructor.
+void ContextScopeBase::destroy() {
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+    if (std::uncaught_exceptions() > 0) {
+#else
+    if (std::uncaught_exception()) {
+#endif
+        std::ostringstream s;
+        this->stringify(&s);
+        g_cs->stringifiedContexts.push_back(s.str().c_str());
     }
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    g_infoContexts.pop_back();
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5555,17 +5699,17 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-ContextState* g_cs = nullptr;
+ContextState *g_cs = nullptr;
 DOCTEST_THREAD_LOCAL bool g_no_colors;
 
 void ContextState::resetRunData() {
-    numTestCases                = 0;
-    numTestCasesPassingFilters  = 0;
+    numTestCases = 0;
+    numTestCasesPassingFilters = 0;
     numTestSuitesPassingFilters = 0;
-    numTestCasesFailed          = 0;
-    numAsserts                  = 0;
-    numAssertsFailed            = 0;
-    numAssertsCurrentTest       = 0;
+    numTestCasesFailed = 0;
+    numAsserts = 0;
+    numAssertsFailed = 0;
+    numAssertsCurrentTest = 0;
     numAssertsFailedCurrentTest = 0;
 }
 
@@ -5575,26 +5719,26 @@ void ContextState::finalizeTestCaseData() {
     // update the non-atomic counters
     numAsserts += numAssertsCurrentTest_atomic;
     numAssertsFailed += numAssertsFailedCurrentTest_atomic;
-    numAssertsCurrentTest       = numAssertsCurrentTest_atomic;
+    numAssertsCurrentTest = numAssertsCurrentTest_atomic;
     numAssertsFailedCurrentTest = numAssertsFailedCurrentTest_atomic;
 
-    if(numAssertsFailedCurrentTest)
+    if (numAssertsFailedCurrentTest)
         failure_flags |= TestCaseFailureReason::AssertFailure;
 
-    if(Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+    if (Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
         Approx(seconds).epsilon(DBL_EPSILON) > currentTest->m_timeout)
         failure_flags |= TestCaseFailureReason::Timeout;
 
-    if(currentTest->m_should_fail) {
-        if(failure_flags) {
+    if (currentTest->m_should_fail) {
+        if (failure_flags) {
             failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
         } else {
             failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
         }
-    } else if(failure_flags && currentTest->m_may_fail) {
+    } else if (failure_flags && currentTest->m_may_fail) {
         failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
-    } else if(currentTest->m_expected_failures > 0) {
-        if(numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
+    } else if (currentTest->m_expected_failures > 0) {
+        if (numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
             failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
         } else {
             failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
@@ -5607,10 +5751,9 @@ void ContextState::finalizeTestCaseData() {
 
     // if any subcase has failed - the whole test case has failed
     testCaseSuccess = !(failure_flags && !ok_to_fail);
-    if(!testCaseSuccess)
+    if (!testCaseSuccess)
         numTestCasesFailed++;
 }
-
 
 } // namespace detail
 } // namespace doctest
@@ -5626,64 +5769,74 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 #ifdef DOCTEST_IS_DEBUGGER_ACTIVE
-    bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
+bool isDebuggerActive() {
+    return DOCTEST_IS_DEBUGGER_ACTIVE();
+}
 #else // DOCTEST_IS_DEBUGGER_ACTIVE
 #ifdef DOCTEST_PLATFORM_LINUX
-    class ErrnoGuard {
-    public:
-        ErrnoGuard() : m_oldErrno(errno) {}
-        ~ErrnoGuard() { errno = m_oldErrno; }
-    private:
-        int m_oldErrno;
-    };
-    // See the comments in Catch2 for the reasoning behind this implementation:
-    // https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
-    bool isDebuggerActive() {
-        ErrnoGuard guard;
-        std::ifstream in("/proc/self/status");
-        for(std::string line; std::getline(in, line);) {
-            static const int PREFIX_LEN = 11;
-            if(line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
-                return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
-            }
+class ErrnoGuard {
+public:
+    ErrnoGuard()
+        : m_oldErrno(errno) {}
+    ~ErrnoGuard() {
+        errno = m_oldErrno;
+    }
+
+private:
+    int m_oldErrno;
+};
+// See the comments in Catch2 for the reasoning behind this implementation:
+// https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
+bool isDebuggerActive() {
+    ErrnoGuard guard;
+    std::ifstream in("/proc/self/status");
+    for (std::string line; std::getline(in, line);) {
+        static const int PREFIX_LEN = 11;
+        if (line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
         }
+    }
+    return false;
+}
+#elif defined(DOCTEST_PLATFORM_MAC)
+// The following function is taken directly from the following technical note:
+// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive() {
+    int mib[4];
+    kinfo_proc info;
+    size_t size;
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    info.kp_proc.p_flag = 0;
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+    // Call sysctl.
+    size = sizeof(info);
+    if (sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, nullptr, 0) != 0) {
+        std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
         return false;
     }
-#elif defined(DOCTEST_PLATFORM_MAC)
-    // The following function is taken directly from the following technical note:
-    // https://developer.apple.com/library/archive/qa/qa1361/_index.html
-    // Returns true if the current process is being debugged (either
-    // running under the debugger or has a debugger attached post facto).
-    bool isDebuggerActive() {
-        int        mib[4];
-        kinfo_proc info;
-        size_t     size;
-        // Initialize the flags so that, if sysctl fails for some bizarre
-        // reason, we get a predictable result.
-        info.kp_proc.p_flag = 0;
-        // Initialize mib, which tells sysctl the info we want, in this case
-        // we're looking for information about a specific process ID.
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROC;
-        mib[2] = KERN_PROC_PID;
-        mib[3] = getpid();
-        // Call sysctl.
-        size = sizeof(info);
-        if(sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, nullptr, 0) != 0) {
-            std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
-            return false;
-        }
-        // We're being debugged if the P_TRACED flag is set.
-        return ((info.kp_proc.p_flag & P_TRACED) != 0);
-    }
+    // We're being debugged if the P_TRACED flag is set.
+    return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
 #elif DOCTEST_MSVC || defined(__MINGW32__) || defined(__MINGW64__)
-    bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
+bool isDebuggerActive() {
+    return ::IsDebuggerPresent() != 0;
+}
 #else
-    bool isDebuggerActive() { return false; }
+bool isDebuggerActive() {
+    return false;
+}
 #endif // Platform
 #endif // DOCTEST_IS_DEBUGGER_ACTIVE
-} // detail
-} // doctest
+} // namespace detail
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -5696,45 +5849,45 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
+DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
-    void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
-        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
-           getExceptionTranslators().end())
-            getExceptionTranslators().push_back(et);
-    }
+void registerExceptionTranslatorImpl(const IExceptionTranslator *et) {
+    if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
+        getExceptionTranslators().end())
+        getExceptionTranslators().push_back(et);
+}
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
-        static std::vector<const IExceptionTranslator*> data;
-        return data;
-    }
+std::vector<const IExceptionTranslator *> &getExceptionTranslators() {
+    static std::vector<const IExceptionTranslator *> data;
+    return data;
+}
 
-    String translateActiveException() {
+String translateActiveException() {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        String res;
-        auto&  translators = getExceptionTranslators();
-        for(auto& curr : translators)
-            if(curr->translate(res))
-                return res;
-        // clang-format off
-        DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
-        try {
-            throw;
-        } catch(std::exception& ex) {
-            return ex.what();
-        } catch(std::string& msg) {
-            return msg.c_str();
-        } catch(const char* msg) {
-            return msg;
-        } catch(...) {
-            return "unknown exception";
-        }
-        DOCTEST_GCC_SUPPRESS_WARNING_POP
-// clang-format on
+    String res;
+    auto &translators = getExceptionTranslators();
+    for (auto &curr: translators)
+        if (curr->translate(res))
+            return res;
+    // clang-format off
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
+    try {
+        throw;
+    } catch (std::exception &ex) {
+        return ex.what();
+    } catch (std::string &msg) {
+        return msg.c_str();
+    } catch (const char *msg) {
+        return msg;
+    } catch (...) {
+        return "unknown exception";
+    }
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    // clang-format on
 #else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        return "";
+    return "";
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+}
 
 } // namespace detail
 } // namespace doctest
@@ -5750,26 +5903,24 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    bool checkIfShouldThrow(assertType::Enum at) {
-        if(at & assertType::is_require)
-            return true;
+bool checkIfShouldThrow(assertType::Enum at) {
+    if (at & assertType::is_require)
+        return true;
 
-        if((at & assertType::is_check)
-           && getContextOptions()->abort_after > 0 &&
-           (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >=
-                   getContextOptions()->abort_after)
-            return true;
+    if ((at & assertType::is_check) && getContextOptions()->abort_after > 0 &&
+        (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >= getContextOptions()->abort_after)
+        return true;
 
-        return false;
-    }
+    return false;
+}
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    DOCTEST_NORETURN void throwException() {
-        g_cs->shouldLogCurrentException = false;
-        throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
-    }
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
-    void throwException() {}
+DOCTEST_NORETURN void throwException() {
+    g_cs->shouldLogCurrentException = false;
+    throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
+}
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 } // namespace detail
@@ -5784,51 +5935,48 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
-        const char* cp = str;
-        const char* mp = wild;
+int wildcmp(const char *str, const char *wild, bool caseSensitive) {
+    const char *cp = str;
+    const char *mp = wild;
 
-        while((*str) && (*wild != '*')) {
-            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
-               (*wild != '?')) {
-                return 0;
+    while ((*str) && (*wild != '*')) {
+        if ((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?')) {
+            return 0;
+        }
+        wild++;
+        str++;
+    }
+
+    while (*str) {
+        if (*wild == '*') {
+            if (!*++wild) {
+                return 1;
             }
+            mp = wild;
+            cp = str + 1;
+        } else if ((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?')) {
             wild++;
             str++;
+        } else {
+            wild = mp;
+            str = cp++;
         }
-
-        while(*str) {
-            if(*wild == '*') {
-                if(!*++wild) {
-                    return 1;
-                }
-                mp = wild;
-                cp = str + 1;
-            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
-                      (*wild == '?')) {
-                wild++;
-                str++;
-            } else {
-                wild = mp;
-                str  = cp++;
-            }
-        }
-
-        while(*wild == '*') {
-            wild++;
-        }
-        return !*wild;
     }
 
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-        bool caseSensitive) {
-        if (filters.empty() && matchEmpty)
+    while (*wild == '*') {
+        wild++;
+    }
+    return !*wild;
+}
+
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive) {
+    if (filters.empty() && matchEmpty)
+        return true;
+    for (auto &curr: filters)
+        if (wildcmp(name, curr.c_str(), caseSensitive))
             return true;
-        for (auto& curr : filters)
-            if (wildcmp(name, curr.c_str(), caseSensitive))
-                return true;
-        return false;
-    }
+    return false;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -5839,7 +5987,9 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
-int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
+int main(int argc, char **argv) {
+    return doctest::Context(argc, argv).run();
+}
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
@@ -5850,9 +6000,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 
 Approx::Approx(double value)
-        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
-        , m_scale(1.0)
-        , m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value) {}
 
 Approx Approx::operator()(double value) const {
     Approx approx(value);
@@ -5861,33 +6009,66 @@ Approx Approx::operator()(double value) const {
     return approx;
 }
 
-Approx& Approx::epsilon(double newEpsilon) {
+Approx &Approx::epsilon(double newEpsilon) {
     m_epsilon = newEpsilon;
     return *this;
 }
-Approx& Approx::scale(double newScale) {
+Approx &Approx::scale(double newScale) {
     m_scale = newScale;
     return *this;
 }
 
-bool operator==(double lhs, const Approx& rhs) {
+bool operator==(double lhs, const Approx &rhs) {
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
-bool operator==(const Approx& lhs, double rhs) { return operator==(rhs, lhs); }
-bool operator!=(double lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
-bool operator!=(const Approx& lhs, double rhs) { return !operator==(rhs, lhs); }
-bool operator<=(double lhs, const Approx& rhs) { return lhs < rhs.m_value || lhs == rhs; }
-bool operator<=(const Approx& lhs, double rhs) { return lhs.m_value < rhs || lhs == rhs; }
-bool operator>=(double lhs, const Approx& rhs) { return lhs > rhs.m_value || lhs == rhs; }
-bool operator>=(const Approx& lhs, double rhs) { return lhs.m_value > rhs || lhs == rhs; }
-bool operator<(double lhs, const Approx& rhs) { return lhs < rhs.m_value && lhs != rhs; }
-bool operator<(const Approx& lhs, double rhs) { return lhs.m_value < rhs && lhs != rhs; }
-bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs != rhs; }
-bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
-String toString(const Approx& in) {
+bool operator==(const Approx &lhs, double rhs) {
+    return operator==(rhs, lhs);
+}
+
+bool operator!=(double lhs, const Approx &rhs) {
+    return !operator==(lhs, rhs);
+}
+
+bool operator!=(const Approx &lhs, double rhs) {
+    return !operator==(rhs, lhs);
+}
+
+bool operator<=(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value || lhs == rhs;
+}
+
+bool operator<=(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs || lhs == rhs;
+}
+
+bool operator>=(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value || lhs == rhs;
+}
+
+bool operator>=(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs || lhs == rhs;
+}
+
+bool operator<(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value && lhs != rhs;
+}
+
+bool operator<(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs && lhs != rhs;
+}
+
+bool operator>(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value && lhs != rhs;
+}
+
+bool operator>(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs && lhs != rhs;
+}
+
+String toString(const Approx &in) {
     return "Approx( " + doctest::toString(in.m_value) + " )";
 }
 
@@ -5899,20 +6080,32 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-Contains::Contains(const String& str) : string(str) { }
+Contains::Contains(const String &str)
+    : string(str) {}
 
-bool Contains::checkWith(const String& other) const {
+bool Contains::checkWith(const String &other) const {
     return strstr(other.c_str(), string.c_str()) != nullptr;
 }
 
-String toString(const Contains& in) {
+String toString(const Contains &in) {
     return "Contains( " + in.string + " )";
 }
 
-bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
-bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
-bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
-bool operator!=(const Contains& lhs, const String& rhs) { return !lhs.checkWith(rhs); }
+bool operator==(const String &lhs, const Contains &rhs) {
+    return rhs.checkWith(lhs);
+}
+
+bool operator==(const Contains &lhs, const String &rhs) {
+    return lhs.checkWith(rhs);
+}
+
+bool operator!=(const String &lhs, const Contains &rhs) {
+    return !rhs.checkWith(lhs);
+}
+
+bool operator!=(const Contains &lhs, const String &rhs) {
+    return !lhs.checkWith(rhs);
+}
 
 } // namespace doctest
 
@@ -5933,10 +6126,21 @@ template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
 template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
 
 template <typename F>
-String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
-String toString(IsNaN<float> in) { return toString<float>(in); }
-String toString(IsNaN<double> in) { return toString<double>(in); }
-String toString(IsNaN<double long> in) { return toString<double long>(in); }
+String toString(IsNaN<F> in) {
+    return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )";
+}
+
+String toString(IsNaN<float> in) {
+    return toString<float>(in);
+}
+
+String toString(IsNaN<double> in) {
+    return toString<double>(in);
+}
+
+String toString(IsNaN<double long> in) {
+    return toString<double long>(in);
+}
 
 } // namespace doctest
 
@@ -5953,13 +6157,13 @@ namespace doctest {
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 // depending on the current options this will remove the path of filenames
-const char* skipPathFromFilename(const char* file) {
+const char *skipPathFromFilename(const char *file) {
 #ifndef DOCTEST_CONFIG_DISABLE
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
+    if (getContextOptions()->no_path_in_filenames) {
+        auto back = std::strrchr(file, '\\');
         auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
+        if (back || forward) {
+            if (back > forward)
                 forward = back;
             return forward + 1;
         }
@@ -5967,17 +6171,15 @@ const char* skipPathFromFilename(const char* file) {
         const auto prefixes = getContextOptions()->strip_file_prefixes;
         const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
         String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
+        for (String::size_type pos = 0U; pos < prefixes.size(); ++pos) {
             const auto prefix_start = pos;
             pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
 
             const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
-                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
+            if (prefix_size > longest_match) {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive
+                // letter capitalization?
+                if (0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size)) {
                     longest_match = prefix_size;
                 }
             }
@@ -5999,48 +6201,66 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    int                         IReporter::get_num_active_contexts() { return 0; }
-    const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
-    int                         IReporter::get_num_stringified_contexts() { return 0; }
-    const String*               IReporter::get_stringified_contexts() { return nullptr; }
+int IReporter::get_num_active_contexts() {
+    return 0;
+}
 
-    int registerReporter(const char*, int, IReporter*) { return 0; }
+const IContextScope *const *IReporter::get_active_contexts() {
+    return nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() {
+    return 0;
+}
+
+const String *IReporter::get_stringified_contexts() {
+    return nullptr;
+}
+
+int registerReporter(const char *, int, IReporter *) {
+    return 0;
+}
 
 #else
 
 namespace detail {
-    reporterMap& getReporters() {
-        static reporterMap data;
-        return data;
-    }
+reporterMap &getReporters() {
+    static reporterMap data;
+    return data;
+}
 
-    reporterMap& getListeners() {
-        static reporterMap data;
-        return data;
-    }
+reporterMap &getListeners() {
+    static reporterMap data;
+    return data;
+}
 } // namespace detail
 
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
-    DOCTEST_DEFINE_INTERFACE(IReporter)
+int IReporter::get_num_active_contexts() {
+    return detail::g_infoContexts.size();
+}
 
-    int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
-    const IContextScope* const* IReporter::get_active_contexts() {
-        return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
-    }
+const IContextScope *const *IReporter::get_active_contexts() {
+    return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+}
 
-    int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
-    const String* IReporter::get_stringified_contexts() {
-        return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
-    }
+int IReporter::get_num_stringified_contexts() {
+    return detail::g_cs->stringifiedContexts.size();
+}
 
-    namespace detail {
-        void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
-            if(isReporter)
-                getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-            else
-                getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-        }
-    } // namespace detail
+const String *IReporter::get_stringified_contexts() {
+    return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
+}
+
+namespace detail {
+void registerReporterImpl(const char *name, int priority, reporterCreatorFunc c, bool isReporter) {
+    if (isReporter)
+        getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+    else
+        getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+}
+} // namespace detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace doctest
@@ -6053,21 +6273,20 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
-    if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-        0)
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-            << Color::None;
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb) {
+    // clang-format off
+    if ((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) == 0)
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
 
-    if(rb.m_at & assertType::is_throws) {
+    if (rb.m_at & assertType::is_throws) {
         s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-    } else if((rb.m_at & assertType::is_throws_as) &&
-                (rb.m_at & assertType::is_throws_with)) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-            << rb.m_exception_string.c_str()
-            << "\", " << rb.m_exception_type << " ) " << Color::None;
-        if(rb.m_threw) {
-            if(!rb.m_failed) {
+    } else if ((rb.m_at & assertType::is_throws_as) && (rb.m_at & assertType::is_throws_with)) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str() << "\", " << rb.m_exception_type
+          << " ) " << Color::None;
+
+        if (rb.m_threw) {
+            if (!rb.m_failed) {
                 s << "threw as expected!\n";
             } else {
                 s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
@@ -6075,34 +6294,28 @@ void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
         } else {
             s << "did NOT throw at all!\n";
         }
-    } else if(rb.m_at &
-                assertType::is_throws_as) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-            << rb.m_exception_type << " ) " << Color::None
-            << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                            "threw a DIFFERENT exception: ") :
-                            "did NOT throw at all!")
-            << Color::Cyan << rb.m_exception << "\n";
-    } else if(rb.m_at &
-                assertType::is_throws_with) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-            << rb.m_exception_string.c_str()
-            << "\" ) " << Color::None
-            << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                            "threw a DIFFERENT exception: ") :
-                            "did NOT throw at all!")
-            << Color::Cyan << rb.m_exception << "\n";
-    } else if(rb.m_at & assertType::is_nothrow) {
-        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-            << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_throws_as) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", " << rb.m_exception_type
+          << " ) " << Color::None
+          << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_throws_with) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str()
+          << "\" ) " << Color::None
+          << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_nothrow) {
+        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception << "\n";
     } else {
-        s << (rb.m_threw ? "THREW exception: " :
-                            (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-        if(rb.m_threw)
+        s << (rb.m_threw ? "THREW exception: " : (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+        if (rb.m_threw)
             s << rb.m_exception << "\n";
         else
             s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
     }
+    // clang-format on
 }
 
 } // namespace doctest
@@ -6120,51 +6333,47 @@ namespace doctest {
 using detail::g_cs;
 
 Whitespace::Whitespace(int nr)
-        : nrSpaces(nr) {}
+    : nrSpaces(nr) {}
 
-std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-    if(ws.nrSpaces != 0)
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws) {
+    if (ws.nrSpaces != 0)
         out << std::setw(ws.nrSpaces) << ' ';
     return out;
 }
 
-ConsoleReporter::ConsoleReporter(const ContextOptions& co)
-        : s(*co.cout)
-        , opt(co) {}
+ConsoleReporter::ConsoleReporter(const ContextOptions &co)
+    : s(*co.cout), opt(co) {}
 
-ConsoleReporter::ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-        : s(ostr)
-        , opt(co) {}
+ConsoleReporter::ConsoleReporter(const ContextOptions &co, std::ostream &ostr)
+    : s(ostr), opt(co) {}
 
 void ConsoleReporter::separator_to_stream() {
     s << Color::Yellow
       << "==============================================================================="
-          "\n";
+         "\n";
 }
 
-const char* ConsoleReporter::getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str) {
-    if(success)
+const char *ConsoleReporter::getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str) {
+    if (success)
         return success_str;
     return failureString(at);
 }
 
 Color::Enum ConsoleReporter::getSuccessOrFailColor(bool success, assertType::Enum at) {
-    return success ? Color::BrightGreen :
-                      (at & assertType::is_warn) ? Color::Yellow : Color::Red;
+    return success ? Color::BrightGreen : (at & assertType::is_warn) ? Color::Yellow : Color::Red;
 }
 
-void ConsoleReporter::successOrFailColoredStringToStream(bool success, assertType::Enum at, const char* success_str) {
-    s << getSuccessOrFailColor(success, at)
-      << getSuccessOrFailString(success, at, success_str) << ": ";
+void ConsoleReporter::successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str) {
+    s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str) << ": ";
 }
 
 void ConsoleReporter::log_contexts() {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
+    if (num_contexts) {
         auto contexts = get_active_contexts();
 
         s << Color::None << "  logged: ";
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             s << (i == 0 ? "" : "          ");
             contexts[i]->stringify(&s);
             s << "\n";
@@ -6175,35 +6384,35 @@ void ConsoleReporter::log_contexts() {
 }
 
 // this was requested to be made virtual so users could override it
-void ConsoleReporter::file_line_to_stream(const char* file, int line, const char* tail) {
+void ConsoleReporter::file_line_to_stream(const char *file, int line, const char *tail) {
     s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
-    << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-    << (opt.gnu_file_line ? ":" : "):") << tail;
+      << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+      << (opt.gnu_file_line ? ":" : "):") << tail;
 }
 
 void ConsoleReporter::logTestStart() {
-    if(hasLoggedCurrentTestStart)
+    if (hasLoggedCurrentTestStart)
         return;
 
     separator_to_stream();
     file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
-    if(tc->m_description)
+    if (tc->m_description)
         s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-    if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+    if (tc->m_test_suite && tc->m_test_suite[0] != '\0')
         s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-    if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+    if (strncmp(tc->m_name, "  Scenario:", 11) != 0)
         s << Color::Yellow << "TEST CASE:  ";
     s << Color::None << tc->m_name << "\n";
 
-    for(size_t i = 0; i < currentSubcaseLevel; ++i) {
-        if(subcasesStack[i].m_name[0] != '\0')
+    for (size_t i = 0; i < currentSubcaseLevel; ++i) {
+        if (subcasesStack[i].m_name[0] != '\0')
             s << "  " << subcasesStack[i].m_name << "\n";
     }
 
-    if(currentSubcaseLevel != subcasesStack.size()) {
+    if (currentSubcaseLevel != subcasesStack.size()) {
         s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
-        for(size_t i = 0; i < subcasesStack.size(); ++i) {
-            if(subcasesStack[i].m_name[0] != '\0')
+        for (size_t i = 0; i < subcasesStack.size(); ++i) {
+            if (subcasesStack[i].m_name[0] != '\0')
                 s << "  " << subcasesStack[i].m_name << "\n";
         }
     }
@@ -6214,13 +6423,12 @@ void ConsoleReporter::logTestStart() {
 }
 
 void ConsoleReporter::printVersion() {
-    if(opt.no_version == false)
-        s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-          << DOCTEST_VERSION_STR << "\"\n";
+    if (opt.no_version == false)
+        s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \"" << DOCTEST_VERSION_STR << "\"\n";
 }
 
 void ConsoleReporter::printIntro() {
-    if(opt.no_intro == false) {
+    if (opt.no_intro == false) {
         printVersion();
         s << Color::Cyan << "[doctest] " << Color::None
           << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
@@ -6250,95 +6458,95 @@ void ConsoleReporter::printHelp() {
     s << Color::Cyan << "[doctest] " << Color::None;
     s << "Query flags - the program quits after them. Available:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "?,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "help, -" DOCTEST_OPTIONS_PREFIX_DISPLAY "h                      "
-      << Whitespace(sizePrefixDisplay*0) <<  "prints this message\n";
+      << Whitespace(sizePrefixDisplay * 0) <<  "prints this message\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "v,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "version                       "
-      << Whitespace(sizePrefixDisplay*1) << "prints the version\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the version\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "c,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "count                         "
-      << Whitespace(sizePrefixDisplay*1) << "prints the number of matching tests\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the number of matching tests\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ltc, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-cases               "
-      << Whitespace(sizePrefixDisplay*1) << "lists all matching tests by name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching tests by name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lts, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-suites              "
-      << Whitespace(sizePrefixDisplay*1) << "lists all matching test suites\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching test suites\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-reporters                "
-      << Whitespace(sizePrefixDisplay*1) << "lists all registered reporters\n\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all registered reporters\n\n";
     // ================================================================================== << 79
     s << Color::Cyan << "[doctest] " << Color::None;
     s << "The available <int>/<string> options/filters are:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case=<filters>           "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case-exclude=<filters>   "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sf,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file=<filters>         "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their file\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their file\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfe, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file-exclude=<filters> "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their file\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their file\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ts,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite=<filters>          "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their test suite\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their test suite\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tse, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite-exclude=<filters>  "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their test suite\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their test suite\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase=<filters>             "
-      << Whitespace(sizePrefixDisplay*1) << "filters     subcases by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     subcases by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-exclude=<filters>     "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT subcases by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT subcases by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "r,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "reporters=<filters>           "
-      << Whitespace(sizePrefixDisplay*1) << "reporters to use (console is default)\n";
+      << Whitespace(sizePrefixDisplay * 1) << "reporters to use (console is default)\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
-      << Whitespace(sizePrefixDisplay*1) << "output filename\n";
+      << Whitespace(sizePrefixDisplay * 1) << "output filename\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
-      << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
+      << Whitespace(sizePrefixDisplay * 1) << "how the tests should be ordered\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       <string> - [file/suite/name/rand/none]\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
-      << Whitespace(sizePrefixDisplay*1) << "seed for random ordering\n";
+      << Whitespace(sizePrefixDisplay * 1) << "seed for random ordering\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "f,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "first=<int>                   "
-      << Whitespace(sizePrefixDisplay*1) << "the first test passing the filters to\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       execute - for range-based execution\n";
+      << Whitespace(sizePrefixDisplay * 1) << "the first test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "l,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "last=<int>                    "
-      << Whitespace(sizePrefixDisplay*1) << "the last test passing the filters to\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       execute - for range-based execution\n";
+      << Whitespace(sizePrefixDisplay * 1) << "the last test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "aa,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "abort-after=<int>             "
-      << Whitespace(sizePrefixDisplay*1) << "stop after <int> failed assertions\n";
+      << Whitespace(sizePrefixDisplay * 1) << "stop after <int> failed assertions\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "scfl,--" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-filter-levels=<int>   "
-      << Whitespace(sizePrefixDisplay*1) << "apply filters for the first <int> levels\n";
+      << Whitespace(sizePrefixDisplay * 1) << "apply filters for the first <int> levels\n";
     s << Color::Cyan << "\n[doctest] " << Color::None;
     s << "Bool options - can be used like flags and true is assumed. Available:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "s,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "success=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "include successful assertions in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "include successful assertions in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "cs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "case-sensitive=<bool>         "
-      << Whitespace(sizePrefixDisplay*1) << "filters being treated as case sensitive\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters being treated as case sensitive\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "e,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "exit=<bool>                   "
-      << Whitespace(sizePrefixDisplay*1) << "exits after the tests finish\n";
+      << Whitespace(sizePrefixDisplay * 1) << "exits after the tests finish\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "d,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "duration=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "prints the time duration of each test\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the time duration of each test\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "m,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "minimal=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "minimal console output (only failures)\n";
+      << Whitespace(sizePrefixDisplay * 1) << "minimal console output (only failures)\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "q,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "quiet=<bool>                  "
-      << Whitespace(sizePrefixDisplay*1) << "no console output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "no console output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nt,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-throw=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "skips exceptions-related assert checks\n";
+      << Whitespace(sizePrefixDisplay * 1) << "skips exceptions-related assert checks\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ne,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-exitcode=<bool>            "
-      << Whitespace(sizePrefixDisplay*1) << "returns (or exits) always with success\n";
+      << Whitespace(sizePrefixDisplay * 1) << "returns (or exits) always with success\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-run=<bool>                 "
-      << Whitespace(sizePrefixDisplay*1) << "skips all runtime doctest operations\n";
+      << Whitespace(sizePrefixDisplay * 1) << "skips all runtime doctest operations\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ni,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-intro=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "omit the framework intro in the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework intro in the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nv,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-version=<bool>             "
-      << Whitespace(sizePrefixDisplay*1) << "omit the framework version in the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework version in the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-colors=<bool>              "
-      << Whitespace(sizePrefixDisplay*1) << "disables colors in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "disables colors in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "fc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "force-colors=<bool>           "
-      << Whitespace(sizePrefixDisplay*1) << "use colors even when not in a tty\n";
+      << Whitespace(sizePrefixDisplay * 1) << "use colors even when not in a tty\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nb,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-breaks=<bool>              "
-      << Whitespace(sizePrefixDisplay*1) << "disables breakpoints in debuggers\n";
+      << Whitespace(sizePrefixDisplay * 1) << "disables breakpoints in debuggers\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ns,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-skip=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "don't skip test cases marked as skip\n";
+      << Whitespace(sizePrefixDisplay * 1) << "don't skip test cases marked as skip\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "gfl, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "gnu-file-line=<bool>          "
-      << Whitespace(sizePrefixDisplay*1) << ":n: vs (n): for line numbers in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << ":n: vs (n): for line numbers in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
-      << Whitespace(sizePrefixDisplay*1) << "only filenames and no paths in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "only filenames and no paths in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "spp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "skip-path-prefixes=<p1:p2>    "
-      << Whitespace(sizePrefixDisplay*1) << "whenever file paths start with this prefix, remove it from the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "whenever file paths start with this prefix, remove it from the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
-      << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "0 instead of real line numbers in output\n";
     // ================================================================================== << 79
     // clang-format on
 
@@ -6348,172 +6556,172 @@ void ConsoleReporter::printHelp() {
 
 void ConsoleReporter::printRegisteredReporters() {
     printVersion();
-    auto printReporters = [this] (const detail::reporterMap& reporters, const char* type) {
-        if(reporters.size()) {
+    auto printReporters = [this](const detail::reporterMap &reporters, const char *type) {
+        if (reporters.size()) {
             s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
-            for(auto& curr : reporters)
-                s << "priority: " << std::setw(5) << curr.first.first
-                  << " name: " << curr.first.second << "\n";
+            for (auto &curr: reporters)
+                s << "priority: " << std::setw(5) << curr.first.first << " name: " << curr.first.second << "\n";
         }
     };
     printReporters(detail::getListeners(), "listeners");
     printReporters(detail::getReporters(), "reporters");
 }
 
-void ConsoleReporter::report_query(const QueryData& in) {
-    if(opt.version) {
+void ConsoleReporter::report_query(const QueryData &in) {
+    if (opt.version) {
         printVersion();
-    } else if(opt.help) {
+    } else if (opt.help) {
         printHelp();
-    } else if(opt.list_reporters) {
+    } else if (opt.list_reporters) {
         printRegisteredReporters();
-    } else if(opt.count || opt.list_test_cases) {
-        if(opt.list_test_cases) {
-            s << Color::Cyan << "[doctest] " << Color::None
-              << "listing all test case names\n";
+    } else if (opt.count || opt.list_test_cases) {
+        if (opt.list_test_cases) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
             separator_to_stream();
         }
 
-        for(unsigned i = 0; i < in.num_data; ++i)
+        for (unsigned i = 0; i < in.num_data; ++i)
             s << Color::None << in.data[i]->m_name << "\n";
 
         separator_to_stream();
 
         s << Color::Cyan << "[doctest] " << Color::None
-          << "unskipped test cases passing the current filters: "
-          << g_cs->numTestCasesPassingFilters << "\n";
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
 
-    } else if(opt.list_test_suites) {
+    } else if (opt.list_test_suites) {
         s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
         separator_to_stream();
 
-        for(unsigned i = 0; i < in.num_data; ++i)
+        for (unsigned i = 0; i < in.num_data; ++i)
             s << Color::None << in.data[i]->m_test_suite << "\n";
 
         separator_to_stream();
 
         s << Color::Cyan << "[doctest] " << Color::None
-          << "unskipped test cases passing the current filters: "
-          << g_cs->numTestCasesPassingFilters << "\n";
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
         s << Color::Cyan << "[doctest] " << Color::None
-          << "test suites with unskipped test cases passing the current filters: "
-          << g_cs->numTestSuitesPassingFilters << "\n";
+          << "test suites with unskipped test cases passing the current filters: " << g_cs->numTestSuitesPassingFilters
+          << "\n";
     }
 }
 
 void ConsoleReporter::test_run_start() {
-    if(!opt.minimal)
+    if (!opt.minimal)
         printIntro();
 }
 
-void ConsoleReporter::test_run_end(const TestRunStats& p) {
-    if(opt.minimal && p.numTestCasesFailed == 0)
+void ConsoleReporter::test_run_end(const TestRunStats &p) {
+    if (opt.minimal && p.numTestCasesFailed == 0)
         return;
 
     separator_to_stream();
     s << std::dec;
 
-    auto totwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-    auto passwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-    auto failwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+    auto totwidth = int(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)
+    ));
+    auto passwidth = int(std::ceil(log10(
+        static_cast<double>(std::max(
+            p.numTestCasesPassingFilters - p.numTestCasesFailed,
+            static_cast<unsigned>(p.numAsserts - p.numAssertsFailed)
+        )) +
+        1
+    )));
+    auto failwidth = int(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)
+    ));
     const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
     s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
       << p.numTestCasesPassingFilters << " | "
-      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                  Color::Green)
-      << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-      << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-      << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
-    if(opt.no_skipped_summary == false) {
+      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed" << Color::None << " | "
+      << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numTestCasesFailed
+      << " failed" << Color::None << " |";
+    if (opt.no_skipped_summary == false) {
         const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-        s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
-          << " skipped" << Color::None;
+        s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped << " skipped" << Color::None;
     }
     s << "\n";
-    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
-      << p.numAsserts << " | "
-      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-      << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-      << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
-      << p.numAssertsFailed << " failed" << Color::None << " |\n";
+    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth) << p.numAsserts << " | "
+      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None << " | "
+      << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numAssertsFailed << " failed"
+      << Color::None << " |\n";
     s << Color::Cyan << "[doctest] " << Color::None
       << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
       << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
 }
 
-void ConsoleReporter::test_case_start(const TestCaseData& in) {
+void ConsoleReporter::test_case_start(const TestCaseData &in) {
     hasLoggedCurrentTestStart = false;
-    tc                        = &in;
+    tc = &in;
     subcasesStack.clear();
     currentSubcaseLevel = 0;
 }
 
-void ConsoleReporter::test_case_reenter(const TestCaseData&) {
+void ConsoleReporter::test_case_reenter(const TestCaseData &) {
     subcasesStack.clear();
 }
 
-void ConsoleReporter::test_case_end(const CurrentTestCaseStats& st) {
-    if(tc->m_no_output)
+void ConsoleReporter::test_case_end(const CurrentTestCaseStats &st) {
+    if (tc->m_no_output)
         return;
 
     // log the preamble of the test case only if there is something
     // else to print - something other than that an assert has failed
-    if(opt.duration ||
+    if (opt.duration ||
         (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
         logTestStart();
 
-    if(opt.duration)
-        s << Color::None << std::setprecision(6) << std::fixed << st.seconds
-          << " s: " << tc->m_name << "\n";
+    if (opt.duration)
+        s << Color::None << std::setprecision(6) << std::fixed << st.seconds << " s: " << tc->m_name << "\n";
 
-    if(st.failure_flags & TestCaseFailureReason::Timeout)
-        s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-          << std::fixed << tc->m_timeout << "!\n";
+    if (st.failure_flags & TestCaseFailureReason::Timeout)
+        s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6) << std::fixed << tc->m_timeout
+          << "!\n";
 
-    if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+    if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
         s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-    } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+    } else if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
         s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-    } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+    } else if (st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
         s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-    } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-        s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
-          << " times so marking it as failed!\n";
-    } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+    } else if (st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+        s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures << " times so marking it as failed!\n";
+    } else if (st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
         s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
           << " times as expected so marking it as not failed!\n";
     }
-    if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+    if (st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
         s << Color::Red << "Aborting - too many failed asserts!\n";
     }
     s << Color::None;
 }
 
-void ConsoleReporter::test_case_exception(const TestCaseException& e) {
+void ConsoleReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
-    if(tc->m_no_output)
+    if (tc->m_no_output)
         return;
 
     logTestStart();
 
     file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
     successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require : assertType::is_check);
-    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
-      << Color::Cyan << e.error_string << "\n";
+    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ");
+    s << Color::Cyan << e.error_string << "\n";
 
     int num_stringified_contexts = get_num_stringified_contexts();
-    if(num_stringified_contexts) {
+    if (num_stringified_contexts) {
         auto stringified_contexts = get_stringified_contexts();
         s << Color::None << "  logged: ";
-        for(int i = num_stringified_contexts; i > 0; --i) {
-            s << (i == num_stringified_contexts ? "" : "          ")
-              << stringified_contexts[i - 1] << "\n";
+        for (int i = num_stringified_contexts; i > 0; --i) {
+            s << (i == num_stringified_contexts ? "" : "          ") << stringified_contexts[i - 1] << "\n";
         }
     }
     s << "\n" << Color::None;
 }
 
-void ConsoleReporter::subcase_start(const SubcaseSignature& subc) {
+void ConsoleReporter::subcase_start(const SubcaseSignature &subc) {
     subcasesStack.push_back(subc);
     ++currentSubcaseLevel;
     hasLoggedCurrentTestStart = false;
@@ -6524,8 +6732,8 @@ void ConsoleReporter::subcase_end() {
     hasLoggedCurrentTestStart = false;
 }
 
-void ConsoleReporter::log_assert(const AssertData& rb) {
-    if((!rb.m_failed && !opt.success) || tc->m_no_output)
+void ConsoleReporter::log_assert(const AssertData &rb) {
+    if ((!rb.m_failed && !opt.success) || tc->m_no_output)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
@@ -6540,8 +6748,8 @@ void ConsoleReporter::log_assert(const AssertData& rb) {
     log_contexts();
 }
 
-void ConsoleReporter::log_message(const MessageData& mb) {
-    if(tc->m_no_output)
+void ConsoleReporter::log_message(const MessageData &mb) {
+    if (tc->m_no_output)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
@@ -6550,13 +6758,12 @@ void ConsoleReporter::log_message(const MessageData& mb) {
 
     file_line_to_stream(mb.m_file, mb.m_line, " ");
     s << getSuccessOrFailColor(false, mb.m_severity)
-      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                "MESSAGE") << ": ";
+      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE") << ": ";
     s << Color::None << mb.m_string << "\n";
     log_contexts();
 }
 
-void ConsoleReporter::test_case_skipped(const TestCaseData&) {}
+void ConsoleReporter::test_case_skipped(const TestCaseData &) {}
 
 } // namespace doctest
 
@@ -6579,33 +6786,33 @@ namespace detail {
 
 DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 
-DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions& co)
-        : ConsoleReporter(co, oss) {}
+DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions &co)
+    : ConsoleReporter(co, oss) {}
 
-#define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                    \
-    void DebugOutputWindowReporter::func(type arg) {                                                                 \
-        using detail::g_no_colors;                                                                 \
-        bool with_col = g_no_colors;                                                               \
-        g_no_colors   = false;                                                                     \
-        ConsoleReporter::func(arg);                                                                \
-        if(oss.tellp() != std::streampos{}) {                                                      \
-            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
-            oss.str("");                                                                           \
-        }                                                                                          \
-        g_no_colors = with_col;                                                                    \
+#define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                                        \
+    void DebugOutputWindowReporter::func(type arg) {                                                                   \
+        using detail::g_no_colors;                                                                                     \
+        bool with_col = g_no_colors;                                                                                   \
+        g_no_colors = false;                                                                                           \
+        ConsoleReporter::func(arg);                                                                                    \
+        if (oss.tellp() != std::streampos{}) {                                                                         \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                                            \
+            oss.str("");                                                                                               \
+        }                                                                                                              \
+        g_no_colors = with_col;                                                                                        \
     }
 
 DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature&, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature &, in)
 DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_end, DOCTEST_EMPTY, DOCTEST_EMPTY)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData&, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData &, in)
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 
@@ -6629,12 +6836,11 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // clang-format off
-
 // =================================================================================================
-// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h/cpp
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h
 // This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
 // =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
 
     class XmlEncode {
     public:
@@ -6727,7 +6933,10 @@ namespace detail {
         std::ostream& m_os;
     };
 
-    // clang-format on
+/* clang-format on */ /* NOLINTEND */
+// =================================================================================================
+// End of copy-pasted code from Catch
+// =================================================================================================
 
 } // namespace detail
 } // namespace doctest
@@ -6744,97 +6953,93 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    // TODO:
-    // - log_message()
-    // - respond to queries
-    // - honor remaining options
-    // - more attributes in tags
-    struct JUnitReporter : public IReporter
-    {
-        detail::XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
-        detail::Timer timer;
-        std::vector<String> deepestSubcaseStackNames;
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter {
+    detail::XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+    detail::Timer timer;
+    std::vector<String> deepestSubcaseStackNames;
 
-        struct JUnitTestCaseData
-        {
-            static std::string getCurrentTimestamp();
+    struct JUnitTestCaseData {
+        static std::string getCurrentTimestamp();
 
-            struct JUnitTestMessage
-            {
-                JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details);
+        struct JUnitTestMessage {
+            JUnitTestMessage(const std::string &_message, const std::string &_type, const std::string &_details);
 
-                JUnitTestMessage(const std::string& _message, const std::string& _details);
+            JUnitTestMessage(const std::string &_message, const std::string &_details);
 
-                std::string message, type, details;
-            };
-
-            struct JUnitTestCase
-            {
-                JUnitTestCase(const std::string& _classname, const std::string& _name);
-
-                std::string classname, name;
-                double time;
-                std::vector<JUnitTestMessage> failures, errors;
-            };
-
-            void add(const std::string& classname, const std::string& name);
-
-            void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack);
-
-            void addTime(double time);
-
-            void addFailure(const std::string& message, const std::string& type, const std::string& details);
-
-            void addError(const std::string& message, const std::string& details);
-
-            std::vector<JUnitTestCase> testcases;
-            double totalSeconds = 0;
-            int totalErrors = 0, totalFailures = 0;
+            std::string message, type, details;
         };
 
-        JUnitTestCaseData testCaseData;
+        struct JUnitTestCase {
+            JUnitTestCase(const std::string &_classname, const std::string &_name);
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+            std::string classname, name;
+            double time;
+            std::vector<JUnitTestMessage> failures, errors;
+        };
 
-        JUnitReporter(const ContextOptions& co);
+        void add(const std::string &classname, const std::string &name);
 
-        unsigned line(unsigned l) const;
+        void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack);
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
+        void addTime(double time);
 
-        void report_query(const QueryData&) override;
+        void addFailure(const std::string &message, const std::string &type, const std::string &details);
 
-        void test_run_start() override;
+        void addError(const std::string &message, const std::string &details);
 
-        void test_run_end(const TestRunStats& p) override;
-
-        void test_case_start(const TestCaseData& in) override;
-
-        void test_case_reenter(const TestCaseData& in) override;
-
-        void test_case_end(const CurrentTestCaseStats&) override;
-
-        void test_case_exception(const TestCaseException& e) override;
-
-        void subcase_start(const SubcaseSignature& in) override;
-
-        void subcase_end() override;
-
-        void log_assert(const AssertData& rb) override;
-
-        void log_message(const MessageData& mb) override;
-
-        void test_case_skipped(const TestCaseData&) override;
-
-        void log_contexts(std::ostringstream& s);
+        std::vector<JUnitTestCase> testcases;
+        double totalSeconds = 0;
+        int totalErrors = 0, totalFailures = 0;
     };
 
-    DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+    JUnitTestCaseData testCaseData;
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
+
+    JUnitReporter(const ContextOptions &co);
+
+    unsigned line(unsigned l) const;
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData &) override;
+
+    void test_run_start() override;
+
+    void test_run_end(const TestRunStats &p) override;
+
+    void test_case_start(const TestCaseData &in) override;
+
+    void test_case_reenter(const TestCaseData &in) override;
+
+    void test_case_end(const CurrentTestCaseStats &) override;
+
+    void test_case_exception(const TestCaseException &e) override;
+
+    void subcase_start(const SubcaseSignature &in) override;
+
+    void subcase_end() override;
+
+    void log_assert(const AssertData &rb) override;
+
+    void log_message(const MessageData &mb) override;
+
+    void test_case_skipped(const TestCaseData &) override;
+
+    void log_contexts(std::ostringstream &s);
+};
+
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
 
 } // namespace doctest
 
@@ -6855,66 +7060,72 @@ std::string JUnitReporter::JUnitTestCaseData::getCurrentTimestamp() {
     // Also, UTC only, again because of backward compatibility (%z is C++11)
     time_t rawtime;
     std::time(&rawtime);
-    auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+    const auto timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
     std::tm timeInfo;
 #ifdef DOCTEST_PLATFORM_WINDOWS
     gmtime_s(&timeInfo, &rawtime);
-#else // DOCTEST_PLATFORM_WINDOWS
+#else  // DOCTEST_PLATFORM_WINDOWS
     gmtime_r(&rawtime, &timeInfo);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
     char timeStamp[timeStampSize];
-    const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+    const char *const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
     std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
     return std::string(timeStamp);
 }
 
-JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_type, const std::string &_details
+)
     : message(_message), type(_type), details(_details) {}
 
-JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(const std::string& _message, const std::string& _details)
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_details
+)
     : message(_message), type(), details(_details) {}
 
-JUnitReporter::JUnitTestCaseData::JUnitTestCase::JUnitTestCase(const std::string& _classname, const std::string& _name)
+JUnitReporter::JUnitTestCaseData::JUnitTestCase::JUnitTestCase(const std::string &_classname, const std::string &_name)
     : classname(_classname), name(_name), time(0), failures() {}
 
-
-void JUnitReporter::JUnitTestCaseData::add(const std::string& classname, const std::string& name) {
+void JUnitReporter::JUnitTestCaseData::add(const std::string &classname, const std::string &name) {
     testcases.emplace_back(classname, name);
 }
 
 void JUnitReporter::JUnitTestCaseData::appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
-    for(auto& curr: nameStack)
-        if(curr.size())
+    for (auto &curr: nameStack)
+        if (curr.size())
             testcases.back().name += std::string("/") + curr.c_str();
 }
 
 void JUnitReporter::JUnitTestCaseData::addTime(double time) {
-    if(time < 1e-4)
+    if (time < 1e-4)
         time = 0;
     testcases.back().time = time;
     totalSeconds += time;
 }
 
-void JUnitReporter::JUnitTestCaseData::addFailure(const std::string& message, const std::string& type, const std::string& details) {
+void JUnitReporter::JUnitTestCaseData::addFailure(
+    const std::string &message, const std::string &type, const std::string &details
+) {
     testcases.back().failures.emplace_back(message, type, details);
     ++totalFailures;
 }
 
-void JUnitReporter::JUnitTestCaseData::addError(const std::string& message, const std::string& details) {
+void JUnitReporter::JUnitTestCaseData::addError(const std::string &message, const std::string &details) {
     testcases.back().errors.emplace_back(message, details);
     ++totalErrors;
 }
 
-JUnitReporter::JUnitReporter(const ContextOptions& co)
-        : xml(*co.cout)
-        , opt(co) {}
+JUnitReporter::JUnitReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
 
-unsigned JUnitReporter::line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+unsigned JUnitReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
 
-void JUnitReporter::report_query(const QueryData&) {
+void JUnitReporter::report_query(const QueryData &) {
     xml.writeDeclaration();
 }
 
@@ -6922,45 +7133,44 @@ void JUnitReporter::test_run_start() {
     xml.writeDeclaration();
 }
 
-void JUnitReporter::test_run_end(const TestRunStats& p) {
+void JUnitReporter::test_run_end(const TestRunStats &p) {
     // remove .exe extension - mainly to have the same output on UNIX and Windows
     std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(binary_name.rfind(".exe") != std::string::npos)
+    if (binary_name.rfind(".exe") != std::string::npos)
         binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
     xml.startElement("testsuites");
-    xml.startElement("testsuite").writeAttribute("name", binary_name)
-            .writeAttribute("errors", testCaseData.totalErrors)
-            .writeAttribute("failures", testCaseData.totalFailures)
-            .writeAttribute("tests", p.numAsserts);
-    if(opt.no_time_in_output == false) {
+    xml.startElement("testsuite")
+        .writeAttribute("name", binary_name)
+        .writeAttribute("errors", testCaseData.totalErrors)
+        .writeAttribute("failures", testCaseData.totalFailures)
+        .writeAttribute("tests", p.numAsserts);
+    if (opt.no_time_in_output == false) {
         xml.writeAttribute("time", testCaseData.totalSeconds);
         xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
     }
-    if(opt.no_version == false)
+    if (opt.no_version == false)
         xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
 
-    for(const auto& testCase : testCaseData.testcases) {
+    for (const auto &testCase: testCaseData.testcases) {
         xml.startElement("testcase")
             .writeAttribute("classname", testCase.classname)
             .writeAttribute("name", testCase.name);
-        if(opt.no_time_in_output == false)
+        if (opt.no_time_in_output == false)
             xml.writeAttribute("time", testCase.time);
         // This is not ideal, but it should be enough to mimic gtest's junit output.
         xml.writeAttribute("status", "run");
 
-        for(const auto& failure : testCase.failures) {
+        for (const auto &failure: testCase.failures) {
             xml.scopedElement("failure")
                 .writeAttribute("message", failure.message)
                 .writeAttribute("type", failure.type)
                 .writeText(failure.details, false);
         }
 
-        for(const auto& error : testCase.errors) {
-            xml.scopedElement("error")
-                .writeAttribute("message", error.message)
-                .writeText(error.details);
+        for (const auto &error: testCase.errors) {
+            xml.scopedElement("error").writeAttribute("message", error.message).writeText(error.details);
         }
 
         xml.endElement();
@@ -6969,12 +7179,12 @@ void JUnitReporter::test_run_end(const TestRunStats& p) {
     xml.endElement();
 }
 
-void JUnitReporter::test_case_start(const TestCaseData& in) {
+void JUnitReporter::test_case_start(const TestCaseData &in) {
     testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
     timer.start();
 }
 
-void JUnitReporter::test_case_reenter(const TestCaseData& in) {
+void JUnitReporter::test_case_reenter(const TestCaseData &in) {
     testCaseData.addTime(timer.getElapsedSeconds());
     testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
     deepestSubcaseStackNames.clear();
@@ -6983,64 +7193,65 @@ void JUnitReporter::test_case_reenter(const TestCaseData& in) {
     testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
 }
 
-void JUnitReporter::test_case_end(const CurrentTestCaseStats&) {
+void JUnitReporter::test_case_end(const CurrentTestCaseStats &) {
     testCaseData.addTime(timer.getElapsedSeconds());
     testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
     deepestSubcaseStackNames.clear();
 }
 
-void JUnitReporter::test_case_exception(const TestCaseException& e) {
+void JUnitReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
     testCaseData.addError("exception", e.error_string.c_str());
 }
 
-void JUnitReporter::subcase_start(const SubcaseSignature& in) {
+void JUnitReporter::subcase_start(const SubcaseSignature &in) {
     deepestSubcaseStackNames.push_back(in.m_name);
 }
 
 void JUnitReporter::subcase_end() {}
 
-void JUnitReporter::log_assert(const AssertData& rb) {
-    if(!rb.m_failed) // report only failures & ignore the `success` option
+void JUnitReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed) // report only failures & ignore the `success` option
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     std::ostringstream os;
-    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
-      << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(rb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
     fulltext_log_assert_to_stream(os, rb);
     log_contexts(os);
     testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
 }
 
-void JUnitReporter::log_message(const MessageData& mb) {
-    if(mb.m_severity & assertType::is_warn) // report only failures
+void JUnitReporter::log_message(const MessageData &mb) {
+    if (mb.m_severity & assertType::is_warn) // report only failures
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     std::ostringstream os;
-    os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(")
-      << line(mb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+    os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(mb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
     os << mb.m_string.c_str() << "\n";
     log_contexts(os);
 
-    testCaseData.addFailure(mb.m_string.c_str(),
-        mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str());
+    testCaseData.addFailure(
+        mb.m_string.c_str(), mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str()
+    );
 }
 
-void JUnitReporter::test_case_skipped(const TestCaseData&) {}
+void JUnitReporter::test_case_skipped(const TestCaseData &) {}
 
-void JUnitReporter::log_contexts(std::ostringstream& s) {
+void JUnitReporter::log_contexts(std::ostringstream &s) {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
+    if (num_contexts) {
         auto contexts = get_active_contexts();
 
         s << "  logged: ";
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             s << (i == 0 ? "" : "          ");
             contexts[i]->stringify(&s);
             s << std::endl;
@@ -7063,50 +7274,49 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-struct XmlReporter : public IReporter
-{
+struct XmlReporter : public IReporter {
     detail::XmlWriter xml;
     DOCTEST_DECLARE_MUTEX(mutex)
 
     // caching pointers/references to objects of these types - safe to do
-    const ContextOptions& opt;
-    const TestCaseData*   tc = nullptr;
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
 
-    XmlReporter(const ContextOptions& co);
+    XmlReporter(const ContextOptions &co);
 
     void log_contexts();
 
     unsigned line(unsigned l) const;
 
-    void test_case_start_impl(const TestCaseData& in);
+    void test_case_start_impl(const TestCaseData &in);
 
     // =========================================================================================
     // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
     // =========================================================================================
 
-    void report_query(const QueryData& in) override;
+    void report_query(const QueryData &in) override;
 
     void test_run_start() override;
 
-    void test_run_end(const TestRunStats& p) override;
+    void test_run_end(const TestRunStats &p) override;
 
-    void test_case_start(const TestCaseData& in) override;
+    void test_case_start(const TestCaseData &in) override;
 
-    void test_case_reenter(const TestCaseData&) override;
+    void test_case_reenter(const TestCaseData &) override;
 
-    void test_case_end(const CurrentTestCaseStats& st) override;
+    void test_case_end(const CurrentTestCaseStats &st) override;
 
-    void test_case_exception(const TestCaseException& e) override;
+    void test_case_exception(const TestCaseException &e) override;
 
-    void subcase_start(const SubcaseSignature& in) override;
+    void subcase_start(const SubcaseSignature &in) override;
 
     void subcase_end() override;
 
-    void log_assert(const AssertData& rb) override;
+    void log_assert(const AssertData &rb) override;
 
-    void log_message(const MessageData& mb) override;
+    void log_message(const MessageData &mb) override;
 
-    void test_case_skipped(const TestCaseData& in) override;
+    void test_case_skipped(const TestCaseData &in) override;
 };
 
 DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
@@ -7125,16 +7335,15 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-XmlReporter::XmlReporter(const ContextOptions& co)
-        : xml(*co.cout)
-        , opt(co) {}
+XmlReporter::XmlReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
 
 void XmlReporter::log_contexts() {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
-        auto              contexts = get_active_contexts();
+    if (num_contexts) {
+        auto contexts = get_active_contexts();
         std::stringstream ss;
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             contexts[i]->stringify(&ss);
             xml.scopedElement("Info").writeText(ss.str());
             ss.str("");
@@ -7142,68 +7351,70 @@ void XmlReporter::log_contexts() {
     }
 }
 
-unsigned XmlReporter::line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+unsigned XmlReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
 
-void XmlReporter::test_case_start_impl(const TestCaseData& in) {
+void XmlReporter::test_case_start_impl(const TestCaseData &in) {
     bool open_ts_tag = false;
-    if(tc != nullptr) { // we have already opened a test suite
-        if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+    if (tc != nullptr) { // we have already opened a test suite
+        if (std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
             xml.endElement();
             open_ts_tag = true;
         }
-    }
-    else {
+    } else {
         open_ts_tag = true; // first test case ==> first test suite
     }
 
-    if(open_ts_tag) {
+    if (open_ts_tag) {
         xml.startElement("TestSuite");
         xml.writeAttribute("name", in.m_test_suite);
     }
 
     tc = &in;
     xml.startElement("TestCase")
-            .writeAttribute("name", in.m_name)
-            .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
-            .writeAttribute("line", line(in.m_line))
-            .writeAttribute("description", in.m_description);
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+        .writeAttribute("line", line(in.m_line))
+        .writeAttribute("description", in.m_description);
 
-    if(Approx(in.m_timeout) != 0)
+    if (Approx(in.m_timeout) != 0)
         xml.writeAttribute("timeout", in.m_timeout);
-    if(in.m_may_fail)
+    if (in.m_may_fail)
         xml.writeAttribute("may_fail", true);
-    if(in.m_should_fail)
+    if (in.m_should_fail)
         xml.writeAttribute("should_fail", true);
 }
 
-void XmlReporter::report_query(const QueryData& in) {
+void XmlReporter::report_query(const QueryData &in) {
     test_run_start();
-    if(opt.list_reporters) {
-        for(auto& curr : detail::getListeners())
+    if (opt.list_reporters) {
+        for (auto &curr: detail::getListeners())
             xml.scopedElement("Listener")
-                    .writeAttribute("priority", curr.first.first)
-                    .writeAttribute("name", curr.first.second);
-        for(auto& curr : detail::getReporters())
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+        for (auto &curr: detail::getReporters())
             xml.scopedElement("Reporter")
-                    .writeAttribute("priority", curr.first.first)
-                    .writeAttribute("name", curr.first.second);
-    } else if(opt.count || opt.list_test_cases) {
-        for(unsigned i = 0; i < in.num_data; ++i) {
-            xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+    } else if (opt.count || opt.list_test_cases) {
+        for (unsigned i = 0; i < in.num_data; ++i) {
+            xml.scopedElement("TestCase")
+                .writeAttribute("name", in.data[i]->m_name)
                 .writeAttribute("testsuite", in.data[i]->m_test_suite)
                 .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
                 .writeAttribute("line", line(in.data[i]->m_line))
                 .writeAttribute("skipped", in.data[i]->m_skip);
         }
         xml.scopedElement("OverallResultsTestCases")
-                .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-    } else if(opt.list_test_suites) {
-        for(unsigned i = 0; i < in.num_data; ++i)
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+    } else if (opt.list_test_suites) {
+        for (unsigned i = 0; i < in.num_data; ++i)
             xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
         xml.scopedElement("OverallResultsTestCases")
-                .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
         xml.scopedElement("OverallResultsTestSuites")
-                .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
+            .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
     }
     xml.endElement();
 }
@@ -7214,108 +7425,106 @@ void XmlReporter::test_run_start() {
     // remove .exe extension - mainly to have the same output on UNIX and Windows
     std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(binary_name.rfind(".exe") != std::string::npos)
+    if (binary_name.rfind(".exe") != std::string::npos)
         binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
     xml.startElement("doctest").writeAttribute("binary", binary_name);
-    if(opt.no_version == false)
+    if (opt.no_version == false)
         xml.writeAttribute("version", DOCTEST_VERSION_STR);
 
     // only the consequential ones (TODO: filters)
     xml.scopedElement("Options")
-            .writeAttribute("order_by", opt.order_by.c_str())
-            .writeAttribute("rand_seed", opt.rand_seed)
-            .writeAttribute("first", opt.first)
-            .writeAttribute("last", opt.last)
-            .writeAttribute("abort_after", opt.abort_after)
-            .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
-            .writeAttribute("case_sensitive", opt.case_sensitive)
-            .writeAttribute("no_throw", opt.no_throw)
-            .writeAttribute("no_skip", opt.no_skip);
+        .writeAttribute("order_by", opt.order_by.c_str())
+        .writeAttribute("rand_seed", opt.rand_seed)
+        .writeAttribute("first", opt.first)
+        .writeAttribute("last", opt.last)
+        .writeAttribute("abort_after", opt.abort_after)
+        .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+        .writeAttribute("case_sensitive", opt.case_sensitive)
+        .writeAttribute("no_throw", opt.no_throw)
+        .writeAttribute("no_skip", opt.no_skip);
 }
 
-void XmlReporter::test_run_end(const TestRunStats& p) {
-    if(tc) // the TestSuite tag - only if there has been at least 1 test case
+void XmlReporter::test_run_end(const TestRunStats &p) {
+    if (tc) // the TestSuite tag - only if there has been at least 1 test case
         xml.endElement();
 
     xml.scopedElement("OverallResultsAsserts")
-            .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
-            .writeAttribute("failures", p.numAssertsFailed);
+        .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+        .writeAttribute("failures", p.numAssertsFailed);
 
     xml.startElement("OverallResultsTestCases")
-            .writeAttribute("successes",
-                            p.numTestCasesPassingFilters - p.numTestCasesFailed)
-            .writeAttribute("failures", p.numTestCasesFailed);
-    if(opt.no_skipped_summary == false)
+        .writeAttribute("successes", p.numTestCasesPassingFilters - p.numTestCasesFailed)
+        .writeAttribute("failures", p.numTestCasesFailed);
+    if (opt.no_skipped_summary == false)
         xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
     xml.endElement();
 
     xml.endElement();
 }
 
-void XmlReporter::test_case_start(const TestCaseData& in) {
+void XmlReporter::test_case_start(const TestCaseData &in) {
     test_case_start_impl(in);
     xml.ensureTagClosed();
 }
 
-void XmlReporter::test_case_reenter(const TestCaseData&) {}
+void XmlReporter::test_case_reenter(const TestCaseData &) {}
 
-void XmlReporter::test_case_end(const CurrentTestCaseStats& st) {
+void XmlReporter::test_case_end(const CurrentTestCaseStats &st) {
     xml.startElement("OverallResultsAsserts")
-            .writeAttribute("successes",
-                            st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-            .writeAttribute("failures", st.numAssertsFailedCurrentTest)
-            .writeAttribute("test_case_success", st.testCaseSuccess);
-    if(opt.duration)
+        .writeAttribute("successes", st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+        .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+        .writeAttribute("test_case_success", st.testCaseSuccess);
+    if (opt.duration)
         xml.writeAttribute("duration", st.seconds);
-    if(tc->m_expected_failures)
+    if (tc->m_expected_failures)
         xml.writeAttribute("expected_failures", tc->m_expected_failures);
     xml.endElement();
 
     xml.endElement();
 }
 
-void XmlReporter::test_case_exception(const TestCaseException& e) {
+void XmlReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
 
-    xml.scopedElement("Exception")
-            .writeAttribute("crash", e.is_crash)
-            .writeText(e.error_string.c_str());
+    xml.scopedElement("Exception").writeAttribute("crash", e.is_crash).writeText(e.error_string.c_str());
 }
 
-void XmlReporter::subcase_start(const SubcaseSignature& in) {
+void XmlReporter::subcase_start(const SubcaseSignature &in) {
     xml.startElement("SubCase")
-            .writeAttribute("name", in.m_name)
-            .writeAttribute("filename", skipPathFromFilename(in.m_file))
-            .writeAttribute("line", line(in.m_line));
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file))
+        .writeAttribute("line", line(in.m_line));
     xml.ensureTagClosed();
 }
 
-void XmlReporter::subcase_end() { xml.endElement(); }
+void XmlReporter::subcase_end() {
+    xml.endElement();
+}
 
-void XmlReporter::log_assert(const AssertData& rb) {
-    if(!rb.m_failed && !opt.success)
+void XmlReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed && !opt.success)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     xml.startElement("Expression")
-            .writeAttribute("success", !rb.m_failed)
-            .writeAttribute("type", assertString(rb.m_at))
-            .writeAttribute("filename", skipPathFromFilename(rb.m_file))
-            .writeAttribute("line", line(rb.m_line));
+        .writeAttribute("success", !rb.m_failed)
+        .writeAttribute("type", assertString(rb.m_at))
+        .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+        .writeAttribute("line", line(rb.m_line));
 
     xml.scopedElement("Original").writeText(rb.m_expr);
 
-    if(rb.m_threw)
+    if (rb.m_threw)
         xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
 
-    if(rb.m_at & assertType::is_throws_as)
+    if (rb.m_at & assertType::is_throws_as)
         xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-    if(rb.m_at & assertType::is_throws_with)
+    if (rb.m_at & assertType::is_throws_with)
         xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
-    if((rb.m_at & assertType::is_normal) && !rb.m_threw)
+    if ((rb.m_at & assertType::is_normal) && !rb.m_threw)
         xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
     log_contexts();
@@ -7323,13 +7532,13 @@ void XmlReporter::log_assert(const AssertData& rb) {
     xml.endElement();
 }
 
-void XmlReporter::log_message(const MessageData& mb) {
+void XmlReporter::log_message(const MessageData &mb) {
     DOCTEST_LOCK_MUTEX(mutex)
 
     xml.startElement("Message")
-            .writeAttribute("type", failureString(mb.m_severity))
-            .writeAttribute("filename", skipPathFromFilename(mb.m_file))
-            .writeAttribute("line", line(mb.m_line));
+        .writeAttribute("type", failureString(mb.m_severity))
+        .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+        .writeAttribute("line", line(mb.m_line));
 
     xml.scopedElement("Text").writeText(mb.m_string.c_str());
 
@@ -7338,8 +7547,8 @@ void XmlReporter::log_message(const MessageData& mb) {
     xml.endElement();
 }
 
-void XmlReporter::test_case_skipped(const TestCaseData& in) {
-    if(opt.no_skipped_summary == false) {
+void XmlReporter::test_case_skipped(const TestCaseData &in) {
+    if (opt.no_skipped_summary == false) {
         test_case_start_impl(in);
         xml.writeAttribute("skipped", "true");
         xml.endElement();
@@ -7371,33 +7580,31 @@ void FatalConditionHandler::freeAltStackMem() {}
 // Windows can easily distinguish between SO and SigSegV,
 // but SigInt, SigTerm, etc are handled differently.
 SignalDefs signalDefs[] = {
-        {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),
-          "SIGILL - Illegal instruction signal"},
-        {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
-        {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION),
-          "SIGSEGV - Segmentation violation signal"},
-        {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
+    {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION), "SIGILL - Illegal instruction signal"},
+    {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
+    {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION), "SIGSEGV - Segmentation violation signal"},
+    {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
 };
 
 LONG CALLBACK FatalConditionHandler::handleException(PEXCEPTION_POINTERS ExceptionInfo) {
-    // Multiple threads may enter this filter/handler at once. We want the error message to be printed on the
-    // console just once no matter how many threads have crashed.
+    // Multiple threads may enter this filter/handler at once. We want the error message to be
+    // printed on the console just once no matter how many threads have crashed.
     DOCTEST_DECLARE_STATIC_MUTEX(mutex)
     static bool execute = true;
     {
         DOCTEST_LOCK_MUTEX(mutex)
-        if(execute) {
+        if (execute) {
             bool reported = false;
-            for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+            for (size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+                if (ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
                     reportFatal(signalDefs[i].name);
                     reported = true;
                     break;
                 }
             }
-            if(reported == false)
+            if (reported == false)
                 reportFatal("Unhandled SEH exception caught");
-            if(isDebuggerActive() && !g_cs->no_breaks)
+            if (isDebuggerActive() && !g_cs->no_breaks)
                 DOCTEST_BREAK_INTO_DEBUGGER();
         }
         execute = false;
@@ -7427,7 +7634,7 @@ FatalConditionHandler::FatalConditionHandler() {
     original_terminate_handler = std::get_terminate();
     std::set_terminate([]() DOCTEST_NOEXCEPT {
         reportFatal("Terminate handler called");
-        if(isDebuggerActive() && !g_cs->no_breaks)
+        if (isDebuggerActive() && !g_cs->no_breaks)
             DOCTEST_BREAK_INTO_DEBUGGER();
         std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
     });
@@ -7437,9 +7644,9 @@ FatalConditionHandler::FatalConditionHandler() {
     // - an exception is thrown from a destructor FROM A DIFFERENT THREAD
     // - an uncaught exception is thrown FROM A DIFFERENT THREAD
     prev_sigabrt_handler = std::signal(SIGABRT, [](int signal) DOCTEST_NOEXCEPT {
-        if(signal == SIGABRT) {
+        if (signal == SIGABRT) {
             reportFatal("SIGABRT - Abort (abnormal termination) signal");
-            if(isDebuggerActive() && !g_cs->no_breaks)
+            if (isDebuggerActive() && !g_cs->no_breaks)
                 DOCTEST_BREAK_INTO_DEBUGGER();
             std::exit(EXIT_FAILURE);
         }
@@ -7449,8 +7656,9 @@ FatalConditionHandler::FatalConditionHandler() {
     // specifically from UnitTest::Run() inside of gtest.cc
 
     // the user does not want to see pop-up dialogs about crashes
-    prev_error_mode_1 = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
-                                      SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    prev_error_mode_1 = SetErrorMode(
+        SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX
+    );
     // This forces the abort message to go to stderr in all circumstances.
     prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
     // In the debug version, Visual Studio pops up a separate dialog
@@ -7465,7 +7673,7 @@ FatalConditionHandler::FatalConditionHandler() {
 }
 
 void FatalConditionHandler::reset() {
-    if(isSet) {
+    if (isSet) {
         // Unregister handler and restore the old guarantee
         SetUnhandledExceptionFilter(previousTop);
         SetThreadStackGuarantee(&guaranteeSize);
@@ -7480,14 +7688,16 @@ void FatalConditionHandler::reset() {
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
 
-UINT         FatalConditionHandler::prev_error_mode_1;
-int          FatalConditionHandler::prev_error_mode_2;
+UINT FatalConditionHandler::prev_error_mode_1;
+int FatalConditionHandler::prev_error_mode_2;
 unsigned int FatalConditionHandler::prev_abort_behavior;
-int          FatalConditionHandler::prev_report_mode;
-_HFILE       FatalConditionHandler::prev_report_file;
-void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
+int FatalConditionHandler::prev_report_mode;
+_HFILE FatalConditionHandler::prev_report_file;
+void(DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
 std::terminate_handler FatalConditionHandler::original_terminate_handler;
 bool FatalConditionHandler::isSet = false;
 ULONG FatalConditionHandler::guaranteeSize = 0;
@@ -7495,22 +7705,23 @@ LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
-SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
-                            {SIGILL, "SIGILL - Illegal instruction signal"},
-                            {SIGFPE, "SIGFPE - Floating point error signal"},
-                            {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-                            {SIGTERM, "SIGTERM - Termination request signal"},
-                            {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+SignalDefs signalDefs[] = {
+    {SIGINT, "SIGINT - Terminal interrupt signal"},
+    {SIGILL, "SIGILL - Illegal instruction signal"},
+    {SIGFPE, "SIGFPE - Floating point error signal"},
+    {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+    {SIGTERM, "SIGTERM - Termination request signal"},
+    {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}
+};
 static_assert(
-  DOCTEST_COUNTOF(signalDefs) == DOCTEST_COUNTOF(FatalConditionHandler::oldSigActions),
-  "arrays should match in size"
+    DOCTEST_COUNTOF(signalDefs) == DOCTEST_COUNTOF(FatalConditionHandler::oldSigActions), "arrays should match in size"
 );
 
 void FatalConditionHandler::handleSignal(int sig) {
-    const char* name = "<unknown signal>";
-    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-        SignalDefs& def = signalDefs[i];
-        if(sig == def.id) {
+    const char *name = "<unknown signal>";
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        SignalDefs &def = signalDefs[i];
+        if (sig == def.id) {
             name = def.name;
             break;
         }
@@ -7531,24 +7742,26 @@ void FatalConditionHandler::freeAltStackMem() {
 FatalConditionHandler::FatalConditionHandler() {
     isSet = true;
     stack_t sigStack;
-    sigStack.ss_sp    = altStackMem;
-    sigStack.ss_size  = altStackSize;
+    sigStack.ss_sp = altStackMem;
+    sigStack.ss_size = altStackSize;
     sigStack.ss_flags = 0;
     sigaltstack(&sigStack, &oldSigStack);
     struct sigaction sa = {};
-    sa.sa_handler       = handleSignal;
-    sa.sa_flags         = SA_ONSTACK;
-    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+    sa.sa_handler = handleSignal;
+    sa.sa_flags = SA_ONSTACK;
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
         sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
 
 void FatalConditionHandler::reset() {
-    if(isSet) {
+    if (isSet) {
         // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-        for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
             sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
         }
         // Return the old stack
@@ -7557,11 +7770,11 @@ void FatalConditionHandler::reset() {
     }
 }
 
-bool             FatalConditionHandler::isSet = false;
+bool FatalConditionHandler::isSet = false;
 struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-stack_t          FatalConditionHandler::oldSigStack = {};
-size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
-char*            FatalConditionHandler::altStackMem = nullptr;
+stack_t FatalConditionHandler::oldSigStack = {};
+size_t FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
+char *FatalConditionHandler::altStackMem = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
@@ -7578,305 +7791,387 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_THREAD_LOCAL class
-    {
-        std::vector<std::streampos> stack;
-        std::stringstream           ss;
+DOCTEST_THREAD_LOCAL class {
+    std::vector<std::streampos> stack;
+    std::stringstream ss;
 
-    public:
-        std::ostream* push() {
-            stack.push_back(ss.tellp());
-            return &ss;
-        }
-
-        String pop() {
-            if (stack.empty())
-                DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
-
-            std::streampos pos = stack.back();
-            stack.pop_back();
-            unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
-            ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
-            return String(ss, sz);
-        }
-    } g_oss;
-
-    std::ostream* tlssPush() {
-        return g_oss.push();
+public:
+    std::ostream *push() {
+        stack.push_back(ss.tellp());
+        return &ss;
     }
 
-    String tlssPop() {
-        return g_oss.pop();
+    String pop() {
+        if (stack.empty())
+            DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
+
+        std::streampos pos = stack.back();
+        stack.pop_back();
+        unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
+        ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
+        return String(ss, sz);
     }
+} g_oss;
+
+std::ostream *tlssPush() {
+    return g_oss.push();
+}
+
+String tlssPop() {
+    return g_oss.pop();
+}
 
 } // namespace detail
 
-    // case insensitive strcmp
-    static int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
+// case insensitive strcmp
+static int stricmp(const char *a, const char *b) {
+    for (;; a++, b++) {
+        const int d = tolower(*a) - tolower(*b);
+        if (d != 0 || !*a)
+            return d;
     }
+}
 
-    char* String::allocate(size_type sz) {
-        if (sz <= last) {
-            buf[sz] = '\0';
-            setLast(last - sz);
-            return buf;
-        } else {
-            setOnHeap();
-            data.size = sz;
-            data.capacity = data.size + 1;
-            data.ptr = new char[data.capacity];
-            data.ptr[sz] = '\0';
-            return data.ptr;
-        }
+char *String::allocate(size_type sz) {
+    if (sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size = sz;
+        data.capacity = data.size + 1;
+        data.ptr = new char[data.capacity];
+        data.ptr[sz] = '\0';
+        return data.ptr;
     }
+}
 
-    void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-    void String::setLast(size_type in) noexcept { buf[last] = char(in); }
-    void String::setSize(size_type sz) noexcept {
-        if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
-        else { data.ptr[sz] = '\0'; data.size = sz; }
+void String::setOnHeap() noexcept {
+    *reinterpret_cast<unsigned char *>(&buf[last]) = 128;
+}
+
+void String::setLast(size_type in) noexcept {
+    buf[last] = char(in);
+}
+
+void String::setSize(size_type sz) noexcept {
+    if (isOnStack()) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+    } else {
+        data.ptr[sz] = '\0';
+        data.size = sz;
     }
+}
 
-    void String::copy(const String& other) {
-        if(other.isOnStack()) {
-            memcpy(buf, other.buf, len);
-        } else {
-            memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
-        }
+void String::copy(const String &other) {
+    if (other.isOnStack()) {
+        memcpy(buf, other.buf, len);
+    } else {
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
+}
 
-    String::String() noexcept {
-        buf[0] = '\0';
-        setLast();
-    }
+String::String() noexcept {
+    buf[0] = '\0';
+    setLast();
+}
 
-    String::~String() {
-        if(!isOnStack())
+String::~String() {
+    if (!isOnStack())
+        delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String(const char *in)
+    : String(in, strlen(in)) {}
+
+String::String(const char *in, size_type in_size) {
+    memcpy(allocate(in_size), in, in_size);
+}
+
+String::String(std::istream &in, size_type in_size) {
+    in.read(allocate(in_size), in_size);
+}
+
+String::String(const String &other) {
+    copy(other);
+}
+
+String &String::operator=(const String &other) {
+    if (this != &other) {
+        if (!isOnStack())
             delete[] data.ptr;
-    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-    String::String(const char* in)
-            : String(in, strlen(in)) {}
-
-    String::String(const char* in, size_type in_size) {
-        memcpy(allocate(in_size), in, in_size);
+        copy(other);
     }
 
-    String::String(std::istream& in, size_type in_size) {
-        in.read(allocate(in_size), in_size);
-    }
+    return *this;
+}
 
-    String::String(const String& other) { copy(other); }
-
-    String& String::operator=(const String& other) {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-
-            copy(other);
-        }
-
-        return *this;
-    }
-
-    String& String::operator+=(const String& other) {
-        const size_type my_old_size = size();
-        const size_type other_size  = other.size();
-        const size_type total_size  = my_old_size + other_size;
-        if(isOnStack()) {
-            if(total_size < len) {
-                // append to the current stack space
-                memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-                // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-                setLast(last - total_size);
-            } else {
-                // alloc new chunk
-                char* temp = new char[total_size + 1];
-                // copy current data to new location before writing in the union
-                memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-                // update data in union
-                setOnHeap();
-                data.size     = total_size;
-                data.capacity = data.size + 1;
-                data.ptr      = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+String &String::operator+=(const String &other) {
+    const size_type my_old_size = size();
+    const size_type other_size = other.size();
+    const size_type total_size = my_old_size + other_size;
+    if (isOnStack()) {
+        if (total_size < len) {
+            // append to the current stack space
+            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            setLast(last - total_size);
         } else {
-            if(data.capacity > total_size) {
-                // append to the current heap block
-                data.size = total_size;
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            } else {
-                // resize
-                data.capacity *= 2;
-                if(data.capacity <= total_size)
-                    data.capacity = total_size + 1;
-                // alloc new chunk
-                char* temp = new char[data.capacity];
-                // copy current data to new location before releasing it
-                memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-                // release old chunk
-                delete[] data.ptr;
-                // update the rest of the union members
-                data.size = total_size;
-                data.ptr  = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+            // alloc new chunk
+            char *temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size = total_size;
+            data.capacity = data.size + 1;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
-
-        return *this;
+    } else {
+        if (data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if (data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char *temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
     }
 
-    String::String(String&& other) noexcept {
+    return *this;
+}
+
+String::String(String &&other) noexcept {
+    memcpy(buf, other.buf, len);
+    other.buf[0] = '\0';
+    other.setLast();
+}
+
+String &String::operator=(String &&other) noexcept {
+    if (this != &other) {
+        if (!isOnStack())
+            delete[] data.ptr;
         memcpy(buf, other.buf, len);
         other.buf[0] = '\0';
         other.setLast();
     }
+    return *this;
+}
 
-    String& String::operator=(String&& other) noexcept {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-            memcpy(buf, other.buf, len);
-            other.buf[0] = '\0';
-            other.setLast();
-        }
-        return *this;
+char String::operator[](size_type i) const {
+    return const_cast<String *>(this)->operator[](i);
+}
+
+char &String::operator[](size_type i) {
+    if (isOnStack())
+        return reinterpret_cast<char *>(buf)[i];
+    return data.ptr[i];
+}
+
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
+String::size_type String::size() const {
+    if (isOnStack())
+        return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+}
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+String::size_type String::capacity() const {
+    if (isOnStack())
+        return len;
+    return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+    cnt = std::min(cnt, size() - pos);
+    char *cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const & {
+    cnt = std::min(cnt, size() - pos);
+    return String{c_str() + pos, cnt};
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char *begin = c_str();
+    const char *end = begin + size();
+    const char *it = begin + pos;
+    for (; it < end && *it != ch; it++) {}
+    if (it < end) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
+    }
+}
+
+String::size_type String::rfind(char ch, size_type pos) const {
+    if (size() == 0) {
+        return npos;
     }
 
-    char String::operator[](size_type i) const {
-        return const_cast<String*>(this)->operator[](i);
+    const char *begin = c_str();
+    const char *it = begin + std::min(pos, size() - 1);
+    for (; it >= begin && *it != ch; it--) {}
+    if (it >= begin) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char& String::operator[](size_type i) {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf)[i];
-        return data.ptr[i];
-    }
+int String::compare(const char *other, bool no_case) const {
+    if (no_case)
+        return doctest::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
 
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-    String::size_type String::size() const {
-        if(isOnStack())
-            return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
-        return data.size;
-    }
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+int String::compare(const String &other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
 
-    String::size_type String::capacity() const {
-        if(isOnStack())
-            return len;
-        return data.capacity;
-    }
+String operator+(const String &lhs, const String &rhs) {
+    return String(lhs) += rhs;
+}
 
-    String String::substr(size_type pos, size_type cnt) && {
-        cnt = std::min(cnt, size() - pos);
-        char* cptr = c_str();
-        memmove(cptr, cptr + pos, cnt);
-        setSize(cnt);
-        return std::move(*this);
-    }
+bool operator==(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) == 0;
+}
 
-    String String::substr(size_type pos, size_type cnt) const & {
-        cnt = std::min(cnt, size() - pos);
-        return String{ c_str() + pos, cnt };
-    }
+bool operator!=(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) != 0;
+}
 
-    String::size_type String::find(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* end = begin + size();
-        const char* it = begin + pos;
-        for (; it < end && *it != ch; it++) { }
-        if (it < end) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
+bool operator<(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) < 0;
+}
 
-    String::size_type String::rfind(char ch, size_type pos) const {
-        if (size() == 0) { return npos; }
+bool operator>(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) > 0;
+}
 
-        const char* begin = c_str();
-        const char* it = begin + std::min(pos, size() - 1);
-        for (; it >= begin && *it != ch; it--) { }
-        if (it >= begin) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
+bool operator<=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) < 0 : true;
+}
 
-    int String::compare(const char* other, bool no_case) const {
-        if(no_case)
-            return doctest::stricmp(c_str(), other);
-        return std::strcmp(c_str(), other);
-    }
+bool operator>=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) > 0 : true;
+}
 
-    int String::compare(const String& other, bool no_case) const {
-        return compare(other.c_str(), no_case);
-    }
-
-    String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
-
-    bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
-    bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
-    bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
-    bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
-    bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
-    bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-
-    std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+std::ostream &operator<<(std::ostream &s, const String &in) {
+    return s << in.c_str();
+}
 
 namespace detail {
 
-    void filldata<const void*>::fill(std::ostream* stream, const void* in) {
-        filldata<const volatile void*>::fill(stream, in);
-    }
+void filldata<const void *>::fill(std::ostream *stream, const void *in) {
+    filldata<const volatile void *>::fill(stream, in);
+}
 
-    void filldata<const volatile void*>::fill(std::ostream* stream, const volatile void* in) {
-        if (in) { *stream << in; }
-        else { *stream << "nullptr"; }
+void filldata<const volatile void *>::fill(std::ostream *stream, const volatile void *in) {
+    if (in) {
+        *stream << in;
+    } else {
+        *stream << "nullptr";
     }
+}
 
-    template <typename T>
-    String toStreamLit(T t) {
-        std::ostream* os = tlssPush();
-        os->operator<<(t);
-        return tlssPop();
-    }
+template <typename T>
+String toStreamLit(T t) {
+    std::ostream *os = tlssPush();
+    os->operator<<(t);
+    return tlssPop();
+}
 } // namespace detail
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
+String toString(const char *in) {
+    return String("\"") + (in ? in : "{null string}") + "\"";
+}
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-String toString(const std::string& in) { return in.c_str(); }
+String toString(const std::string &in) {
+    return in.c_str();
+}
 #endif // VS 2019
 
-String toString(const String& in) { return in; }
+String toString(const String &in) {
+    return in;
+}
 
-String toString(std::nullptr_t) { return "nullptr"; }
+String toString(std::nullptr_t) {
+    return "nullptr";
+}
 
-String toString(bool in) { return in ? "true" : "false"; }
+String toString(bool in) {
+    return in ? "true" : "false";
+}
 
-String toString(float in) { return detail::toStreamLit(in); }
-String toString(double in) { return detail::toStreamLit(in); }
-String toString(double long in) { return detail::toStreamLit(in); }
+String toString(float in) {
+    return detail::toStreamLit(in);
+}
+String toString(double in) {
+    return detail::toStreamLit(in);
+}
+String toString(double long in) {
+    return detail::toStreamLit(in);
+}
 
-String toString(char in) { return detail::toStreamLit(static_cast<signed>(in)); }
-String toString(char signed in) { return detail::toStreamLit(static_cast<signed>(in)); }
-String toString(char unsigned in) { return detail::toStreamLit(static_cast<unsigned>(in)); }
-String toString(short in) { return detail::toStreamLit(in); }
-String toString(short unsigned in) { return detail::toStreamLit(in); }
-String toString(signed in) { return detail::toStreamLit(in); }
-String toString(unsigned in) { return detail::toStreamLit(in); }
-String toString(long in) { return detail::toStreamLit(in); }
-String toString(long unsigned in) { return detail::toStreamLit(in); }
-String toString(long long in) { return detail::toStreamLit(in); }
-String toString(long long unsigned in) { return detail::toStreamLit(in); }
+String toString(char in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char signed in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char unsigned in) {
+    return detail::toStreamLit(static_cast<unsigned>(in));
+}
+String toString(short in) {
+    return detail::toStreamLit(in);
+}
+String toString(short unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(signed in) {
+    return detail::toStreamLit(in);
+}
+String toString(unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long unsigned in) {
+    return detail::toStreamLit(in);
+}
 
 } // namespace doctest
 
@@ -7889,144 +8184,155 @@ namespace doctest {
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(unsigned long long a, unsigned long long b) {
-        return (a << 5) + b;
-    }
+DOCTEST_NO_SANITIZE_INTEGER
+unsigned long long hash(unsigned long long a, unsigned long long b) {
+    return (a << 5) + b;
+}
 
-    // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-    DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(const char* str) {
-        unsigned long long hash = 5381;
-        char c;
-        while ((c = *str++))
-            hash = ((hash << 5) + hash) + c; // hash * 33 + c
-        return hash;
-    }
+// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+DOCTEST_NO_SANITIZE_INTEGER
+unsigned long long hash(const char *str) {
+    unsigned long long hash = 5381;
+    char c;
+    while ((c = *str++))
+        hash = ((hash << 5) + hash) + c; // hash * 33 + c
+    return hash;
+}
 
-    unsigned long long hash(const SubcaseSignature& sig) {
-        return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
-    }
+unsigned long long hash(const SubcaseSignature &sig) {
+    return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
+}
 
-    unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
-        unsigned long long running = 0;
-        auto end = sigs.begin() + count;
-        for (auto it = sigs.begin(); it != end; it++) {
-            running = hash(running, hash(*it));
-        }
-        return running;
+unsigned long long hash(const std::vector<SubcaseSignature> &sigs, size_t count) {
+    unsigned long long running = 0;
+    auto end = sigs.begin() + count;
+    for (auto it = sigs.begin(); it != end; it++) {
+        running = hash(running, hash(*it));
     }
+    return running;
+}
 
-    unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
-        unsigned long long running = 0;
-        for (const SubcaseSignature& sig : sigs) {
-            running = hash(running, hash(sig));
-        }
-        return running;
+unsigned long long hash(const std::vector<SubcaseSignature> &sigs) {
+    unsigned long long running = 0;
+    for (const SubcaseSignature &sig: sigs) {
+        running = hash(running, hash(sig));
     }
+    return running;
+}
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 
-    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-        return m_line == other.m_line
-            && std::strcmp(m_file, other.m_file) == 0
-            && m_name == other.m_name;
-    }
+bool SubcaseSignature::operator==(const SubcaseSignature &other) const {
+    return m_line == other.m_line && std::strcmp(m_file, other.m_file) == 0 && m_name == other.m_name;
+}
 
-    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        if(std::strcmp(m_file, other.m_file) != 0)
-            return std::strcmp(m_file, other.m_file) < 0;
-        return m_name.compare(other.m_name) < 0;
-    }
+bool SubcaseSignature::operator<(const SubcaseSignature &other) const {
+    if (m_line != other.m_line)
+        return m_line < other.m_line;
+    if (std::strcmp(m_file, other.m_file) != 0)
+        return std::strcmp(m_file, other.m_file) < 0;
+    return m_name.compare(other.m_name) < 0;
+}
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
-                return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
-                return true;
-        }
-        return false;
+bool Subcase::checkFilters() {
+    if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+        if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+            return true;
+        if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+            return true;
     }
+    return false;
+}
 
-    Subcase::Subcase(const String& name, const char* file, int line)
-            : m_signature({name, file, line}) {
+Subcase::Subcase(const String &name, const char *file, int line)
+    : m_signature({name, file, line}) {
+    if (!g_cs->reachedLeaf) {
+        if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size() ||
+            g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+            // Going down.
+            if (checkFilters()) {
+                return;
+            }
+
+            g_cs->subcaseStack.push_back(m_signature);
+            g_cs->currentSubcaseDepth++;
+            m_entered = true;
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+        }
+    } else {
+        if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+            // This subcase is reentered via control flow.
+            g_cs->currentSubcaseDepth++;
+            m_entered = true;
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+        } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+                   g_cs->fullyTraversedSubcases.find(
+                       hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
+                   ) == g_cs->fullyTraversedSubcases.end()) {
+            if (checkFilters()) {
+                return;
+            }
+            // This subcase is part of the one to be executed next.
+            g_cs->nextSubcaseStack.clear();
+            g_cs->nextSubcaseStack.insert(
+                g_cs->nextSubcaseStack.end(),
+                g_cs->subcaseStack.begin(),
+                g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth
+            );
+            g_cs->nextSubcaseStack.push_back(m_signature);
+        }
+    }
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+Subcase::~Subcase() {
+    if (m_entered) {
+        g_cs->currentSubcaseDepth--;
+
         if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
-                // Going down.
-                if (checkFilters()) { return; }
-
-                g_cs->subcaseStack.push_back(m_signature);
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            }
-        } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
-                // This subcase is reentered via control flow.
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
-                // This subcase is part of the one to be executed next.
-                g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
-                g_cs->nextSubcaseStack.push_back(m_signature);
-            }
+            // Leaf.
+            g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+            g_cs->nextSubcaseStack.clear();
+            g_cs->reachedLeaf = true;
+        } else if (g_cs->nextSubcaseStack.empty()) {
+            // All children are finished.
+            g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
         }
-    }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
-    Subcase::~Subcase() {
-        if (m_entered) {
-            g_cs->currentSubcaseDepth--;
-
-            if (!g_cs->reachedLeaf) {
-                // Leaf.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-                g_cs->nextSubcaseStack.clear();
-                g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
-                // All children are finished.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-            }
-
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-            if(std::uncaught_exceptions() > 0
-    #else
-            if(std::uncaught_exception()
-    #endif
-                && g_cs->shouldLogCurrentException) {
-                DOCTEST_ITERATE_THROUGH_REPORTERS(
-                        test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
-                g_cs->shouldLogCurrentException = false;
-            }
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+        if (std::uncaught_exceptions() > 0
+#else
+        if (std::uncaught_exception()
+#endif
+            && g_cs->shouldLogCurrentException) {
+            DOCTEST_ITERATE_THROUGH_REPORTERS(
+                test_case_exception,
+                {"exception thrown in subcase - will translate later "
+                 "when the whole test case has been exited (cannot "
+                 "translate while there is an active exception)",
+                 false}
+            );
+            g_cs->shouldLogCurrentException = false;
         }
+
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
+}
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    Subcase::operator bool() const { return m_entered; }
+Subcase::operator bool() const {
+    return m_entered;
+}
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
@@ -8042,54 +8348,55 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-std::set<TestCase>& getRegisteredTests() {
+std::set<TestCase> &getRegisteredTests() {
     static std::set<TestCase> data;
     return data;
 }
 
-TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                    const String& type, int template_id) {
-    m_file              = file;
-    m_line              = line;
-    m_name              = nullptr; // will be later overridden in operator*
-    m_test_suite        = test_suite.m_test_suite;
-    m_description       = test_suite.m_description;
-    m_skip              = test_suite.m_skip;
-    m_no_breaks         = test_suite.m_no_breaks;
-    m_no_output         = test_suite.m_no_output;
-    m_may_fail          = test_suite.m_may_fail;
-    m_should_fail       = test_suite.m_should_fail;
+TestCase::TestCase(
+    funcType test, const char *file, unsigned line, const TestSuite &test_suite, const String &type, int template_id
+) {
+    m_file = file;
+    m_line = line;
+    m_name = nullptr; // will be later overridden in operator*
+    m_test_suite = test_suite.m_test_suite;
+    m_description = test_suite.m_description;
+    m_skip = test_suite.m_skip;
+    m_no_breaks = test_suite.m_no_breaks;
+    m_no_output = test_suite.m_no_output;
+    m_may_fail = test_suite.m_may_fail;
+    m_should_fail = test_suite.m_should_fail;
     m_expected_failures = test_suite.m_expected_failures;
-    m_timeout           = test_suite.m_timeout;
+    m_timeout = test_suite.m_timeout;
 
-    m_test        = test;
-    m_type        = type;
+    m_test = test;
+    m_type = type;
     m_template_id = template_id;
 }
 
-TestCase::TestCase(const TestCase& other)
-        : TestCaseData() {
+TestCase::TestCase(const TestCase &other)
+    : TestCaseData() {
     *this = other;
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-TestCase& TestCase::operator=(const TestCase& other) {
+TestCase &TestCase::operator=(const TestCase &other) {
     TestCaseData::operator=(other);
-    m_test        = other.m_test;
-    m_type        = other.m_type;
+    m_test = other.m_test;
+    m_type = other.m_type;
     m_template_id = other.m_template_id;
-    m_full_name   = other.m_full_name;
+    m_full_name = other.m_full_name;
 
-    if(m_template_id != -1)
+    if (m_template_id != -1)
         m_name = m_full_name.c_str();
     return *this;
 }
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-TestCase& TestCase::operator*(const char* in) {
+TestCase &TestCase::operator*(const char *in) {
     m_name = in;
     // make a new name with an appended type for templated test case
-    if(m_template_id != -1) {
+    if (m_template_id != -1) {
         m_full_name = String(m_name) + "<" + m_type + ">";
         // redirect the name to point to the newly constructed full name
         m_name = m_full_name.c_str();
@@ -8097,21 +8404,21 @@ TestCase& TestCase::operator*(const char* in) {
     return *this;
 }
 
-bool TestCase::operator<(const TestCase& other) const {
+bool TestCase::operator<(const TestCase &other) const {
     // this will be used only to differentiate between test cases - not relevant for sorting
-    if(m_line != other.m_line)
+    if (m_line != other.m_line)
         return m_line < other.m_line;
     const int name_cmp = strcmp(m_name, other.m_name);
-    if(name_cmp != 0)
+    if (name_cmp != 0)
         return name_cmp < 0;
     const int file_cmp = m_file.compare(other.m_file);
-    if(file_cmp != 0)
+    if (file_cmp != 0)
         return file_cmp < 0;
     return m_template_id < other.m_template_id;
 }
 
 // used by the macros for registering tests
-int regTest(const TestCase& tc) {
+int regTest(const TestCase &tc) {
     getRegisteredTests().insert(tc);
     return 0;
 }
@@ -8130,13 +8437,13 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-TestSuite& TestSuite::operator*(const char* in) {
+TestSuite &TestSuite::operator*(const char *in) {
     m_test_suite = in;
     return *this;
 }
 
 // sets the current test suite
-int setTestSuite(const TestSuite& ts) {
+int setTestSuite(const TestSuite &ts) {
     doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
     return 0;
 }
@@ -8146,7 +8453,7 @@ int setTestSuite(const TestSuite& ts) {
 
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite
-doctest::detail::TestSuite& getCurrentTestSuite() {
+doctest::detail::TestSuite &getCurrentTestSuite() {
     static doctest::detail::TestSuite data{};
     return data;
 }
@@ -8164,11 +8471,13 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
-ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
+ticks_t getCurrentTicks() {
+    return DOCTEST_CONFIG_GETCURRENTTICKS();
+}
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
 ticks_t getCurrentTicks() {
-    static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
-    if(!hz.QuadPart) {
+    static LARGE_INTEGER hz = {{0}}, hzo = {{0}};
+    if (!hz.QuadPart) {
         QueryPerformanceFrequency(&hz);
         QueryPerformanceCounter(&hzo);
     }
@@ -8184,17 +8493,21 @@ ticks_t getCurrentTicks() {
 }
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-void Timer::start() { m_ticks = getCurrentTicks(); }
+void Timer::start() {
+    m_ticks = getCurrentTicks();
+}
 
 unsigned int Timer::getElapsedMicroseconds() const {
     return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
 }
 
-//unsigned int Timer::getElapsedMilliseconds() const {
-//    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
-//}
+// unsigned int Timer::getElapsedMilliseconds() const {
+//     return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
+// }
 
-double Timer::getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
+double Timer::getElapsedSeconds() const {
+    return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -8210,12 +8523,11 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // clang-format off
-
 // =================================================================================================
-// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h/cpp
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.cpp
 // This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
 // =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
 
 using uchar = unsigned char;
 
@@ -8490,11 +8802,10 @@ using uchar = unsigned char;
         }
     }
 
+/* clang-format on */ /* NOLINTEND */
 // =================================================================================================
 // End of copy-pasted code from Catch
 // =================================================================================================
-
-    // clang-format on
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/extensions/doctest_mpi.h
+++ b/doctest/extensions/doctest_mpi.h
@@ -13,75 +13,77 @@ namespace doctest {
 // we need a sub-communicator of N procs to execute it.
 // It is then registered here and can be re-used
 // by other tests that requires a sub-comm of the same size
-std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
+std::unordered_map<int, mpi_sub_comm> sub_comms_by_size;
 
 // Record if at least one MPI_TEST_CASE was registered "skipped"
 // because there is not enought procs to execute it
 int nb_test_cases_skipped_insufficient_procs = 0;
 
-
 std::string thread_level_to_string(int thread_lvl);
 int mpi_init_thread(int argc, char *argv[], int required_thread_support);
 void mpi_finalize();
-
 
 // Can be safely called before MPI_Init()
 //   This is needed for MPI_TEST_CASE because we use doctest::skip()
 //   to prevent execution of tests where there is not enough procs,
 //   but doctest::skip() is called during test registration, that is, before main(), and hence before MPI_Init()
 int mpi_comm_world_size() {
-  #if defined(OPEN_MPI)
-    const char* size_str = std::getenv("OMPI_COMM_WORLD_SIZE");
-  #elif defined(I_MPI_VERSION) || defined(MPI_VERSION) // Intel MPI + MPICH (at least)
-    const char* size_str = std::getenv("PMI_SIZE"); // see https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
-  #else
-    #error "Unknown MPI implementation: please submit an issue or a PR to doctest. Meanwhile, you can look at the output of e.g. `mpirun -np 3 env` to search for an environnement variable that contains the size of MPI_COMM_WORLD and extend this code accordingly"
-  #endif
-  if (size_str==nullptr) return 1; // not launched with mpirun/mpiexec, so assume only one process
-  return std::stoi(size_str);
+#if defined(OPEN_MPI)
+    const char *size_str = std::getenv("OMPI_COMM_WORLD_SIZE");
+#elif defined(I_MPI_VERSION) || defined(MPI_VERSION) // Intel MPI + MPICH (at least)
+    const char *size_str = std::getenv(
+        "PMI_SIZE" // https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
+    );
+#else
+#error "Unknown MPI implementation: please submit an issue or a PR to doctest. Meanwhile, you can look at the output\
+ of e.g. `mpirun -np 3 env` to search for an environnement variable that contains the size of MPI_COMM_WORLD and extend\
+ this code accordingly"
+#endif
+    if (size_str == nullptr)
+        return 1; // not launched with mpirun/mpiexec, so assume only one process
+    return std::stoi(size_str);
 }
 
 // Record size of MPI_COMM_WORLD with mpi_comm_world_size()
 int world_size_before_init = mpi_comm_world_size();
 
-
 std::string thread_level_to_string(int thread_lvl) {
-  switch (thread_lvl) {
-    case MPI_THREAD_SINGLE:     return "MPI_THREAD_SINGLE";
-    case MPI_THREAD_FUNNELED:   return "MPI_THREAD_FUNNELED";
-    case MPI_THREAD_SERIALIZED: return "MPI_THREAD_SERIALIZED";
-    case MPI_THREAD_MULTIPLE:   return "MPI_THREAD_MULTIPLE";
-    default: return "Invalid MPI thread level";
-  }
+    switch (thread_lvl) {
+        case MPI_THREAD_SINGLE:     return "MPI_THREAD_SINGLE";
+        case MPI_THREAD_FUNNELED:   return "MPI_THREAD_FUNNELED";
+        case MPI_THREAD_SERIALIZED: return "MPI_THREAD_SERIALIZED";
+        case MPI_THREAD_MULTIPLE:   return "MPI_THREAD_MULTIPLE";
+        default:                    return "Invalid MPI thread level";
+    }
 }
 int mpi_init_thread(int argc, char *argv[], int required_thread_support) {
-  int provided_thread_support;
-  MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
+    int provided_thread_support;
+    MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
 
-  int world_size;
-  MPI_Comm_size(MPI_COMM_WORLD,&world_size);
-  if (world_size_before_init != world_size) {
-    DOCTEST_INTERNAL_ERROR(
-      "doctest found "+std::to_string(world_size_before_init)+" MPI processes before `MPI_Init_thread`,"
-      " but MPI_COMM_WORLD is actually of size "+std::to_string(world_size)+".\n"
-      "This is most likely due to your MPI implementation not being well supported by doctest. Please report this issue on GitHub"
-    );
-  }
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    if (world_size_before_init != world_size) {
+        DOCTEST_INTERNAL_ERROR(
+            "doctest found " + std::to_string(world_size_before_init) + " MPI processes before `MPI_Init_thread`," +
+            " but MPI_COMM_WORLD is actually of size " + std::to_string(world_size) + ".\n" +
+            "This is most likely due to your MPI implementation not being well supported by doctest. Please report "
+            "this issue on GitHub"
+        );
+    }
 
-  if (provided_thread_support!=required_thread_support) {
-    std::cout <<
-        "WARNING: " + thread_level_to_string(required_thread_support) + " was asked, "
-      + "but only " + thread_level_to_string(provided_thread_support) + " is provided by the MPI library\n";
-  }
-  return provided_thread_support;
+    if (provided_thread_support != required_thread_support) {
+        std::cout << "WARNING: " + thread_level_to_string(required_thread_support) + " was asked, but only " +
+                         thread_level_to_string(provided_thread_support) + " is provided by the MPI library\n";
+    }
+    return provided_thread_support;
 }
 void mpi_finalize() {
-  // We need to destroy all created sub-communicators before calling MPI_Finalize()
-  doctest::sub_comms_by_size.clear();
-  MPI_Finalize();
+    // We need to destroy all created sub-communicators before calling MPI_Finalize()
+    doctest::sub_comms_by_size.clear();
+    MPI_Finalize();
 }
 
-} // doctest
+} // namespace doctest
 
 #else // DOCTEST_CONFIG_IMPLEMENT
 
@@ -91,7 +93,7 @@ void mpi_finalize() {
 
 namespace doctest {
 
-extern std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
+extern std::unordered_map<int, mpi_sub_comm> sub_comms_by_size;
 extern int nb_test_cases_skipped_insufficient_procs;
 extern int world_size_before_init;
 int mpi_comm_world_size();
@@ -99,70 +101,83 @@ int mpi_comm_world_size();
 int mpi_init_thread(int argc, char *argv[], int required_thread_support);
 void mpi_finalize();
 
-template<int nb_procs, class F>
+template <int nb_procs, class F>
 void execute_mpi_test_case(F func) {
-  auto it = sub_comms_by_size.find(nb_procs);
-  if (it==end(sub_comms_by_size)) {
-    bool was_emplaced = false;
-    std::tie(it,was_emplaced) = sub_comms_by_size.emplace(std::make_pair(nb_procs,mpi_sub_comm(nb_procs)));
-    assert(was_emplaced);
-  }
-  const mpi_sub_comm& sub = it->second;
-  if (sub.comm != MPI_COMM_NULL) {
-    func(sub.rank,nb_procs,sub.comm,std::integral_constant<int,nb_procs>{});
-  };
+    auto it = sub_comms_by_size.find(nb_procs);
+    if (it == end(sub_comms_by_size)) {
+        bool was_emplaced = false;
+        std::tie(it, was_emplaced) = sub_comms_by_size.emplace(std::make_pair(nb_procs, mpi_sub_comm(nb_procs)));
+        assert(was_emplaced);
+    }
+    const mpi_sub_comm &sub = it->second;
+    if (sub.comm != MPI_COMM_NULL) {
+        func(sub.rank, nb_procs, sub.comm, std::integral_constant<int, nb_procs>{});
+    };
 }
 
-inline bool
-insufficient_procs(int test_nb_procs) {
-  static const int world_size = mpi_comm_world_size();
-  bool insufficient = test_nb_procs>world_size;
-  if (insufficient) {
-    ++nb_test_cases_skipped_insufficient_procs;
-  }
-  return insufficient;
+inline bool insufficient_procs(int test_nb_procs) {
+    static const int world_size = mpi_comm_world_size();
+    bool insufficient = test_nb_procs > world_size;
+    if (insufficient) {
+        ++nb_test_cases_skipped_insufficient_procs;
+    }
+    return insufficient;
 }
 
-} // doctest
+} // namespace doctest
 
+#define DOCTEST_MPI_GEN_ASSERTION(rank_to_test, assertion, ...)                                                        \
+    static_assert(                                                                                                     \
+        rank_to_test < test_nb_procs_as_int_constant.value,                                                            \
+        "Trying to assert on a rank greater than the number of procs of the test!"                                     \
+    );                                                                                                                 \
+    if (rank_to_test == test_rank)                                                                                     \
+    assertion(__VA_ARGS__)
 
-#define DOCTEST_MPI_GEN_ASSERTION(rank_to_test, assertion, ...) \
-  static_assert(rank_to_test<test_nb_procs_as_int_constant.value,"Trying to assert on a rank greater than the number of procs of the test!"); \
-  if(rank_to_test == test_rank) assertion(__VA_ARGS__)
+#define DOCTEST_MPI_WARN(rank_to_test, ...) DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_WARN, __VA_ARGS__)
+#define DOCTEST_MPI_CHECK(rank_to_test, ...) DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_CHECK, __VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE(rank_to_test, ...) DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_REQUIRE, __VA_ARGS__)
+#define DOCTEST_MPI_WARN_FALSE(rank_to_test, ...)                                                                      \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_WARN_FALSE, __VA_ARGS__)
+#define DOCTEST_MPI_CHECK_FALSE(rank_to_test, ...)                                                                     \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_CHECK_FALSE, __VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE_FALSE(rank_to_test, ...)                                                                   \
+    DOCTEST_MPI_GEN_ASSERTION(rank_to_test, DOCTEST_REQUIRE_FALSE, __VA_ARGS__)
 
-#define DOCTEST_MPI_WARN(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN,__VA_ARGS__)
-#define DOCTEST_MPI_CHECK(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK,__VA_ARGS__)
-#define DOCTEST_MPI_REQUIRE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE,__VA_ARGS__)
-#define DOCTEST_MPI_WARN_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN_FALSE,__VA_ARGS__)
-#define DOCTEST_MPI_CHECK_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK_FALSE,__VA_ARGS__)
-#define DOCTEST_MPI_REQUIRE_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE_FALSE,__VA_ARGS__)
-
-#define DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,func) \
-  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs>); \
-  TEST_CASE(name * doctest::description("MPI_TEST_CASE") * doctest::skip(doctest::insufficient_procs(nb_procs))) { \
-    doctest::execute_mpi_test_case<nb_procs>(func); \
-  } \
-  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs> test_nb_procs_as_int_constant)
+#define DOCTEST_CREATE_MPI_TEST_CASE(name, nb_procs, func)                                                             \
+    static void func(                                                                                                  \
+        DOCTEST_UNUSED int test_rank,                                                                                  \
+        DOCTEST_UNUSED int test_nb_procs,                                                                              \
+        DOCTEST_UNUSED MPI_Comm test_comm,                                                                             \
+        DOCTEST_UNUSED std::integral_constant<int, nb_procs>                                                           \
+    );                                                                                                                 \
+    TEST_CASE(name *doctest::description("MPI_TEST_CASE") * doctest::skip(doctest::insufficient_procs(nb_procs))) {    \
+        doctest::execute_mpi_test_case<nb_procs>(func);                                                                \
+    }                                                                                                                  \
+    static void func(                                                                                                  \
+        DOCTEST_UNUSED int test_rank,                                                                                  \
+        DOCTEST_UNUSED int test_nb_procs,                                                                              \
+        DOCTEST_UNUSED MPI_Comm test_comm,                                                                             \
+        DOCTEST_UNUSED std::integral_constant<int, nb_procs> test_nb_procs_as_int_constant                             \
+    )
   // DOC: test_rank, test_nb_procs, and test_comm are available UNDER THESE SPECIFIC NAMES in the body of the unit test
   // DOC: test_nb_procs_as_int_constant is equal to test_nb_procs, but as a compile time value
   //          (used in CHECK-like macros to assert the checked rank exists)
 
-#define DOCTEST_MPI_TEST_CASE(name,nb_procs) \
-  DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,DOCTEST_ANONYMOUS(DOCTEST_MPI_FUNC))
-
+#define DOCTEST_MPI_TEST_CASE(name, nb_procs)                                                                          \
+    DOCTEST_CREATE_MPI_TEST_CASE(name, nb_procs, DOCTEST_ANONYMOUS(DOCTEST_MPI_FUNC))
 
 // == SHORT VERSIONS OF THE MACROS
 #if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
-#define MPI_WARN           DOCTEST_MPI_WARN
-#define MPI_CHECK          DOCTEST_MPI_CHECK
-#define MPI_REQUIRE        DOCTEST_MPI_REQUIRE
-#define MPI_WARN_FALSE     DOCTEST_MPI_WARN_FALSE
-#define MPI_CHECK_FALSE    DOCTEST_MPI_CHECK_FALSE
-#define MPI_REQUIRE_FALSE  DOCTEST_MPI_REQUIRE_FALSE
+#define MPI_WARN DOCTEST_MPI_WARN
+#define MPI_CHECK DOCTEST_MPI_CHECK
+#define MPI_REQUIRE DOCTEST_MPI_REQUIRE
+#define MPI_WARN_FALSE DOCTEST_MPI_WARN_FALSE
+#define MPI_CHECK_FALSE DOCTEST_MPI_CHECK_FALSE
+#define MPI_REQUIRE_FALSE DOCTEST_MPI_REQUIRE_FALSE
 
-#define MPI_TEST_CASE      DOCTEST_MPI_TEST_CASE
+#define MPI_TEST_CASE DOCTEST_MPI_TEST_CASE
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
-
 
 #endif // DOCTEST_CONFIG_IMPLEMENT
 

--- a/doctest/extensions/doctest_util.h
+++ b/doctest/extensions/doctest_util.h
@@ -24,13 +24,13 @@
 
 namespace doctest {
 
-    inline void applyCommandLine(doctest::Context& ctx, const std::vector<std::string>& args) {
-        auto doctest_args = std::make_unique<const char*[]>(args.size());
-        for (size_t i = 0; i < args.size(); ++i) {
-            doctest_args[i] = args[i].c_str();
-        }
-        ctx.applyCommandLine(args.size(), doctest_args.get());
+inline void applyCommandLine(doctest::Context &ctx, const std::vector<std::string> &args) {
+    auto doctest_args = std::make_unique<const char *[]>(args.size());
+    for (size_t i = 0; i < args.size(); ++i) {
+        doctest_args[i] = args[i].c_str();
     }
+    ctx.applyCommandLine(args.size(), doctest_args.get());
+}
 
 } // namespace doctest
 

--- a/doctest/extensions/mpi_reporter.h
+++ b/doctest/extensions/mpi_reporter.h
@@ -6,7 +6,6 @@
 #include <string>
 #include "mpi.h"
 
-
 #include <vector>
 #include <mutex>
 
@@ -19,38 +18,38 @@ namespace {
 
 // https://stackoverflow.com/a/11826666/1583122
 struct NullBuffer : std::streambuf {
-  int overflow(int c) { return c; }
+    int overflow(int c) {
+        return c;
+    }
 };
 class NullStream : public std::ostream {
-  public:
+public:
     NullStream()
-      : std::ostream(&nullBuff)
-    {}
-  private:
+        : std::ostream(&nullBuff) {}
+
+private:
     NullBuffer nullBuff = {};
 };
 static NullStream nullStream;
 
-
 /* \brief Extends the ConsoleReporter of doctest
  *        Each process writes its results to its own file
- *        Intended to be used when a test assertion fails and the user wants to know exactly what happens on which process
+ *        Intended to be used when a test assertion fails and the user wants to know exactly what happens on which
+ * process
  */
 struct MpiFileReporter : public ConsoleReporter {
-  std::ofstream logfile_stream = {};
+    std::ofstream logfile_stream = {};
 
-  MpiFileReporter(const ContextOptions& co)
-    : ConsoleReporter(co,logfile_stream)
-  {
-    int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MpiFileReporter(const ContextOptions &co)
+        : ConsoleReporter(co, logfile_stream) {
+        int rank = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    std::string logfile_name = "doctest_" + std::to_string(rank) + ".log";
+        std::string logfile_name = "doctest_" + std::to_string(rank) + ".log";
 
-    logfile_stream = std::ofstream(logfile_name.c_str(), std::fstream::out);
-  }
+        logfile_stream = std::ofstream(logfile_name.c_str(), std::fstream::out);
+    }
 };
-
 
 /* \brief Extends the ConsoleReporter of doctest
  *        Allows to manage the execution of tests in a parallel framework
@@ -58,214 +57,209 @@ struct MpiFileReporter : public ConsoleReporter {
  */
 struct MpiConsoleReporter : public ConsoleReporter {
 private:
-  static std::ostream& replace_by_null_if_not_rank_0(std::ostream* os) {
-    int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank==0) {
-      return *os;
-    } else {
-      return nullStream;
+    static std::ostream &replace_by_null_if_not_rank_0(std::ostream *os) {
+        int rank = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if (rank == 0) {
+            return *os;
+        } else {
+            return nullStream;
+        }
     }
-  }
-  std::vector<std::pair<std::string, int>> m_failure_str_queue = {};
+    std::vector<std::pair<std::string, int>> m_failure_str_queue = {};
+
 public:
-  MpiConsoleReporter(const ContextOptions& co)
-    : ConsoleReporter(co,replace_by_null_if_not_rank_0(co.cout))
-  {}
+    MpiConsoleReporter(const ContextOptions &co)
+        : ConsoleReporter(co, replace_by_null_if_not_rank_0(co.cout)) {}
 
-  std::string file_line_to_string(const char* file, int line,
-                                  const char* tail = ""){
-    std::stringstream ss;
-    ss << skipPathFromFilename(file)
-    << (opt.gnu_file_line ? ":" : "(")
-    << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-    << (opt.gnu_file_line ? ":" : "):") << tail;
-    return ss.str();
-  }
-
-  void test_run_end(const TestRunStats& p) override {
-    ConsoleReporter::test_run_end(p);
-
-    const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-
-    // -----------------------------------------------------
-    // > Gather information in rank 0
-    int n_rank, rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &n_rank);
-
-    int g_numAsserts         = 0;
-    int g_numAssertsFailed   = 0;
-    int g_numTestCasesFailed = 0;
-
-    MPI_Reduce(&p.numAsserts        , &g_numAsserts        , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Reduce(&p.numAssertsFailed  , &g_numAssertsFailed  , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Reduce(&p.numTestCasesFailed, &g_numTestCasesFailed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-
-    std::vector<int> numAssertsFailedByRank;
-    if(rank == 0){
-      numAssertsFailedByRank.resize(static_cast<std::size_t>(n_rank));
+    std::string file_line_to_string(const char *file, int line, const char *tail = "") {
+        std::stringstream ss;
+        ss << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+           << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+           << (opt.gnu_file_line ? ":" : "):") << tail;
+        return ss.str();
     }
 
-    MPI_Gather(&p.numAssertsFailed, 1, MPI_INT, numAssertsFailedByRank.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+    void test_run_end(const TestRunStats &p) override {
+        ConsoleReporter::test_run_end(p);
 
-    if(rank == 0) {
-      separator_to_stream();
-      s << Color::Cyan << "[doctest] " << Color::None << "assertions on all processes: " << std::setw(6)
-        << g_numAsserts << " | "
-        << ((g_numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-        << std::setw(6) << (g_numAsserts - g_numAssertsFailed) << " passed" << Color::None
-        << " | " << (g_numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
-        << g_numAssertsFailed << " failed" << Color::None << " |\n";
-      if (nb_test_cases_skipped_insufficient_procs>0) {
-        s << Color::Cyan << "[doctest] " << Color::Yellow << "WARNING: Skipped ";
-        if (nb_test_cases_skipped_insufficient_procs>1) {
-          s << nb_test_cases_skipped_insufficient_procs << " tests requiring more than ";
+        const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+
+        // -----------------------------------------------------
+        // > Gather information in rank 0
+        int n_rank, rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &n_rank);
+
+        int g_numAsserts = 0;
+        int g_numAssertsFailed = 0;
+        int g_numTestCasesFailed = 0;
+
+        MPI_Reduce(&p.numAsserts, &g_numAsserts, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&p.numAssertsFailed, &g_numAssertsFailed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&p.numTestCasesFailed, &g_numTestCasesFailed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+
+        std::vector<int> numAssertsFailedByRank;
+        if (rank == 0) {
+            numAssertsFailedByRank.resize(static_cast<std::size_t>(n_rank));
+        }
+
+        MPI_Gather(&p.numAssertsFailed, 1, MPI_INT, numAssertsFailedByRank.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+        if (rank == 0) {
+            separator_to_stream();
+            s << Color::Cyan << "[doctest] " << Color::None << "assertions on all processes: " << std::setw(6)
+              << g_numAsserts << " | " << ((g_numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+              << std::setw(6) << (g_numAsserts - g_numAssertsFailed) << " passed" << Color::None << " | "
+              << (g_numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6) << g_numAssertsFailed << " failed"
+              << Color::None << " |\n";
+            if (nb_test_cases_skipped_insufficient_procs > 0) {
+                s << Color::Cyan << "[doctest] " << Color::Yellow << "WARNING: Skipped ";
+                if (nb_test_cases_skipped_insufficient_procs > 1) {
+                    s << nb_test_cases_skipped_insufficient_procs << " tests requiring more than ";
+                } else {
+                    s << nb_test_cases_skipped_insufficient_procs << " test requiring more than ";
+                }
+                if (mpi_comm_world_size() > 1) {
+                    s << mpi_comm_world_size() << " MPI processes to run\n";
+                } else {
+                    s << mpi_comm_world_size() << " MPI process to run\n";
+                }
+            }
+
+            separator_to_stream();
+            if (g_numAssertsFailed > 0) {
+
+                s << Color::Cyan << "[doctest] " << Color::None << "fail on rank:" << std::setw(6) << "\n";
+                for (std::size_t i = 0; i < numAssertsFailedByRank.size(); ++i) {
+                    if (numAssertsFailedByRank[i] > 0) {
+                        s << std::setw(16) << " -> On rank [" << i << "] with " << numAssertsFailedByRank[i]
+                          << " test failed" << std::endl;
+                    }
+                }
+            }
+            s << Color::Cyan << "[doctest] " << Color::None
+              << "Status: " << (g_numTestCasesFailed > 0 ? Color::Red : Color::Green)
+              << ((g_numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+        }
+    }
+
+    void test_case_end(const CurrentTestCaseStats &st) override {
+        if (is_mpi_test_case()) {
+            // function called by every rank at the end of a test
+            // if failed assertions happened, they have been sent to rank 0
+            // here rank zero gathers them and prints them all
+
+            int rank;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+            std::vector<MPI_Request> requests;
+            requests.reserve(m_failure_str_queue.size()); // avoid realloc & copy of MPI_Request
+            for (const std::pair<std::string, int> &failure: m_failure_str_queue) {
+                const std::string &failure_str = failure.first;
+                const int failure_line = failure.second;
+
+                int failure_msg_size = static_cast<int>(failure_str.size());
+
+                requests.push_back(MPI_REQUEST_NULL);
+                MPI_Isend(
+                    failure_str.c_str(), failure_msg_size, MPI_BYTE, 0, failure_line, MPI_COMM_WORLD, &requests.back()
+                ); // Tag = file line
+            }
+
+            // Compute the number of assert with fail among all procs
+            const int nb_fail_asserts = static_cast<int>(m_failure_str_queue.size());
+            int nb_fail_asserts_glob = 0;
+            MPI_Reduce(&nb_fail_asserts, &nb_fail_asserts_glob, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+
+            if (rank == 0) {
+                MPI_Status status;
+                MPI_Status status_recv;
+
+                using id_string = std::pair<int, std::string>;
+                std::vector<id_string> msgs(static_cast<std::size_t>(nb_fail_asserts_glob));
+
+                for (std::size_t i = 0; i < static_cast<std::size_t>(nb_fail_asserts_glob); ++i) {
+                    MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+
+                    int count;
+                    MPI_Get_count(&status, MPI_BYTE, &count);
+
+                    std::string recv_msg(static_cast<std::size_t>(count), '\0');
+                    void *recv_msg_data = const_cast<char *>(
+                        recv_msg.data()
+                    ); // const_cast needed. Non-const .data() exists in C++11 though...
+                    MPI_Recv(
+                        recv_msg_data, count, MPI_BYTE, status.MPI_SOURCE, status.MPI_TAG, MPI_COMM_WORLD, &status_recv
+                    );
+
+                    msgs[i] = {status.MPI_SOURCE, recv_msg};
+                }
+
+                std::sort(begin(msgs), end(msgs), [](const id_string &x, const id_string &y) {
+                    return x.first < y.first;
+                });
+
+                // print
+                if (nb_fail_asserts_glob > 0) {
+                    separator_to_stream();
+                    file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
+                    if (tc->m_test_suite && tc->m_test_suite[0] != '\0')
+                        s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+                    if (strncmp(tc->m_name, "  Scenario:", 11) != 0)
+                        s << Color::Yellow << "TEST CASE:  ";
+                    s << Color::None << tc->m_name << "\n\n";
+                    for (const auto &msg: msgs) {
+                        s << msg.second;
+                    }
+                    s << "\n";
+                }
+            }
+
+            MPI_Waitall(static_cast<int>(requests.size()), requests.data(), MPI_STATUSES_IGNORE);
+            m_failure_str_queue.clear();
+        }
+
+        ConsoleReporter::test_case_end(st);
+    }
+
+    bool is_mpi_test_case() const {
+        return tc->m_description != nullptr && std::string(tc->m_description) == std::string("MPI_TEST_CASE");
+    }
+
+    void log_assert(const AssertData &rb) override {
+        if (!is_mpi_test_case()) {
+            ConsoleReporter::log_assert(rb);
         } else {
-          s << nb_test_cases_skipped_insufficient_procs << " test requiring more than ";
-        }
-        if (mpi_comm_world_size()>1) {
-          s << mpi_comm_world_size() << " MPI processes to run\n";
-        } else {
-          s << mpi_comm_world_size() << " MPI process to run\n";
-        }
-      }
+            int rank;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-      separator_to_stream();
-      if(g_numAssertsFailed > 0){
+            if (!rb.m_failed && !opt.success)
+                return;
 
-        s << Color::Cyan << "[doctest] " << Color::None << "fail on rank:" << std::setw(6) << "\n";
-        for(std::size_t i = 0; i < numAssertsFailedByRank.size(); ++i){
-          if( numAssertsFailedByRank[i] > 0 ){
-            s << std::setw(16) << " -> On rank [" << i << "] with " << numAssertsFailedByRank[i] << " test failed" << std::endl;
-          }
+            std::lock_guard<std::mutex> lock(mutex);
+
+            std::stringstream failure_msg;
+            failure_msg << Color::Red << "On rank [" << rank << "] : " << Color::None;
+            failure_msg << file_line_to_string(rb.m_file, rb.m_line, " ");
+
+            if ((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) == 0) {
+                failure_msg << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None
+
+                            << (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n")
+                            << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp.c_str() << " )\n";
+            }
+
+            m_failure_str_queue.push_back({failure_msg.str(), rb.m_line});
         }
-      }
-      s << Color::Cyan << "[doctest] " << Color::None
-        << "Status: " << (g_numTestCasesFailed > 0 ? Color::Red : Color::Green)
-        << ((g_numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
     }
-  }
-
-  void test_case_end(const CurrentTestCaseStats& st) override {
-    if (is_mpi_test_case()) {
-      // function called by every rank at the end of a test
-      // if failed assertions happened, they have been sent to rank 0
-      // here rank zero gathers them and prints them all
-
-      int rank;
-      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-      std::vector<MPI_Request> requests;
-      requests.reserve(m_failure_str_queue.size());  // avoid realloc & copy of MPI_Request
-      for (const std::pair<std::string, int> &failure : m_failure_str_queue)
-      {
-        const std::string & failure_str = failure.first;
-        const int failure_line = failure.second;
-
-        int failure_msg_size = static_cast<int>(failure_str.size());
-
-        requests.push_back(MPI_REQUEST_NULL);
-        MPI_Isend(failure_str.c_str(), failure_msg_size, MPI_BYTE,
-                 0, failure_line, MPI_COMM_WORLD, &requests.back()); // Tag = file line
-      }
-
-
-      // Compute the number of assert with fail among all procs
-      const int nb_fail_asserts = static_cast<int>(m_failure_str_queue.size());
-      int nb_fail_asserts_glob = 0;
-      MPI_Reduce(&nb_fail_asserts, &nb_fail_asserts_glob, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-
-      if(rank == 0) {
-        MPI_Status status;
-        MPI_Status status_recv;
-
-        using id_string = std::pair<int,std::string>;
-        std::vector<id_string> msgs(static_cast<std::size_t>(nb_fail_asserts_glob));
-
-        for (std::size_t i=0; i<static_cast<std::size_t>(nb_fail_asserts_glob); ++i) {
-          MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
-
-          int count;
-          MPI_Get_count(&status, MPI_BYTE, &count);
-
-          std::string recv_msg(static_cast<std::size_t>(count),'\0');
-          void* recv_msg_data = const_cast<char*>(recv_msg.data()); // const_cast needed. Non-const .data() exists in C++11 though...
-          MPI_Recv(recv_msg_data, count, MPI_BYTE, status.MPI_SOURCE,
-                   status.MPI_TAG, MPI_COMM_WORLD, &status_recv);
-
-          msgs[i] = {status.MPI_SOURCE,recv_msg};
-        }
-
-        std::sort(begin(msgs),end(msgs),[](const id_string& x, const id_string& y){ return x.first < y.first; });
-
-        // print
-        if (nb_fail_asserts_glob>0) {
-          separator_to_stream();
-          file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
-          if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
-            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-          if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-            s << Color::Yellow << "TEST CASE:  ";
-          s << Color::None << tc->m_name << "\n\n";
-          for(const auto& msg : msgs) {
-            s << msg.second;
-          }
-          s << "\n";
-        }
-      }
-
-      MPI_Waitall(static_cast<int>(requests.size()), requests.data(), MPI_STATUSES_IGNORE);
-      m_failure_str_queue.clear();
-    }
-
-    ConsoleReporter::test_case_end(st);
-  }
-
-  bool is_mpi_test_case() const {
-    return tc->m_description != nullptr
-        && std::string(tc->m_description) == std::string("MPI_TEST_CASE");
-  }
-
-  void log_assert(const AssertData& rb) override {
-    if (!is_mpi_test_case()) {
-      ConsoleReporter::log_assert(rb);
-    } else {
-      int rank;
-      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-
-      if(!rb.m_failed && !opt.success)
-        return;
-
-      std::lock_guard<std::mutex> lock(mutex);
-
-      std::stringstream failure_msg;
-      failure_msg << Color::Red << "On rank [" << rank << "] : " << Color::None;
-      failure_msg << file_line_to_string(rb.m_file, rb.m_line, " ");
-
-      if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==0){
-        failure_msg << Color::Cyan
-                    << assertString(rb.m_at)
-                    << "( " << rb.m_expr << " ) "
-                    << Color::None
-
-                    << (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n")
-                    << "  values: "
-                    << assertString(rb.m_at)
-                    << "( " << rb.m_decomp.c_str() << " )\n";
-      }
-
-      m_failure_str_queue.push_back({failure_msg.str(), rb.m_line});
-    }
-  }
 }; // MpiConsoleReporter
 
 // "1" is the priority - used for ordering when multiple reporters/listeners are used
 REGISTER_REPORTER("MpiConsoleReporter", 1, MpiConsoleReporter);
 REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
 
-} // anonymous
-} // doctest
+} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_REPORTER_H

--- a/doctest/extensions/mpi_sub_comm.h
+++ b/doctest/extensions/mpi_sub_comm.h
@@ -8,77 +8,74 @@
 
 namespace doctest {
 
-inline
-int mpi_world_nb_procs() {
-  int n;
-  MPI_Comm_size(MPI_COMM_WORLD, &n);
-  return n;
+inline int mpi_world_nb_procs() {
+    int n;
+    MPI_Comm_size(MPI_COMM_WORLD, &n);
+    return n;
 }
 
 struct mpi_sub_comm {
-  int nb_procs;
-  int rank;
-  MPI_Comm comm;
+    int nb_procs;
+    int rank;
+    MPI_Comm comm;
 
-  mpi_sub_comm( mpi_sub_comm const& ) = delete;
-  mpi_sub_comm& operator=( mpi_sub_comm const& ) = delete;
+    mpi_sub_comm(const mpi_sub_comm &) = delete;
+    mpi_sub_comm &operator=(const mpi_sub_comm &) = delete;
 
-  mpi_sub_comm(int nb_prcs) noexcept
-    : nb_procs(nb_prcs)
-    , rank(-1)
-    , comm(MPI_COMM_NULL)
-  {
-    int comm_world_rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
-    if (nb_procs>mpi_world_nb_procs()) {
-      if (comm_world_rank==0) {
-        MESSAGE(
-          "Unable to run test: need ", std::to_string(nb_procs), " procs",
-          " but program launched with only ", std::to_string(doctest::mpi_world_nb_procs()), "."
-        );
-        CHECK(nb_procs<=mpi_world_nb_procs());
-      }
-    } else {
-      int color = MPI_UNDEFINED;
-      if(comm_world_rank < nb_procs){
-        color = 0;
-      }
-      MPI_Comm_split(MPI_COMM_WORLD, color, comm_world_rank, &comm);
+    mpi_sub_comm(int nb_prcs) noexcept
+        : nb_procs(nb_prcs), rank(-1), comm(MPI_COMM_NULL) {
+        int comm_world_rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
+        if (nb_procs > mpi_world_nb_procs()) {
+            if (comm_world_rank == 0) {
+                MESSAGE(
+                    "Unable to run test: need ",
+                    std::to_string(nb_procs),
+                    " procs",
+                    " but program launched with only ",
+                    std::to_string(doctest::mpi_world_nb_procs()),
+                    "."
+                );
+                CHECK(nb_procs <= mpi_world_nb_procs());
+            }
+        } else {
+            int color = MPI_UNDEFINED;
+            if (comm_world_rank < nb_procs) {
+                color = 0;
+            }
+            MPI_Comm_split(MPI_COMM_WORLD, color, comm_world_rank, &comm);
 
-      if(comm != MPI_COMM_NULL){
-        MPI_Comm_rank(comm, &rank);
-        assert(rank==comm_world_rank);
-      }
+            if (comm != MPI_COMM_NULL) {
+                MPI_Comm_rank(comm, &rank);
+                assert(rank == comm_world_rank);
+            }
+        }
     }
-  }
 
-  void destroy_comm() {
-    if(comm != MPI_COMM_NULL){
-      MPI_Comm_free(&comm);
+    void destroy_comm() {
+        if (comm != MPI_COMM_NULL) {
+            MPI_Comm_free(&comm);
+        }
     }
-  }
-  
-  mpi_sub_comm(mpi_sub_comm&& x)
-    : nb_procs(x.nb_procs)
-    , rank(x.rank)
-    , comm(x.comm)
-  {
-    x.comm = MPI_COMM_NULL;
-  }
-  mpi_sub_comm& operator=(mpi_sub_comm&& x) {
-    destroy_comm();
-    nb_procs = x.nb_procs;
-    rank = x.rank;
-    comm = x.comm;
-    x.comm = MPI_COMM_NULL;
-    return *this;
-  }
 
-  ~mpi_sub_comm() {
-    destroy_comm();
-  }
+    mpi_sub_comm(mpi_sub_comm &&x)
+        : nb_procs(x.nb_procs), rank(x.rank), comm(x.comm) {
+        x.comm = MPI_COMM_NULL;
+    }
+    mpi_sub_comm &operator=(mpi_sub_comm &&x) {
+        destroy_comm();
+        nb_procs = x.nb_procs;
+        rank = x.rank;
+        comm = x.comm;
+        x.comm = MPI_COMM_NULL;
+        return *this;
+    }
+
+    ~mpi_sub_comm() {
+        destroy_comm();
+    }
 };
 
-} // doctest
+} // namespace doctest
 
 #endif // DOCTEST_SUB_COMM_H

--- a/doctest/parts/private/assert/data.cpp
+++ b/doctest/parts/private/assert/data.cpp
@@ -7,18 +7,31 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    using detail::g_cs;
+using detail::g_cs;
 
-    AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const StringContains& exception_string)
-        : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
-        m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
-        m_exception_string(exception_string) {
-    #if DOCTEST_MSVC
-        if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-    #endif // MSVC
-    }
+AssertData::AssertData(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const StringContains &exception_string
+)
+    : m_test_case(g_cs->currentTest),
+      m_at(at),
+      m_file(file),
+      m_line(line),
+      m_expr(expr),
+      m_failed(true),
+      m_threw(false),
+      m_threw_as(false),
+      m_exception_type(exception_type),
+      m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/assert/expression.cpp
+++ b/doctest/parts/private/assert/expression.cpp
@@ -8,7 +8,7 @@ namespace doctest {
 namespace detail {
 
 ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-        : m_at(at) {}
+    : m_at(at) {}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/assert/handler.cpp
+++ b/doctest/parts/private/assert/handler.cpp
@@ -10,55 +10,53 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    void addAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0)
-            g_cs->numAssertsCurrentTest_atomic++;
-    }
+void addAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsCurrentTest_atomic++;
+}
 
-    void addFailedAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0)
-            g_cs->numAssertsFailedCurrentTest_atomic++;
-    }
+void addFailedAssert(assertType::Enum at) {
+    if ((at & assertType::is_warn) == 0)
+        g_cs->numAssertsFailedCurrentTest_atomic++;
+}
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message) {
-        g_cs->failure_flags |= TestCaseFailureReason::Crash;
+void reportFatal(const std::string &message) {
+    g_cs->failure_flags |= TestCaseFailureReason::Crash;
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while (g_cs->subcaseStack.size()) {
-            g_cs->subcaseStack.pop_back();
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
-
-        g_cs->finalizeTestCaseData();
-
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    while (g_cs->subcaseStack.size()) {
+        g_cs->subcaseStack.pop_back();
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
+
+    g_cs->finalizeTestCaseData();
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+}
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
+void failed_out_of_a_testing_context(const AssertData &ad) {
+    if (g_cs->ah)
+        g_cs->ah(ad);
+    else
+        std::abort();
+}
 
-    void failed_out_of_a_testing_context(const AssertData& ad) {
-        if(g_cs->ah)
-            g_cs->ah(ad);
-        else
-            std::abort();
-    }
+bool decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result) {
+    bool failed = !result.m_passed;
 
-    bool decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
-                       const Result& result) {
-        bool failed = !result.m_passed;
-
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
-        DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
+    DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
+    return !failed;
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/assert/handler.h
+++ b/doctest/parts/private/assert/handler.h
@@ -10,12 +10,12 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    void addAssert(assertType::Enum at);
+void addAssert(assertType::Enum at);
 
-    void addFailedAssert(assertType::Enum at);
+void addFailedAssert(assertType::Enum at);
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message);
+void reportFatal(const std::string &message);
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
 } // namespace detail

--- a/doctest/parts/private/assert/message.cpp
+++ b/doctest/parts/private/assert/message.cpp
@@ -10,42 +10,42 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
-        m_stream   = tlssPush();
-        m_file     = file;
-        m_line     = line;
-        m_severity = severity;
+MessageBuilder::MessageBuilder(const char *file, int line, assertType::Enum severity) {
+    m_stream = tlssPush();
+    m_file = file;
+    m_line = line;
+    m_severity = severity;
+}
+
+MessageBuilder::~MessageBuilder() {
+    if (!logged)
+        tlssPop();
+}
+
+bool MessageBuilder::log() {
+    if (!logged) {
+        m_string = tlssPop();
+        logged = true;
     }
 
-    MessageBuilder::~MessageBuilder() {
-        if (!logged)
-            tlssPop();
+    DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
+
+    const bool isWarn = m_severity & assertType::is_warn;
+
+    // warn is just a message in this context so we don't treat it as an assert
+    if (!isWarn) {
+        addAssert(m_severity);
+        addFailedAssert(m_severity);
     }
 
-    bool MessageBuilder::log() {
-        if (!logged) {
-            m_string = tlssPop();
-            logged = true;
-        }
+    return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
-
-        const bool isWarn = m_severity & assertType::is_warn;
-
-        // warn is just a message in this context so we don't treat it as an assert
-        if(!isWarn) {
-            addAssert(m_severity);
-            addFailedAssert(m_severity);
-        }
-
-        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
-    }
-
-    void MessageBuilder::react() {
-        if(m_severity & assertType::is_require)
-            throwException();
-    }
+void MessageBuilder::react() {
+    if (m_severity & assertType::is_require)
+        throwException();
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/assert/result.cpp
+++ b/doctest/parts/private/assert/result.cpp
@@ -10,62 +10,73 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    Result::Result(bool passed, const String& decomposition)
-            : m_passed(passed)
-            , m_decomp(decomposition) {}
+Result::Result(bool passed, const String &decomposition)
+    : m_passed(passed), m_decomp(decomposition) {}
 
-    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const String& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const String &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
-    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-        const char* exception_type, const Contains& exception_string)
-        : AssertData(at, file, line, expr, exception_type, exception_string) { }
+ResultBuilder::ResultBuilder(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const char *exception_type,
+    const Contains &exception_string
+)
+    : AssertData(at, file, line, expr, exception_type, exception_string) {}
 
-    void ResultBuilder::setResult(const Result& res) {
-        m_decomp = res.m_decomp;
-        m_failed = !res.m_passed;
+void ResultBuilder::setResult(const Result &res) {
+    m_decomp = res.m_decomp;
+    m_failed = !res.m_passed;
+}
+
+void ResultBuilder::translateException() {
+    m_threw = true;
+    m_exception = translateActiveException();
+}
+
+bool ResultBuilder::log() {
+    if (m_at & assertType::is_throws) {
+        m_failed = !m_threw;
+    } else if ((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) {
+        m_failed = !m_threw_as || !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_throws_as) {
+        m_failed = !m_threw_as;
+    } else if (m_at & assertType::is_throws_with) {
+        m_failed = !m_exception_string.check(m_exception);
+    } else if (m_at & assertType::is_nothrow) {
+        m_failed = m_threw;
     }
 
-    void ResultBuilder::translateException() {
-        m_threw     = true;
-        m_exception = translateActiveException();
+    if (m_exception.size())
+        m_exception = "\"" + m_exception + "\"";
+
+    if (is_running_in_test) {
+        addAssert(m_at);
+        DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
+
+        if (m_failed)
+            addFailedAssert(m_at);
+    } else if (m_failed) {
+        failed_out_of_a_testing_context(*this);
     }
 
-    bool ResultBuilder::log() {
-        if(m_at & assertType::is_throws) {
-            m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) {
-            m_failed = !m_threw_as || !m_exception_string.check(m_exception);
-        } else if(m_at & assertType::is_throws_as) {
-            m_failed = !m_threw_as;
-        } else if(m_at & assertType::is_throws_with) {
-            m_failed = !m_exception_string.check(m_exception);
-        } else if(m_at & assertType::is_nothrow) {
-            m_failed = m_threw;
-        }
+    return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
+           (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
 
-        if(m_exception.size())
-            m_exception = "\"" + m_exception + "\"";
-
-        if(is_running_in_test) {
-            addAssert(m_at);
-            DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
-
-            if(m_failed)
-                addFailedAssert(m_at);
-        } else if(m_failed) {
-            failed_out_of_a_testing_context(*this);
-        }
-
-        return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
-            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
-    }
-
-    void ResultBuilder::react() const {
-        if(m_failed && checkIfShouldThrow(m_at))
-            throwException();
-    }
+void ResultBuilder::react() const {
+    if (m_failed && checkIfShouldThrow(m_at))
+        throwException();
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/assert/type.cpp
+++ b/doctest/parts/private/assert/type.cpp
@@ -5,19 +5,19 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-// clang-format off
-const char* assertString(assertType::Enum at) {
+const char *assertString(assertType::Enum at) {
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitly handled
-    #define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type) case assertType::DT_ ## assert_type: return #assert_type
-    #define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type) \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_ ## assert_type); \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_ ## assert_type); \
-        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_ ## assert_type)
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type)                                                                 \
+    case assertType::DT_##assert_type: return #assert_type
+#define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type)                                                                \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_##assert_type);                                                             \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_##assert_type);                                                            \
+    DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_##assert_type)
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
     DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")
     DOCTEST_GCC_SUPPRESS_WARNING_PUSH
     DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")
-    switch(at) {
+    switch (at) {
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN);
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK);
         DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE);
@@ -50,14 +50,13 @@ const char* assertString(assertType::Enum at) {
     DOCTEST_GCC_SUPPRESS_WARNING_POP
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 }
-// clang-format on
 
-const char* failureString(assertType::Enum at) {
-    if(at & assertType::is_warn)
+const char *failureString(assertType::Enum at) {
+    if (at & assertType::is_warn)
         return "WARNING";
-    if(at & assertType::is_check)
+    if (at & assertType::is_check)
         return "ERROR";
-    if(at & assertType::is_require)
+    if (at & assertType::is_require)
         return "FATAL ERROR";
     return "";
 }

--- a/doctest/parts/private/atomic.h
+++ b/doctest/parts/private/atomic.h
@@ -11,99 +11,103 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_CONFIG_NO_MULTITHREADING
-    template <typename T>
-    using Atomic = T;
-#else // DOCTEST_CONFIG_NO_MULTITHREADING
-    template <typename T>
-    using Atomic = std::atomic<T>;
+template <typename T>
+using Atomic = T;
+#else  // DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = std::atomic<T>;
 #endif // DOCTEST_CONFIG_NO_MULTITHREADING
 
 #if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
-    template <typename T>
-    using MultiLaneAtomic = Atomic<T>;
-#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
-    // Provides a multilane implementation of an atomic variable that supports add, sub, load,
-    // store. Instead of using a single atomic variable, this splits up into multiple ones,
-    // each sitting on a separate cache line. The goal is to provide a speedup when most
-    // operations are modifying. It achieves this with two properties:
-    //
-    // * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
-    // * Each atomic sits on a separate cache line, so false sharing is reduced.
-    //
-    // The disadvantage is that there is a small overhead due to the use of TLS, and load/store
-    // is slower because all atomics have to be accessed.
-    template <typename T>
-    class MultiLaneAtomic
-    {
-        struct CacheLineAlignedAtomic
-        {
-            Atomic<T> atomic{};
-            char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
-        };
-        CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
-
-        static_assert(sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
-                      "guarantee one atomic takes exactly one cache line");
-
-    public:
-        T operator++() DOCTEST_NOEXCEPT { return fetch_add(1) + 1; }
-
-        T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
-
-        T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_add(arg, order);
-        }
-
-        T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            return myAtomic().fetch_sub(arg, order);
-        }
-
-        operator T() const DOCTEST_NOEXCEPT { return load(); }
-
-        T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
-            auto result = T();
-            for(auto const& c : m_atomics) {
-                result += c.atomic.load(order);
-            }
-            return result;
-        }
-
-        T operator=(T desired) DOCTEST_NOEXCEPT {
-            store(desired);
-            return desired;
-        }
-
-        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
-            // first value becomes desired", all others become 0.
-            for(auto& c : m_atomics) {
-                c.atomic.store(desired, order);
-                desired = {};
-            }
-        }
-
-    private:
-        // Each thread has a different atomic that it operates on. If more than NumLanes threads
-        // use this, some will use the same atomic. So performance will degrade a bit, but still
-        // everything will work.
-        //
-        // The logic here is a bit tricky. The call should be as fast as possible, so that there
-        // is minimal to no overhead in determining the correct atomic for the current thread.
-        //
-        // 1. A global static counter laneCounter counts continuously up.
-        // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
-        //    assigned in a round-robin fashion.
-        // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
-        //    little overhead.
-        Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
-            static Atomic<size_t> laneCounter;
-            DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
-                    laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
-
-            return m_atomics[tlsLaneIdx].atomic;
-        }
+template <typename T>
+using MultiLaneAtomic = Atomic<T>;
+#else  // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+// Provides a multilane implementation of an atomic variable that supports add, sub, load,
+// store. Instead of using a single atomic variable, this splits up into multiple ones,
+// each sitting on a separate cache line. The goal is to provide a speedup when most
+// operations are modifying. It achieves this with two properties:
+//
+// * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
+// * Each atomic sits on a separate cache line, so false sharing is reduced.
+//
+// The disadvantage is that there is a small overhead due to the use of TLS, and load/store
+// is slower because all atomics have to be accessed.
+template <typename T>
+class MultiLaneAtomic {
+    struct CacheLineAlignedAtomic {
+        Atomic<T> atomic{};
+        char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
     };
-#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+    CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
 
+    static_assert(
+        sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
+        "guarantee one atomic takes exactly one cache line"
+    );
+
+public:
+    T operator++() DOCTEST_NOEXCEPT {
+        return fetch_add(1) + 1;
+    }
+
+    T operator++(int) DOCTEST_NOEXCEPT {
+        return fetch_add(1);
+    }
+
+    T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_add(arg, order);
+    }
+
+    T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        return myAtomic().fetch_sub(arg, order);
+    }
+
+    operator T() const DOCTEST_NOEXCEPT {
+        return load();
+    }
+
+    T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+        auto result = T();
+        for (const auto &c: m_atomics) {
+            result += c.atomic.load(order);
+        }
+        return result;
+    }
+
+    T operator=(T desired) DOCTEST_NOEXCEPT {
+        store(desired);
+        return desired;
+    }
+
+    void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+        // first value becomes desired", all others become 0.
+        for (auto &c: m_atomics) {
+            c.atomic.store(desired, order);
+            desired = {};
+        }
+    }
+
+private:
+    // Each thread has a different atomic that it operates on. If more than NumLanes threads
+    // use this, some will use the same atomic. So performance will degrade a bit, but still
+    // everything will work.
+    //
+    // The logic here is a bit tricky. The call should be as fast as possible, so that there
+    // is minimal to no overhead in determining the correct atomic for the current thread.
+    //
+    // 1. A global static counter laneCounter counts continuously up.
+    // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
+    //    assigned in a round-robin fashion.
+    // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
+    //    little overhead.
+    Atomic<T> &myAtomic() DOCTEST_NOEXCEPT {
+        static Atomic<size_t> laneCounter;
+        DOCTEST_THREAD_LOCAL size_t tlsLaneIdx = laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
+
+        return m_atomics[tlsLaneIdx].atomic;
+    }
+};
+#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/color.cpp
+++ b/doctest/parts/private/color.cpp
@@ -16,96 +16,92 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 
 namespace detail {
-    void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
+void color_to_stream(std::ostream &, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
 } // namespace detail
 
 namespace Color {
-    std::ostream& operator<<(std::ostream& s, Color::Enum code) {
-        detail::color_to_stream(s, code);
-        return s;
-    }
+std::ostream &operator<<(std::ostream &s, Color::Enum code) {
+    detail::color_to_stream(s, code);
+    return s;
+}
 } // namespace Color
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    void color_to_stream(std::ostream& s, Color::Enum code) {
-        static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
-        static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
-    #ifdef DOCTEST_CONFIG_COLORS_ANSI
-        if(g_no_colors ||
-            (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
-            return;
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+void color_to_stream(std::ostream &s, Color::Enum code) {
+    static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+    static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
+#ifdef DOCTEST_CONFIG_COLORS_ANSI
+    if (g_no_colors || (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+        return;
 
-        auto col = "";
-        // clang-format off
-            DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-            DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
-            switch(code) {
-                case Color::Red:         col = "[0;31m"; break;
-                case Color::Green:       col = "[0;32m"; break;
-                case Color::Blue:        col = "[0;34m"; break;
-                case Color::Cyan:        col = "[0;36m"; break;
-                case Color::Yellow:      col = "[0;33m"; break;
-                case Color::Grey:        col = "[1;30m"; break;
-                case Color::LightGrey:   col = "[0;37m"; break;
-                case Color::BrightRed:   col = "[1;31m"; break;
-                case Color::BrightGreen: col = "[1;32m"; break;
-                case Color::BrightWhite: col = "[1;37m"; break;
-                case Color::Bright: // invalid
-                case Color::None:
-                case Color::White:
-                default:                 col = "[0m";
-            }
-            DOCTEST_CLANG_SUPPRESS_WARNING_POP
-        // clang-format on
-        s << "\033" << col;
-    #endif // DOCTEST_CONFIG_COLORS_ANSI
-
-    #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(g_no_colors ||
-            (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
-            return;
-
-        static struct ConsoleHelper {
-            HANDLE stdoutHandle;
-            WORD   origFgAttrs;
-            WORD   origBgAttrs;
-
-            ConsoleHelper() {
-                stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-                CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-                GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
-                origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                    BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-                origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                    FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-            }
-        } ch;
-
-    #define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
-
-        // clang-format off
-        switch (code) {
-            case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
-            case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
-            case Color::Green:       DOCTEST_SET_ATTR(FOREGROUND_GREEN);                                    break;
-            case Color::Blue:        DOCTEST_SET_ATTR(FOREGROUND_BLUE);                                     break;
-            case Color::Cyan:        DOCTEST_SET_ATTR(FOREGROUND_BLUE | FOREGROUND_GREEN);                  break;
-            case Color::Yellow:      DOCTEST_SET_ATTR(FOREGROUND_RED | FOREGROUND_GREEN);                   break;
-            case Color::Grey:        DOCTEST_SET_ATTR(0);                                                   break;
-            case Color::LightGrey:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY);                                break;
-            case Color::BrightRed:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_RED);               break;
-            case Color::BrightGreen: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN);             break;
-            case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
-            case Color::None:
-            case Color::Bright: // invalid
-            default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
-        }
-            // clang-format on
-    #endif // DOCTEST_CONFIG_COLORS_WINDOWS
+    auto col = "";
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
+    switch (code) {
+        case Color::Red:         col = "[0;31m"; break;
+        case Color::Green:       col = "[0;32m"; break;
+        case Color::Blue:        col = "[0;34m"; break;
+        case Color::Cyan:        col = "[0;36m"; break;
+        case Color::Yellow:      col = "[0;33m"; break;
+        case Color::Grey:        col = "[1;30m"; break;
+        case Color::LightGrey:   col = "[0;37m"; break;
+        case Color::BrightRed:   col = "[1;31m"; break;
+        case Color::BrightGreen: col = "[1;32m"; break;
+        case Color::BrightWhite: col = "[1;37m"; break;
+        case Color::Bright:      // invalid
+        case Color::None:
+        case Color::White:
+        default:                 col = "[0m";
     }
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    s << "\033" << col;
+#endif // DOCTEST_CONFIG_COLORS_ANSI
+
+#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
+    if (g_no_colors || (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+        return;
+
+    static struct ConsoleHelper {
+        HANDLE stdoutHandle;
+        WORD origFgAttrs;
+        WORD origBgAttrs;
+
+        ConsoleHelper() {
+            stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+            GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+            origFgAttrs =
+                csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+            origBgAttrs =
+                csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+        }
+    } ch;
+
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+
+    // clang-format off
+    switch (code) {
+        case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
+        case Color::Green:       DOCTEST_SET_ATTR(FOREGROUND_GREEN);                                    break;
+        case Color::Blue:        DOCTEST_SET_ATTR(FOREGROUND_BLUE);                                     break;
+        case Color::Cyan:        DOCTEST_SET_ATTR(FOREGROUND_BLUE | FOREGROUND_GREEN);                  break;
+        case Color::Yellow:      DOCTEST_SET_ATTR(FOREGROUND_RED | FOREGROUND_GREEN);                   break;
+        case Color::Grey:        DOCTEST_SET_ATTR(0);                                                   break;
+        case Color::LightGrey:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY);                                break;
+        case Color::BrightRed:   DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_RED);               break;
+        case Color::BrightGreen: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN);             break;
+        case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
+        case Color::None:
+        case Color::Bright:      // invalid
+        default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
+    }
+        // clang-format on
+#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLED
 } // namespace doctest

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -12,671 +12,680 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    bool is_running_in_test = false;
+bool is_running_in_test = false;
 
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    Context::Context(int, const char* const*) {}
-    Context::~Context() = default;
-    void Context::applyCommandLine(int, const char* const*) {}
-    void Context::addFilter(const char*, const char*) {}
-    void Context::clearFilters() {}
-    void Context::setOption(const char*, bool) {}
-    void Context::setOption(const char*, int) {}
-    void Context::setOption(const char*, const char*) {}
-    bool Context::shouldExit() { return false; }
-    void Context::setAsDefaultForAssertsOutOfTestCases() {}
-    void Context::setAssertHandler(detail::assert_handler) {}
-    void Context::setCout(std::ostream*) {}
-    int  Context::run() { return 0; }
+Context::Context(int, const char *const *) {}
+Context::~Context() = default;
+void Context::applyCommandLine(int, const char *const *) {}
+void Context::addFilter(const char *, const char *) {}
+void Context::clearFilters() {}
+void Context::setOption(const char *, bool) {}
+void Context::setOption(const char *, int) {}
+void Context::setOption(const char *, const char *) {}
+bool Context::shouldExit() {
+    return false;
+}
+void Context::setAsDefaultForAssertsOutOfTestCases() {}
+void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream *) {}
+int Context::run() {
+    return 0;
+}
 
 #else
 
 namespace detail {
-    // for sorting tests by file/line
-    bool fileOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        // this is needed because MSVC gives different case for drive letters
-        // for __FILE__ when evaluated in a header and a source file
-        const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
-        if(res != 0)
-            return res < 0;
-        if(lhs->m_line != rhs->m_line)
-            return lhs->m_line < rhs->m_line;
-        return lhs->m_template_id < rhs->m_template_id;
-    }
+// for sorting tests by file/line
+bool fileOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    // this is needed because MSVC gives different case for drive letters
+    // for __FILE__ when evaluated in a header and a source file
+    const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
+    if (res != 0)
+        return res < 0;
+    if (lhs->m_line != rhs->m_line)
+        return lhs->m_line < rhs->m_line;
+    return lhs->m_template_id < rhs->m_template_id;
+}
 
-    // for sorting tests by suite/file/line
-    bool suiteOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-        if(res != 0)
-            return res < 0;
-        return fileOrderComparator(lhs, rhs);
-    }
+// for sorting tests by suite/file/line
+bool suiteOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+    if (res != 0)
+        return res < 0;
+    return fileOrderComparator(lhs, rhs);
+}
 
-    // for sorting tests by name/suite/file/line
-    bool nameOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_name, rhs->m_name);
-        if(res != 0)
-            return res < 0;
-        return suiteOrderComparator(lhs, rhs);
-    }
+// for sorting tests by name/suite/file/line
+bool nameOrderComparator(const TestCase *lhs, const TestCase *rhs) {
+    const int res = std::strcmp(lhs->m_name, rhs->m_name);
+    if (res != 0)
+        return res < 0;
+    return suiteOrderComparator(lhs, rhs);
+}
 
-    // the implementation of parseOption()
-    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String* value) {
-        // going from the end to the beginning and stopping on the first occurrence from the end
-        for(int i = argc; i > 0; --i) {
-            auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) {
-                // eliminate matches in which the chars before the option are not '-'
-                bool noBadCharsFound = true;
-                auto curr            = argv[index];
-                while(curr != temp) {
-                    if(*curr++ != '-') {
-                        noBadCharsFound = false;
-                        break;
-                    }
+// the implementation of parseOption()
+bool parseOptionImpl(int argc, const char *const *argv, const char *pattern, String *value) {
+    // going from the end to the beginning and stopping on the first occurrence from the end
+    for (int i = argc; i > 0; --i) {
+        auto index = i - 1;
+        auto temp = std::strstr(argv[index], pattern);
+        if (temp && (value || strlen(temp) == strlen(pattern))) {
+            // eliminate matches in which the chars before the option are not '-'
+            bool noBadCharsFound = true;
+            auto curr = argv[index];
+            while (curr != temp) {
+                if (*curr++ != '-') {
+                    noBadCharsFound = false;
+                    break;
                 }
-                if(noBadCharsFound && argv[index][0] == '-') {
-                    if(value) {
-                        // parsing the value of an option
-                        temp += strlen(pattern);
-                        const unsigned len = strlen(temp);
-                        if(len) {
-                            *value = temp;
-                            return true;
-                        }
-                    } else {
-                        // just a flag - no value
+            }
+            if (noBadCharsFound && argv[index][0] == '-') {
+                if (value) {
+                    // parsing the value of an option
+                    temp += strlen(pattern);
+                    const unsigned len = strlen(temp);
+                    if (len) {
+                        *value = temp;
                         return true;
                     }
+                } else {
+                    // just a flag - no value
+                    return true;
                 }
             }
         }
-        return false;
     }
+    return false;
+}
 
-    // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
-        if(value)
-            *value = defaultVal;
+// parses an option and returns the string after the '=' character
+bool parseOption(
+    int argc, const char *const *argv, const char *pattern, String *value = nullptr, const String &defaultVal = String()
+) {
+    if (value)
+        *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        // offset (normally 3 for "dt-") to skip prefix
-        if(parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
-            return true;
+    // offset (normally 3 for "dt-") to skip prefix
+    if (parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
+        return true;
 #endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        return parseOptionImpl(argc, argv, pattern, value);
-    }
+    return parseOptionImpl(argc, argv, pattern, value);
+}
 
-    // locates a flag on the command line
-    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
-        return parseOption(argc, argv, pattern);
-    }
+// locates a flag on the command line
+bool parseFlag(int argc, const char *const *argv, const char *pattern) {
+    return parseOption(argc, argv, pattern);
+}
 
-    // parses a comma separated list of words after a pattern in one of the arguments in argv
-    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
-                           std::vector<String>& res) {
-        String filtersString;
-        if(parseOption(argc, argv, pattern, &filtersString)) {
-            // tokenize with "," as a separator, unless escaped with backslash
-            std::ostringstream s;
-            auto flush = [&s, &res]() {
-                auto string = s.str();
-                if(string.size() > 0) {
-                    res.push_back(string.c_str());
-                }
-                s.str("");
-            };
-
-            bool seenBackslash = false;
-            const char* current = filtersString.c_str();
-            const char* end = current + strlen(current);
-            while(current != end) {
-                char character = *current++;
-                if(seenBackslash) {
-                    seenBackslash = false;
-                    if(character == ',' || character == '\\') {
-                        s.put(character);
-                        continue;
-                    }
-                    s.put('\\');
-                }
-                if(character == '\\') {
-                    seenBackslash = true;
-                } else if(character == ',') {
-                    flush();
-                } else {
-                    s.put(character);
-                }
+// parses a comma separated list of words after a pattern in one of the arguments in argv
+bool parseCommaSepArgs(int argc, const char *const *argv, const char *pattern, std::vector<String> &res) {
+    String filtersString;
+    if (parseOption(argc, argv, pattern, &filtersString)) {
+        // tokenize with "," as a separator, unless escaped with backslash
+        std::ostringstream s;
+        auto flush = [&s, &res]() {
+            auto string = s.str();
+            if (string.size() > 0) {
+                res.push_back(string.c_str());
             }
+            s.str("");
+        };
 
-            if(seenBackslash) {
+        bool seenBackslash = false;
+        const char *current = filtersString.c_str();
+        const char *end = current + strlen(current);
+        while (current != end) {
+            char character = *current++;
+            if (seenBackslash) {
+                seenBackslash = false;
+                if (character == ',' || character == '\\') {
+                    s.put(character);
+                    continue;
+                }
                 s.put('\\');
             }
-            flush();
+            if (character == '\\') {
+                seenBackslash = true;
+            } else if (character == ',') {
+                flush();
+            } else {
+                s.put(character);
+            }
+        }
+
+        if (seenBackslash) {
+            s.put('\\');
+        }
+        flush();
+        return true;
+    }
+    return false;
+}
+
+enum optionType { option_bool, option_int };
+
+// parses an int/bool option from the command line
+bool parseIntOption(int argc, const char *const *argv, const char *pattern, optionType type, int &res) {
+    String parsedValue;
+    if (!parseOption(argc, argv, pattern, &parsedValue))
+        return false;
+
+    if (type) {
+        // integer
+        // TODO: change this to use std::stoi or something else! currently it uses undefined
+        // behavior - assumes '0' on failed parse...
+        int theInt = std::atoi(parsedValue.c_str());
+        if (theInt != 0) {
+            res = theInt;
             return true;
         }
-        return false;
-    }
+    } else {
+        // boolean
+        const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
+        const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
 
-    enum optionType
-    {
-        option_bool,
-        option_int
-    };
-
-    // parses an int/bool option from the command line
-    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
-                        int& res) {
-        String parsedValue;
-        if(!parseOption(argc, argv, pattern, &parsedValue))
-            return false;
-
-        if(type) {
-            // integer
-            // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
-            int theInt = std::atoi(parsedValue.c_str());
-            if (theInt != 0) {
-                res = theInt;
+        // if the value matches any of the positive/negative possibilities
+        for (unsigned i = 0; i < 4; i++) {
+            if (parsedValue.compare(positive[i], true) == 0) {
+                res = 1;
                 return true;
             }
-        } else {
-            // boolean
-            const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
-            const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
-
-            // if the value matches any of the positive/negative possibilities
-            for (unsigned i = 0; i < 4; i++) {
-                if (parsedValue.compare(positive[i], true) == 0) {
-                    res = 1;
-                    return true;
-                }
-                if (parsedValue.compare(negative[i], true) == 0) {
-                    res = 0;
-                    return true;
-                }
+            if (parsedValue.compare(negative[i], true) == 0) {
+                res = 0;
+                return true;
             }
         }
-        return false;
     }
+    return false;
+}
 
 } // namespace detail
 
-    Context::Context(int argc, const char* const* argv)
-            : p(new detail::ContextState) {
-        parseArgs(argc, argv, true);
-        if(argc)
-            p->binary_name = argv[0];
+Context::Context(int argc, const char *const *argv)
+    : p(new detail::ContextState) {
+    parseArgs(argc, argv, true);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+Context::~Context() {
+    if (detail::g_cs == p)
+        detail::g_cs = nullptr;
+    delete p;
+}
+
+void Context::applyCommandLine(int argc, const char *const *argv) {
+    parseArgs(argc, argv);
+    if (argc)
+        p->binary_name = argv[0];
+}
+
+// parses args
+void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
+    using namespace detail;
+
+    // clang-format off
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sfe=",                p->filters[1]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite=",         p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ts=",                 p->filters[2]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite-exclude=", p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tse=",                p->filters[3]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case=",          p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tc=",                 p->filters[4]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case-exclude=",  p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tce=",                p->filters[5]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase=",            p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sc=",                 p->filters[6]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase-exclude=",    p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
+    parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
+    // clang-format on
+
+    int intRes = 0;
+    String strRes;
+
+#define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                                       \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||                     \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))                      \
+        p->var = static_cast<bool>(intRes);                                                                            \
+    else if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                              \
+             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                                               \
+        p->var = true;                                                                                                 \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                                            \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||                      \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))                       \
+        p->var = intRes;                                                                                               \
+    else if (withDefaults)                                                                                             \
+    p->var = default
+
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                                            \
+    if (parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||                           \
+        parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) || withDefaults)            \
+    p->var = strRes
+
+    DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
+    DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
+    DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
+
+    DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);
+    DOCTEST_PARSE_INT_OPTION("last", "l", last, UINT_MAX);
+
+    DOCTEST_PARSE_INT_OPTION("abort-after", "aa", abort_after, 0);
+    DOCTEST_PARSE_INT_OPTION("subcase-filter-levels", "scfl", subcase_filter_levels, INT_MAX);
+
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("success", "s", success, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-breaks", "nb", no_breaks, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
+    DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
+
+    if (withDefaults) {
+        p->help = false;
+        p->version = false;
+        p->count = false;
+        p->list_test_cases = false;
+        p->list_test_suites = false;
+        p->list_reporters = false;
     }
-
-    Context::~Context() {
-        if(detail::g_cs == p)
-            detail::g_cs = nullptr;
-        delete p;
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+        p->help = true;
+        p->exit = true;
     }
-
-    void Context::applyCommandLine(int argc, const char* const* argv) {
-        parseArgs(argc, argv);
-        if(argc)
-            p->binary_name = argv[0];
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+        p->version = true;
+        p->exit = true;
     }
-
-    // parses args
-    void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-        using namespace detail;
-
-        // clang-format off
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sfe=",                p->filters[1]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite=",         p->filters[2]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ts=",                 p->filters[2]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-suite-exclude=", p->filters[3]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tse=",                p->filters[3]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case=",          p->filters[4]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tc=",                 p->filters[4]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "test-case-exclude=",  p->filters[5]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "tce=",                p->filters[5]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase=",            p->filters[6]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sc=",                 p->filters[6]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "subcase-exclude=",    p->filters[7]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
-        parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
-        // clang-format on
-
-        int    intRes = 0;
-        String strRes;
-
-    #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-            p->var = static_cast<bool>(intRes);                                                        \
-        else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
-                parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
-            p->var = true;                                                                             \
-        else if(withDefaults)                                                                          \
-        p->var = default
-
-    #define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-        if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
-           parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
-            p->var = intRes;                                                                           \
-        else if(withDefaults)                                                                          \
-        p->var = default
-
-    #define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-        if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", &strRes, default) ||        \
-           parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", &strRes, default) ||       \
-           withDefaults)                                                                               \
-        p->var = strRes
-
-        // clang-format off
-        DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
-        DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
-        DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
-
-        DOCTEST_PARSE_INT_OPTION("first", "f", first, 0);
-        DOCTEST_PARSE_INT_OPTION("last", "l", last, UINT_MAX);
-
-        DOCTEST_PARSE_INT_OPTION("abort-after", "aa", abort_after, 0);
-        DOCTEST_PARSE_INT_OPTION("subcase-filter-levels", "scfl", subcase_filter_levels, INT_MAX);
-
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("success", "s", success, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-breaks", "nb", no_breaks, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skip", "ns", no_skip, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
-        DOCTEST_PARSE_STR_OPTION("strip-file-prefixes", "sfp", strip_file_prefixes, "");
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
-        DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
-        // clang-format on
-
-        if(withDefaults) {
-            p->help             = false;
-            p->version          = false;
-            p->count            = false;
-            p->list_test_cases  = false;
-            p->list_test_suites = false;
-            p->list_reporters   = false;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
-            p->help = true;
-            p->exit = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
-            p->version = true;
-            p->exit    = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
-            p->count = true;
-            p->exit  = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
-            p->list_test_cases = true;
-            p->exit            = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
-            p->list_test_suites = true;
-            p->exit             = true;
-        }
-        if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-           parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
-            p->list_reporters = true;
-            p->exit           = true;
-        }
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+        p->count = true;
+        p->exit = true;
     }
-
-    // allows the user to add procedurally to the filters from the command line
-    void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
-
-    // allows the user to clear all filters from the command line
-    void Context::clearFilters() {
-        for(auto& curr : p->filters)
-            curr.clear();
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+        p->list_test_cases = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the bool options from the command line
-    void Context::setOption(const char* option, bool value) {
-        setOption(option, value ? "true" : "false");
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+        p->list_test_suites = true;
+        p->exit = true;
     }
-
-    // allows the user to override procedurally the int options from the command line
-    void Context::setOption(const char* option, int value) {
-        setOption(option, toString(value).c_str());
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+        p->list_reporters = true;
+        p->exit = true;
     }
+}
 
-    // allows the user to override procedurally the string options from the command line
-    void Context::setOption(const char* option, const char* value) {
-        auto argv   = String("-") + option + "=" + value;
-        auto lvalue = argv.c_str();
-        parseArgs(1, &lvalue);
-    }
+// allows the user to add procedurally to the filters from the command line
+void Context::addFilter(const char *filter, const char *value) {
+    setOption(filter, value);
+}
 
-    // users should query this in their main() and exit the program if true
-    bool Context::shouldExit() { return p->exit; }
+// allows the user to clear all filters from the command line
+void Context::clearFilters() {
+    for (auto &curr: p->filters)
+        curr.clear();
+}
 
-    void Context::setAsDefaultForAssertsOutOfTestCases() { detail::g_cs = p; }
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char *option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
 
-    void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
+// allows the user to override procedurally the int options from the command line
+void Context::setOption(const char *option, int value) {
+    setOption(option, toString(value).c_str());
+}
 
-    void Context::setCout(std::ostream* out) { p->cout = out; }
+// allows the user to override procedurally the string options from the command line
+void Context::setOption(const char *option, const char *value) {
+    auto argv = String("-") + option + "=" + value;
+    auto lvalue = argv.c_str();
+    parseArgs(1, &lvalue);
+}
 
-    static class DiscardOStream : public std::ostream
-    {
+// users should query this in their main() and exit the program if true
+bool Context::shouldExit() {
+    return p->exit;
+}
+
+void Context::setAsDefaultForAssertsOutOfTestCases() {
+    detail::g_cs = p;
+}
+
+void Context::setAssertHandler(detail::assert_handler ah) {
+    p->ah = ah;
+}
+
+void Context::setCout(std::ostream *out) {
+    p->cout = out;
+}
+
+static class DiscardOStream : public std::ostream {
+private:
+    class : public std::streambuf {
     private:
-        class : public std::streambuf
-        {
-        private:
-            // allowing some buffering decreases the amount of calls to overflow
-            char buf[1024];
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
 
-        protected:
-            std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+    protected:
+        std::streamsize xsputn(const char_type *, std::streamsize count) override {
+            return count;
+        }
 
-            int_type overflow(int_type ch) override {
-                setp(std::begin(buf), std::end(buf));
-                return traits_type::not_eof(ch);
-            }
-        } discardBuf;
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
 
-    public:
-        DiscardOStream()
-                : std::ostream(&discardBuf) {}
-    } discardOut;
+public:
+    DiscardOStream()
+        : std::ostream(&discardBuf) {}
+} discardOut;
 
-    // the main function that does all the filtering and test running
-    int Context::run() {
-        using namespace detail;
+// the main function that does all the filtering and test running
+int Context::run() {
+    using namespace detail;
 
-        // save the old context state in case such was setup - for using asserts out of a testing context
-        auto old_cs = g_cs;
-        // this is the current contest
-        g_cs               = p;
-        is_running_in_test = true;
+    // save the old context state in case such was setup - for using asserts out of a testing context
+    auto old_cs = g_cs;
+    // this is the current contest
+    g_cs = p;
+    is_running_in_test = true;
 
-        g_no_colors = p->no_colors;
-        p->resetRunData();
+    g_no_colors = p->no_colors;
+    p->resetRunData();
 
-        std::fstream fstr;
-        if(p->cout == nullptr) {
-            if(p->quiet) {
-                p->cout = &discardOut;
-            } else if(p->out.size()) {
-                // to a file if specified
-                fstr.open(p->out.c_str(), std::fstream::out);
-                p->cout = &fstr;
-                if (!fstr.is_open()) {
-                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
-                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
-                    p->cout = &std::cout;
-                }
-
-            } else {
-    #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                // stdout by default
+    std::fstream fstr;
+    if (p->cout == nullptr) {
+        if (p->quiet) {
+            p->cout = &discardOut;
+        } else if (p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+            if (!fstr.is_open()) {
+                // clang-format off
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
+                std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
                 p->cout = &std::cout;
-    #else // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-                return EXIT_FAILURE;
-    #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-            }
-        }
-
-        FatalConditionHandler::allocateAltStackMem();
-
-        auto cleanup_and_return = [&]() {
-            FatalConditionHandler::freeAltStackMem();
-
-            if(fstr.is_open())
-                fstr.close();
-
-            // restore context
-            g_cs               = old_cs;
-            is_running_in_test = false;
-
-            // we have to free the reporters which were allocated when the run started
-            for(auto& curr : p->reporters_currently_used)
-                delete curr;
-            p->reporters_currently_used.clear();
-
-            if(p->numTestCasesFailed && !p->no_exitcode)
-                return EXIT_FAILURE;
-            return EXIT_SUCCESS;
-        };
-
-        // setup default reporter if none is given through the command line
-        if(p->filters[8].empty())
-            p->filters[8].push_back("console");
-
-        // check to see if any of the registered reporters has been selected
-        for(auto& curr : getReporters()) {
-            if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-                p->reporters_currently_used.push_back(curr.second(*g_cs));
-        }
-
-        // TODO: check if there is nothing in reporters_currently_used
-
-        // prepend all listeners
-        for(auto& curr : getListeners())
-            p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
-
-    #ifdef DOCTEST_PLATFORM_WINDOWS
-        if(isDebuggerActive() && p->no_debug_output == false)
-            p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
-    #endif // DOCTEST_PLATFORM_WINDOWS
-
-        // handle version, help and no_run
-        if(p->no_run || p->version || p->help || p->list_reporters) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
-
-            return cleanup_and_return();
-        }
-
-        std::vector<const TestCase*> testArray;
-        for(auto& curr : getRegisteredTests())
-            testArray.push_back(&curr);
-        p->numTestCases = testArray.size();
-
-        // sort the collected records
-        if(!testArray.empty()) {
-            if(p->order_by.compare("file", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
-            } else if(p->order_by.compare("suite", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
-            } else if(p->order_by.compare("name", true) == 0) {
-                std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
-            } else if(p->order_by.compare("rand", true) == 0) {
-                std::srand(p->rand_seed);
-
-                // random_shuffle implementation
-                const auto first = &testArray[0];
-                for(size_t i = testArray.size() - 1; i > 0; --i) {
-                    int idxToSwap = std::rand() % (i + 1);
-
-                    const auto temp = first[i];
-
-                    first[i]         = first[idxToSwap];
-                    first[idxToSwap] = temp;
-                }
-            } else if(p->order_by.compare("none", true) == 0) {
-                // means no sorting - beneficial for death tests which call into the executable
-                // with a specific test case in mind - we don't want to slow down the startup times
-            }
-        }
-
-        std::set<String> testSuitesPassingFilt;
-
-        bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
-        std::vector<const TestCaseData*> queryResults;
-
-        if(!query_mode)
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
-
-        // invoke the registered functions if they match the filter criteria (or just count them)
-        for(auto& curr : testArray) {
-            const auto& tc = *curr;
-
-            bool skip_me = false;
-            if(tc.m_skip && !p->no_skip)
-                skip_me = true;
-
-            if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-                skip_me = true;
-            if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-                skip_me = true;
-            if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-                skip_me = true;
-
-            if(!skip_me)
-                p->numTestCasesPassingFilters++;
-
-            // skip the test if it is not in the execution range
-            if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-               (p->first > p->numTestCasesPassingFilters))
-                skip_me = true;
-
-            if(skip_me) {
-                if(!query_mode)
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
-                continue;
+                // clang-format on
             }
 
-            // do not execute the test if we are to only count the number of filter passing tests
-            if(p->count)
-                continue;
-
-            // print the name of the test and don't execute it
-            if(p->list_test_cases) {
-                queryResults.push_back(&tc);
-                continue;
-            }
-
-            // print the name of the test suite if not done already and don't execute it
-            if(p->list_test_suites) {
-                if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                    queryResults.push_back(&tc);
-                    testSuitesPassingFilt.insert(tc.m_test_suite);
-                    p->numTestSuitesPassingFilters++;
-                }
-                continue;
-            }
-
-            // execute the test if it passes all the filtering
-            {
-                p->currentTest = &tc;
-
-                p->failure_flags = TestCaseFailureReason::None;
-                p->seconds       = 0;
-
-                // reset atomic counters
-                p->numAssertsFailedCurrentTest_atomic = 0;
-                p->numAssertsCurrentTest_atomic       = 0;
-
-                p->fullyTraversedSubcases.clear();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
-
-                p->timer.start();
-
-                bool run_test = true;
-
-                do {
-                    // reset some of the fields for subcases (except for the set of fully passed ones)
-                    p->reachedLeaf = false;
-                    // May not be empty if previous subcase exited via exception.
-                    p->subcaseStack.clear();
-                    p->currentSubcaseDepth = 0;
-
-                    p->shouldLogCurrentException = true;
-
-                    // reset stuff for logging with INFO()
-                    p->stringifiedContexts.clear();
-
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    try {
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
-                        FatalConditionHandler fatalConditionHandler; // Handle signals
-                        // execute the test
-                        tc.m_test();
-                        fatalConditionHandler.reset();
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                    } catch(const TestFailureException&) {
-                        p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                    } catch(...) {
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
-                                                          {translateActiveException(), false});
-                        p->failure_flags |= TestCaseFailureReason::Exception;
-                    }
-    #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                    // exit this loop if enough assertions have failed - even if there are more subcases
-                    if(p->abort_after > 0 &&
-                       p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                        run_test = false;
-                        p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
-                    }
-
-                    if(!p->nextSubcaseStack.empty() && run_test)
-                        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
-                    if(p->nextSubcaseStack.empty())
-                        run_test = false;
-                } while(run_test);
-
-                p->finalizeTestCaseData();
-
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-                p->currentTest = nullptr;
-
-                // stop executing tests if enough assertions have failed
-                if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                    break;
-            }
-        }
-
-        if(!query_mode) {
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
         } else {
-            QueryData qdata;
-            qdata.run_stats = g_cs;
-            qdata.data      = queryResults.data();
-            qdata.num_data  = unsigned(queryResults.size());
-            DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+#ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            // stdout by default
+            p->cout = &std::cout;
+#else  // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
+            return EXIT_FAILURE;
+#endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
         }
+    }
+
+    FatalConditionHandler::allocateAltStackMem();
+
+    auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
+        if (fstr.is_open())
+            fstr.close();
+
+        // restore context
+        g_cs = old_cs;
+        is_running_in_test = false;
+
+        // we have to free the reporters which were allocated when the run started
+        for (auto &curr: p->reporters_currently_used)
+            delete curr;
+        p->reporters_currently_used.clear();
+
+        if (p->numTestCasesFailed && !p->no_exitcode)
+            return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    };
+
+    // setup default reporter if none is given through the command line
+    if (p->filters[8].empty())
+        p->filters[8].push_back("console");
+
+    // check to see if any of the registered reporters has been selected
+    for (auto &curr: getReporters()) {
+        if (matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+            p->reporters_currently_used.push_back(curr.second(*g_cs));
+    }
+
+    // TODO: check if there is nothing in reporters_currently_used
+
+    // prepend all listeners
+    for (auto &curr: getListeners())
+        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if (isDebuggerActive() && p->no_debug_output == false)
+        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    // handle version, help and no_run
+    if (p->no_run || p->version || p->help || p->list_reporters) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
 
         return cleanup_and_return();
     }
+
+    std::vector<const TestCase *> testArray;
+    for (auto &curr: getRegisteredTests())
+        testArray.push_back(&curr);
+    p->numTestCases = testArray.size();
+
+    // sort the collected records
+    if (!testArray.empty()) {
+        if (p->order_by.compare("file", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+        } else if (p->order_by.compare("suite", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+        } else if (p->order_by.compare("name", true) == 0) {
+            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+        } else if (p->order_by.compare("rand", true) == 0) {
+            std::srand(p->rand_seed);
+
+            // random_shuffle implementation
+            const auto first = &testArray[0];
+            for (size_t i = testArray.size() - 1; i > 0; --i) {
+                int idxToSwap = std::rand() % (i + 1);
+
+                const auto temp = first[i];
+
+                first[i] = first[idxToSwap];
+                first[idxToSwap] = temp;
+            }
+        } else if (p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
+        }
+    }
+
+    std::set<String> testSuitesPassingFilt;
+
+    bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData *> queryResults;
+
+    if (!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+    // invoke the registered functions if they match the filter criteria (or just count them)
+    for (auto &curr: testArray) {
+        const auto &tc = *curr;
+
+        bool skip_me = false;
+        if (tc.m_skip && !p->no_skip)
+            skip_me = true;
+
+        if (!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+            skip_me = true;
+        if (!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+            skip_me = true;
+        if (matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+            skip_me = true;
+
+        if (!skip_me)
+            p->numTestCasesPassingFilters++;
+
+        // skip the test if it is not in the execution range
+        if ((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+            (p->first > p->numTestCasesPassingFilters))
+            skip_me = true;
+
+        if (skip_me) {
+            if (!query_mode)
+                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+            continue;
+        }
+
+        // do not execute the test if we are to only count the number of filter passing tests
+        if (p->count)
+            continue;
+
+        // print the name of the test and don't execute it
+        if (p->list_test_cases) {
+            queryResults.push_back(&tc);
+            continue;
+        }
+
+        // print the name of the test suite if not done already and don't execute it
+        if (p->list_test_suites) {
+            if ((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+                queryResults.push_back(&tc);
+                testSuitesPassingFilt.insert(tc.m_test_suite);
+                p->numTestSuitesPassingFilters++;
+            }
+            continue;
+        }
+
+        // execute the test if it passes all the filtering
+        {
+            p->currentTest = &tc;
+
+            p->failure_flags = TestCaseFailureReason::None;
+            p->seconds = 0;
+
+            // reset atomic counters
+            p->numAssertsFailedCurrentTest_atomic = 0;
+            p->numAssertsCurrentTest_atomic = 0;
+
+            p->fullyTraversedSubcases.clear();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+            p->timer.start();
+
+            bool run_test = true;
+
+            do {
+                // reset some of the fields for subcases (except for the set of fully passed ones)
+                p->reachedLeaf = false;
+                // May not be empty if previous subcase exited via exception.
+                p->subcaseStack.clear();
+                p->currentSubcaseDepth = 0;
+
+                p->shouldLogCurrentException = true;
+
+                // reset stuff for logging with INFO()
+                p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+       // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a
+       // static method)
+                    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
+                    FatalConditionHandler fatalConditionHandler;  // Handle signals
+                    // execute the test
+                    tc.m_test();
+                    fatalConditionHandler.reset();
+                    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+                } catch (const TestFailureException &) {
+                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
+                } catch (...) {
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {translateActiveException(), false});
+                    p->failure_flags |= TestCaseFailureReason::Exception;
+                }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+                // exit this loop if enough assertions have failed - even if there are more subcases
+                if (p->abort_after > 0 &&
+                    p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+                    run_test = false;
+                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+                }
+
+                if (!p->nextSubcaseStack.empty() && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if (p->nextSubcaseStack.empty())
+                    run_test = false;
+            } while (run_test);
+
+            p->finalizeTestCaseData();
+
+            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+            p->currentTest = nullptr;
+
+            // stop executing tests if enough assertions have failed
+            if (p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                break;
+        }
+    }
+
+    if (!query_mode) {
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+    } else {
+        QueryData qdata;
+        qdata.run_stats = g_cs;
+        qdata.data = queryResults.data();
+        qdata.num_data = unsigned(queryResults.size());
+        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+    }
+
+    return cleanup_and_return();
+}
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/context/options.cpp
+++ b/doctest/parts/private/context/options.cpp
@@ -5,7 +5,9 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs); }
+const ContextOptions *getContextOptions() {
+    return DOCTEST_BRANCH_ON_DISABLED(nullptr, detail::g_cs);
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/context_scope.cpp
+++ b/doctest/parts/private/context_scope.cpp
@@ -10,41 +10,42 @@ DOCTEST_DEFINE_INTERFACE(IContextScope)
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-    DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
+DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+ContextScopeBase::ContextScopeBase() {
+    g_infoContexts.push_back(this);
+}
 
-    ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
-        if (other.need_to_destroy) {
-            other.destroy();
-        }
-        other.need_to_destroy = false;
-        g_infoContexts.push_back(this);
+ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
+    if (other.need_to_destroy) {
+        other.destroy();
     }
+    other.need_to_destroy = false;
+    g_infoContexts.push_back(this);
+}
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    // destroy cannot be inlined into the destructor because that would mean calling stringify after
-    // ContextScope has been destroyed (base class destructors run after derived class destructors).
-    // Instead, ContextScope calls this method directly from its destructor.
-    void ContextScopeBase::destroy() {
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-        if(std::uncaught_exceptions() > 0) {
-    #else
-        if(std::uncaught_exception()) {
-    #endif
-            std::ostringstream s;
-            this->stringify(&s);
-            g_cs->stringifiedContexts.push_back(s.str().c_str());
-        }
-        g_infoContexts.pop_back();
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+// destroy cannot be inlined into the destructor because that would mean calling stringify after
+// ContextScope has been destroyed (base class destructors run after derived class destructors).
+// Instead, ContextScope calls this method directly from its destructor.
+void ContextScopeBase::destroy() {
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+    if (std::uncaught_exceptions() > 0) {
+#else
+    if (std::uncaught_exception()) {
+#endif
+        std::ostringstream s;
+        this->stringify(&s);
+        g_cs->stringifiedContexts.push_back(s.str().c_str());
     }
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    g_infoContexts.pop_back();
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/context_scope.h
+++ b/doctest/parts/private/context_scope.h
@@ -9,8 +9,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    extern DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
-}
+extern DOCTEST_THREAD_LOCAL std::vector<IContextScope *> g_infoContexts; // for logging with INFO()
+} // namespace detail
 } // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/context_state.cpp
+++ b/doctest/parts/private/context_state.cpp
@@ -8,17 +8,17 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-ContextState* g_cs = nullptr;
+ContextState *g_cs = nullptr;
 DOCTEST_THREAD_LOCAL bool g_no_colors;
 
 void ContextState::resetRunData() {
-    numTestCases                = 0;
-    numTestCasesPassingFilters  = 0;
+    numTestCases = 0;
+    numTestCasesPassingFilters = 0;
     numTestSuitesPassingFilters = 0;
-    numTestCasesFailed          = 0;
-    numAsserts                  = 0;
-    numAssertsFailed            = 0;
-    numAssertsCurrentTest       = 0;
+    numTestCasesFailed = 0;
+    numAsserts = 0;
+    numAssertsFailed = 0;
+    numAssertsCurrentTest = 0;
     numAssertsFailedCurrentTest = 0;
 }
 
@@ -28,26 +28,26 @@ void ContextState::finalizeTestCaseData() {
     // update the non-atomic counters
     numAsserts += numAssertsCurrentTest_atomic;
     numAssertsFailed += numAssertsFailedCurrentTest_atomic;
-    numAssertsCurrentTest       = numAssertsCurrentTest_atomic;
+    numAssertsCurrentTest = numAssertsCurrentTest_atomic;
     numAssertsFailedCurrentTest = numAssertsFailedCurrentTest_atomic;
 
-    if(numAssertsFailedCurrentTest)
+    if (numAssertsFailedCurrentTest)
         failure_flags |= TestCaseFailureReason::AssertFailure;
 
-    if(Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+    if (Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
         Approx(seconds).epsilon(DBL_EPSILON) > currentTest->m_timeout)
         failure_flags |= TestCaseFailureReason::Timeout;
 
-    if(currentTest->m_should_fail) {
-        if(failure_flags) {
+    if (currentTest->m_should_fail) {
+        if (failure_flags) {
             failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
         } else {
             failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
         }
-    } else if(failure_flags && currentTest->m_may_fail) {
+    } else if (failure_flags && currentTest->m_may_fail) {
         failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
-    } else if(currentTest->m_expected_failures > 0) {
-        if(numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
+    } else if (currentTest->m_expected_failures > 0) {
+        if (numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
             failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
         } else {
             failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
@@ -60,10 +60,9 @@ void ContextState::finalizeTestCaseData() {
 
     // if any subcase has failed - the whole test case has failed
     testCaseSuccess = !(failure_flags && !ok_to_fail);
-    if(!testCaseSuccess)
+    if (!testCaseSuccess)
         numTestCasesFailed++;
 }
-
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/context_state.h
+++ b/doctest/parts/private/context_state.h
@@ -12,41 +12,40 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // this holds both parameters from the command line and runtime data for tests
-    struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
-    {
-        MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
-        MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
+// this holds both parameters from the command line and runtime data for tests
+struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats {
+    MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
+    MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
-        std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+    std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
 
-        std::vector<IReporter*> reporters_currently_used;
+    std::vector<IReporter *> reporters_currently_used;
 
-        assert_handler ah = nullptr;
+    assert_handler ah = nullptr;
 
-        Timer timer;
+    Timer timer;
 
-        std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+    std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
 
-        // stuff for subcases
-        bool reachedLeaf;
-        std::vector<SubcaseSignature> subcaseStack;
-        std::vector<SubcaseSignature> nextSubcaseStack;
-        std::unordered_set<unsigned long long> fullyTraversedSubcases;
-        size_t currentSubcaseDepth;
-        Atomic<bool> shouldLogCurrentException;
+    // stuff for subcases
+    bool reachedLeaf;
+    std::vector<SubcaseSignature> subcaseStack;
+    std::vector<SubcaseSignature> nextSubcaseStack;
+    std::unordered_set<unsigned long long> fullyTraversedSubcases;
+    size_t currentSubcaseDepth;
+    Atomic<bool> shouldLogCurrentException;
 
-        void resetRunData();
+    void resetRunData();
 
-        void finalizeTestCaseData();
-    };
+    void finalizeTestCaseData();
+};
 
-    extern ContextState* g_cs;
+extern ContextState *g_cs;
 
-    // used to avoid locks for the debug output
-    // TODO: figure out if this is indeed necessary/correct - seems like either there still
-    // could be a race or that there wouldn't be a race even if using the context directly
-    extern DOCTEST_THREAD_LOCAL bool g_no_colors;
+// used to avoid locks for the debug output
+// TODO: figure out if this is indeed necessary/correct - seems like either there still
+// could be a race or that there wouldn't be a race even if using the context directly
+extern DOCTEST_THREAD_LOCAL bool g_no_colors;
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/debugger.cpp
+++ b/doctest/parts/private/debugger.cpp
@@ -7,64 +7,74 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 #ifdef DOCTEST_IS_DEBUGGER_ACTIVE
-    bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
+bool isDebuggerActive() {
+    return DOCTEST_IS_DEBUGGER_ACTIVE();
+}
 #else // DOCTEST_IS_DEBUGGER_ACTIVE
 #ifdef DOCTEST_PLATFORM_LINUX
-    class ErrnoGuard {
-    public:
-        ErrnoGuard() : m_oldErrno(errno) {}
-        ~ErrnoGuard() { errno = m_oldErrno; }
-    private:
-        int m_oldErrno;
-    };
-    // See the comments in Catch2 for the reasoning behind this implementation:
-    // https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
-    bool isDebuggerActive() {
-        ErrnoGuard guard;
-        std::ifstream in("/proc/self/status");
-        for(std::string line; std::getline(in, line);) {
-            static const int PREFIX_LEN = 11;
-            if(line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
-                return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
-            }
+class ErrnoGuard {
+public:
+    ErrnoGuard()
+        : m_oldErrno(errno) {}
+    ~ErrnoGuard() {
+        errno = m_oldErrno;
+    }
+
+private:
+    int m_oldErrno;
+};
+// See the comments in Catch2 for the reasoning behind this implementation:
+// https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
+bool isDebuggerActive() {
+    ErrnoGuard guard;
+    std::ifstream in("/proc/self/status");
+    for (std::string line; std::getline(in, line);) {
+        static const int PREFIX_LEN = 11;
+        if (line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
         }
+    }
+    return false;
+}
+#elif defined(DOCTEST_PLATFORM_MAC)
+// The following function is taken directly from the following technical note:
+// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive() {
+    int mib[4];
+    kinfo_proc info;
+    size_t size;
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    info.kp_proc.p_flag = 0;
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+    // Call sysctl.
+    size = sizeof(info);
+    if (sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, nullptr, 0) != 0) {
+        std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
         return false;
     }
-#elif defined(DOCTEST_PLATFORM_MAC)
-    // The following function is taken directly from the following technical note:
-    // https://developer.apple.com/library/archive/qa/qa1361/_index.html
-    // Returns true if the current process is being debugged (either
-    // running under the debugger or has a debugger attached post facto).
-    bool isDebuggerActive() {
-        int        mib[4];
-        kinfo_proc info;
-        size_t     size;
-        // Initialize the flags so that, if sysctl fails for some bizarre
-        // reason, we get a predictable result.
-        info.kp_proc.p_flag = 0;
-        // Initialize mib, which tells sysctl the info we want, in this case
-        // we're looking for information about a specific process ID.
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROC;
-        mib[2] = KERN_PROC_PID;
-        mib[3] = getpid();
-        // Call sysctl.
-        size = sizeof(info);
-        if(sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, nullptr, 0) != 0) {
-            std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
-            return false;
-        }
-        // We're being debugged if the P_TRACED flag is set.
-        return ((info.kp_proc.p_flag & P_TRACED) != 0);
-    }
+    // We're being debugged if the P_TRACED flag is set.
+    return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
 #elif DOCTEST_MSVC || defined(__MINGW32__) || defined(__MINGW64__)
-    bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
+bool isDebuggerActive() {
+    return ::IsDebuggerPresent() != 0;
+}
 #else
-    bool isDebuggerActive() { return false; }
+bool isDebuggerActive() {
+    return false;
+}
 #endif // Platform
 #endif // DOCTEST_IS_DEBUGGER_ACTIVE
-} // detail
-} // doctest
+} // namespace detail
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/exception_translator.cpp
+++ b/doctest/parts/private/exception_translator.cpp
@@ -8,45 +8,45 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
+DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
-    void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
-        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
-           getExceptionTranslators().end())
-            getExceptionTranslators().push_back(et);
-    }
+void registerExceptionTranslatorImpl(const IExceptionTranslator *et) {
+    if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
+        getExceptionTranslators().end())
+        getExceptionTranslators().push_back(et);
+}
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
-        static std::vector<const IExceptionTranslator*> data;
-        return data;
-    }
+std::vector<const IExceptionTranslator *> &getExceptionTranslators() {
+    static std::vector<const IExceptionTranslator *> data;
+    return data;
+}
 
-    String translateActiveException() {
+String translateActiveException() {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        String res;
-        auto&  translators = getExceptionTranslators();
-        for(auto& curr : translators)
-            if(curr->translate(res))
-                return res;
-        // clang-format off
-        DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
-        try {
-            throw;
-        } catch(std::exception& ex) {
-            return ex.what();
-        } catch(std::string& msg) {
-            return msg.c_str();
-        } catch(const char* msg) {
-            return msg;
-        } catch(...) {
-            return "unknown exception";
-        }
-        DOCTEST_GCC_SUPPRESS_WARNING_POP
-// clang-format on
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        return "";
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+    String res;
+    auto &translators = getExceptionTranslators();
+    for (auto &curr: translators)
+        if (curr->translate(res))
+            return res;
+    // clang-format off
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
+    try {
+        throw;
+    } catch (std::exception &ex) {
+        return ex.what();
+    } catch (std::string &msg) {
+        return msg.c_str();
+    } catch (const char *msg) {
+        return msg;
+    } catch (...) {
+        return "unknown exception";
     }
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    // clang-format on
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+    return "";
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/exception_translator.h
+++ b/doctest/parts/private/exception_translator.h
@@ -10,8 +10,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators();
-    String translateActiveException();
+std::vector<const IExceptionTranslator *> &getExceptionTranslators();
+String translateActiveException();
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/exceptions.cpp
+++ b/doctest/parts/private/exceptions.cpp
@@ -8,26 +8,24 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    bool checkIfShouldThrow(assertType::Enum at) {
-        if(at & assertType::is_require)
-            return true;
+bool checkIfShouldThrow(assertType::Enum at) {
+    if (at & assertType::is_require)
+        return true;
 
-        if((at & assertType::is_check)
-           && getContextOptions()->abort_after > 0 &&
-           (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >=
-                   getContextOptions()->abort_after)
-            return true;
+    if ((at & assertType::is_check) && getContextOptions()->abort_after > 0 &&
+        (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >= getContextOptions()->abort_after)
+        return true;
 
-        return false;
-    }
+    return false;
+}
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    DOCTEST_NORETURN void throwException() {
-        g_cs->shouldLogCurrentException = false;
-        throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
-    }
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS
-    void throwException() {}
+DOCTEST_NORETURN void throwException() {
+    g_cs->shouldLogCurrentException = false;
+    throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
+}
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 } // namespace detail

--- a/doctest/parts/private/exceptions.h
+++ b/doctest/parts/private/exceptions.h
@@ -8,27 +8,26 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    template <typename Ex>
-    DOCTEST_NORETURN void throw_exception(Ex const& e) {
+template <typename Ex>
+DOCTEST_NORETURN void throw_exception(const Ex &e) {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+    throw e;
+#else // DOCTEST_CONFIG_NO_EXCEPTIONS
 #ifdef DOCTEST_CONFIG_HANDLE_EXCEPTION
-        DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
+    DOCTEST_CONFIG_HANDLE_EXCEPTION(e);
 #else // DOCTEST_CONFIG_HANDLE_EXCEPTION
 #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
-        std::cerr << "doctest will terminate because it needed to throw an exception.\n"
-                  << "The message was: " << e.what() << '\n';
+    std::cerr << "doctest will terminate because it needed to throw an exception.\n"
+              << "The message was: " << e.what() << '\n';
 #endif // DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
 #endif // DOCTEST_CONFIG_HANDLE_EXCEPTION
-        std::terminate();
+    std::terminate();
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+}
 
 #ifndef DOCTEST_INTERNAL_ERROR
-#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
-    detail::throw_exception(std::logic_error(                                                              \
-            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
+#define DOCTEST_INTERNAL_ERROR(msg)                                                                                    \
+    detail::throw_exception(std::logic_error(__FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
 #endif // DOCTEST_INTERNAL_ERROR
 } // namespace detail
 

--- a/doctest/parts/private/filters.cpp
+++ b/doctest/parts/private/filters.cpp
@@ -6,51 +6,48 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
-        const char* cp = str;
-        const char* mp = wild;
+int wildcmp(const char *str, const char *wild, bool caseSensitive) {
+    const char *cp = str;
+    const char *mp = wild;
 
-        while((*str) && (*wild != '*')) {
-            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
-               (*wild != '?')) {
-                return 0;
+    while ((*str) && (*wild != '*')) {
+        if ((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?')) {
+            return 0;
+        }
+        wild++;
+        str++;
+    }
+
+    while (*str) {
+        if (*wild == '*') {
+            if (!*++wild) {
+                return 1;
             }
+            mp = wild;
+            cp = str + 1;
+        } else if ((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?')) {
             wild++;
             str++;
+        } else {
+            wild = mp;
+            str = cp++;
         }
-
-        while(*str) {
-            if(*wild == '*') {
-                if(!*++wild) {
-                    return 1;
-                }
-                mp = wild;
-                cp = str + 1;
-            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
-                      (*wild == '?')) {
-                wild++;
-                str++;
-            } else {
-                wild = mp;
-                str  = cp++;
-            }
-        }
-
-        while(*wild == '*') {
-            wild++;
-        }
-        return !*wild;
     }
 
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-        bool caseSensitive) {
-        if (filters.empty() && matchEmpty)
+    while (*wild == '*') {
+        wild++;
+    }
+    return !*wild;
+}
+
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive) {
+    if (filters.empty() && matchEmpty)
+        return true;
+    for (auto &curr: filters)
+        if (wildcmp(name, curr.c_str(), caseSensitive))
             return true;
-        for (auto& curr : filters)
-            if (wildcmp(name, curr.c_str(), caseSensitive))
-                return true;
-        return false;
-    }
+    return false;
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/filters.h
+++ b/doctest/parts/private/filters.h
@@ -10,14 +10,14 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // matching of a string against a wildcard mask (case sensitivity configurable) taken from
-    // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
-    int wildcmp(const char* str, const char* wild, bool caseSensitive);
+// matching of a string against a wildcard mask (case sensitivity configurable) taken from
+// https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
+int wildcmp(const char *str, const char *wild, bool caseSensitive);
 
-    // checks if the name matches any of the filters (and can be configured what to do when empty)
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty, bool caseSensitive);
+// checks if the name matches any of the filters (and can be configured what to do when empty)
+bool matchesAny(const char *name, const std::vector<String> &filters, bool matchEmpty, bool caseSensitive);
 
-} // namespace
+} // namespace detail
 } // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/main.cpp
+++ b/doctest/parts/private/main.cpp
@@ -4,7 +4,9 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) // 'function' : must be 'attribute' - see issue #182
-int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
+int main(int argc, char **argv) {
+    return doctest::Context(argc, argv).run();
+}
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -5,9 +5,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 
 Approx::Approx(double value)
-        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
-        , m_scale(1.0)
-        , m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value) {}
 
 Approx Approx::operator()(double value) const {
     Approx approx(value);
@@ -16,33 +14,66 @@ Approx Approx::operator()(double value) const {
     return approx;
 }
 
-Approx& Approx::epsilon(double newEpsilon) {
+Approx &Approx::epsilon(double newEpsilon) {
     m_epsilon = newEpsilon;
     return *this;
 }
-Approx& Approx::scale(double newScale) {
+Approx &Approx::scale(double newScale) {
     m_scale = newScale;
     return *this;
 }
 
-bool operator==(double lhs, const Approx& rhs) {
+bool operator==(double lhs, const Approx &rhs) {
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
-bool operator==(const Approx& lhs, double rhs) { return operator==(rhs, lhs); }
-bool operator!=(double lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
-bool operator!=(const Approx& lhs, double rhs) { return !operator==(rhs, lhs); }
-bool operator<=(double lhs, const Approx& rhs) { return lhs < rhs.m_value || lhs == rhs; }
-bool operator<=(const Approx& lhs, double rhs) { return lhs.m_value < rhs || lhs == rhs; }
-bool operator>=(double lhs, const Approx& rhs) { return lhs > rhs.m_value || lhs == rhs; }
-bool operator>=(const Approx& lhs, double rhs) { return lhs.m_value > rhs || lhs == rhs; }
-bool operator<(double lhs, const Approx& rhs) { return lhs < rhs.m_value && lhs != rhs; }
-bool operator<(const Approx& lhs, double rhs) { return lhs.m_value < rhs && lhs != rhs; }
-bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs != rhs; }
-bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
-String toString(const Approx& in) {
+bool operator==(const Approx &lhs, double rhs) {
+    return operator==(rhs, lhs);
+}
+
+bool operator!=(double lhs, const Approx &rhs) {
+    return !operator==(lhs, rhs);
+}
+
+bool operator!=(const Approx &lhs, double rhs) {
+    return !operator==(rhs, lhs);
+}
+
+bool operator<=(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value || lhs == rhs;
+}
+
+bool operator<=(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs || lhs == rhs;
+}
+
+bool operator>=(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value || lhs == rhs;
+}
+
+bool operator>=(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs || lhs == rhs;
+}
+
+bool operator<(double lhs, const Approx &rhs) {
+    return lhs < rhs.m_value && lhs != rhs;
+}
+
+bool operator<(const Approx &lhs, double rhs) {
+    return lhs.m_value < rhs && lhs != rhs;
+}
+
+bool operator>(double lhs, const Approx &rhs) {
+    return lhs > rhs.m_value && lhs != rhs;
+}
+
+bool operator>(const Approx &lhs, double rhs) {
+    return lhs.m_value > rhs && lhs != rhs;
+}
+
+String toString(const Approx &in) {
     return "Approx( " + doctest::toString(in.m_value) + " )";
 }
 

--- a/doctest/parts/private/matchers/contains.cpp
+++ b/doctest/parts/private/matchers/contains.cpp
@@ -4,20 +4,32 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-Contains::Contains(const String& str) : string(str) { }
+Contains::Contains(const String &str)
+    : string(str) {}
 
-bool Contains::checkWith(const String& other) const {
+bool Contains::checkWith(const String &other) const {
     return strstr(other.c_str(), string.c_str()) != nullptr;
 }
 
-String toString(const Contains& in) {
+String toString(const Contains &in) {
     return "Contains( " + in.string + " )";
 }
 
-bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
-bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
-bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
-bool operator!=(const Contains& lhs, const String& rhs) { return !lhs.checkWith(rhs); }
+bool operator==(const String &lhs, const Contains &rhs) {
+    return rhs.checkWith(lhs);
+}
+
+bool operator==(const Contains &lhs, const String &rhs) {
+    return lhs.checkWith(rhs);
+}
+
+bool operator!=(const String &lhs, const Contains &rhs) {
+    return !rhs.checkWith(lhs);
+}
+
+bool operator!=(const Contains &lhs, const String &rhs) {
+    return !lhs.checkWith(rhs);
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/matchers/is_nan.cpp
+++ b/doctest/parts/private/matchers/is_nan.cpp
@@ -15,10 +15,21 @@ template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
 template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
 
 template <typename F>
-String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
-String toString(IsNaN<float> in) { return toString<float>(in); }
-String toString(IsNaN<double> in) { return toString<double>(in); }
-String toString(IsNaN<double long> in) { return toString<double long>(in); }
+String toString(IsNaN<F> in) {
+    return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )";
+}
+
+String toString(IsNaN<float> in) {
+    return toString<float>(in);
+}
+
+String toString(IsNaN<double> in) {
+    return toString<double>(in);
+}
+
+String toString(IsNaN<double long> in) {
+    return toString<double long>(in);
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/path.cpp
+++ b/doctest/parts/private/path.cpp
@@ -11,13 +11,13 @@ namespace doctest {
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 // depending on the current options this will remove the path of filenames
-const char* skipPathFromFilename(const char* file) {
+const char *skipPathFromFilename(const char *file) {
 #ifndef DOCTEST_CONFIG_DISABLE
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
+    if (getContextOptions()->no_path_in_filenames) {
+        auto back = std::strrchr(file, '\\');
         auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
+        if (back || forward) {
+            if (back > forward)
                 forward = back;
             return forward + 1;
         }
@@ -25,17 +25,15 @@ const char* skipPathFromFilename(const char* file) {
         const auto prefixes = getContextOptions()->strip_file_prefixes;
         const char separator = DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR;
         String::size_type longest_match = 0U;
-        for(String::size_type pos = 0U; pos < prefixes.size(); ++pos)
-        {
+        for (String::size_type pos = 0U; pos < prefixes.size(); ++pos) {
             const auto prefix_start = pos;
             pos = std::min(prefixes.find(separator, prefix_start), prefixes.size());
 
             const auto prefix_size = pos - prefix_start;
-            if(prefix_size > longest_match)
-            {
-                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive letter capitalization?
-                if(0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size))
-                {
+            if (prefix_size > longest_match) {
+                // TODO under DOCTEST_MSVC: does the comparison need strnicmp() to work with drive
+                // letter capitalization?
+                if (0 == std::strncmp(prefixes.c_str() + prefix_start, file, prefix_size)) {
                     longest_match = prefix_size;
                 }
             }

--- a/doctest/parts/private/prelude.h
+++ b/doctest/parts/private/prelude.h
@@ -11,7 +11,8 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <ctime>
 #include <cmath>
 #include <climits>
-// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/doctest/doctest/pull/37
+// borland (Embarcadero) compiler requires math.h and not cmath -
+// https://github.com/doctest/doctest/pull/37
 #ifdef __BORLANDC__
 #include <math.h>
 #endif // __BORLANDC__

--- a/doctest/parts/private/reporter.cpp
+++ b/doctest/parts/private/reporter.cpp
@@ -8,48 +8,66 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
-    int                         IReporter::get_num_active_contexts() { return 0; }
-    const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
-    int                         IReporter::get_num_stringified_contexts() { return 0; }
-    const String*               IReporter::get_stringified_contexts() { return nullptr; }
+int IReporter::get_num_active_contexts() {
+    return 0;
+}
 
-    int registerReporter(const char*, int, IReporter*) { return 0; }
+const IContextScope *const *IReporter::get_active_contexts() {
+    return nullptr;
+}
+
+int IReporter::get_num_stringified_contexts() {
+    return 0;
+}
+
+const String *IReporter::get_stringified_contexts() {
+    return nullptr;
+}
+
+int registerReporter(const char *, int, IReporter *) {
+    return 0;
+}
 
 #else
 
 namespace detail {
-    reporterMap& getReporters() {
-        static reporterMap data;
-        return data;
-    }
+reporterMap &getReporters() {
+    static reporterMap data;
+    return data;
+}
 
-    reporterMap& getListeners() {
-        static reporterMap data;
-        return data;
-    }
+reporterMap &getListeners() {
+    static reporterMap data;
+    return data;
+}
 } // namespace detail
 
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
-    DOCTEST_DEFINE_INTERFACE(IReporter)
+int IReporter::get_num_active_contexts() {
+    return detail::g_infoContexts.size();
+}
 
-    int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
-    const IContextScope* const* IReporter::get_active_contexts() {
-        return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
-    }
+const IContextScope *const *IReporter::get_active_contexts() {
+    return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+}
 
-    int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
-    const String* IReporter::get_stringified_contexts() {
-        return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
-    }
+int IReporter::get_num_stringified_contexts() {
+    return detail::g_cs->stringifiedContexts.size();
+}
 
-    namespace detail {
-        void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
-            if(isReporter)
-                getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-            else
-                getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-        }
-    } // namespace detail
+const String *IReporter::get_stringified_contexts() {
+    return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
+}
+
+namespace detail {
+void registerReporterImpl(const char *name, int priority, reporterCreatorFunc c, bool isReporter) {
+    if (isReporter)
+        getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+    else
+        getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+}
+} // namespace detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace doctest

--- a/doctest/parts/private/reporter.h
+++ b/doctest/parts/private/reporter.h
@@ -10,16 +10,16 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    // the int (priority) is part of the key for automatic sorting - sadly one can register a
-    // reporter with a duplicate name and a different priority but hopefully that won't happen often :|
-    using reporterMap = std::map<std::pair<int, String>, detail::reporterCreatorFunc>;
+// the int (priority) is part of the key for automatic sorting - sadly one can register a
+// reporter with a duplicate name and a different priority but hopefully that won't happen often :|
+using reporterMap = std::map<std::pair<int, String>, detail::reporterCreatorFunc>;
 
-    reporterMap& getReporters();
-    reporterMap& getListeners();
+reporterMap &getReporters();
+reporterMap &getListeners();
 } // namespace detail
 
-#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                           \
-    for(auto& curr_rep : g_cs->reporters_currently_used)                                           \
+#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                                               \
+    for (auto &curr_rep: g_cs->reporters_currently_used)                                                               \
     curr_rep->function(__VA_ARGS__)
 
 } // namespace doctest

--- a/doctest/parts/private/reporters/common.cpp
+++ b/doctest/parts/private/reporters/common.cpp
@@ -7,21 +7,20 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
-    if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-        0)
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-            << Color::None;
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb) {
+    // clang-format off
+    if ((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) == 0)
+        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
 
-    if(rb.m_at & assertType::is_throws) {
+    if (rb.m_at & assertType::is_throws) {
         s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-    } else if((rb.m_at & assertType::is_throws_as) &&
-                (rb.m_at & assertType::is_throws_with)) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-            << rb.m_exception_string.c_str()
-            << "\", " << rb.m_exception_type << " ) " << Color::None;
-        if(rb.m_threw) {
-            if(!rb.m_failed) {
+    } else if ((rb.m_at & assertType::is_throws_as) && (rb.m_at & assertType::is_throws_with)) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str() << "\", " << rb.m_exception_type
+          << " ) " << Color::None;
+
+        if (rb.m_threw) {
+            if (!rb.m_failed) {
                 s << "threw as expected!\n";
             } else {
                 s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
@@ -29,34 +28,28 @@ void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
         } else {
             s << "did NOT throw at all!\n";
         }
-    } else if(rb.m_at &
-                assertType::is_throws_as) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-            << rb.m_exception_type << " ) " << Color::None
-            << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                            "threw a DIFFERENT exception: ") :
-                            "did NOT throw at all!")
-            << Color::Cyan << rb.m_exception << "\n";
-    } else if(rb.m_at &
-                assertType::is_throws_with) {
-        s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-            << rb.m_exception_string.c_str()
-            << "\" ) " << Color::None
-            << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                            "threw a DIFFERENT exception: ") :
-                            "did NOT throw at all!")
-            << Color::Cyan << rb.m_exception << "\n";
-    } else if(rb.m_at & assertType::is_nothrow) {
-        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-            << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_throws_as) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", " << rb.m_exception_type
+          << " ) " << Color::None
+          << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_throws_with) {
+        s << Color::Cyan << assertString(rb.m_at) << "( "
+          << rb.m_expr << ", \"" << rb.m_exception_string.c_str()
+          << "\" ) " << Color::None
+          << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ") : "did NOT throw at all!")
+          << Color::Cyan << rb.m_exception << "\n";
+    } else if (rb.m_at & assertType::is_nothrow) {
+        s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception << "\n";
     } else {
-        s << (rb.m_threw ? "THREW exception: " :
-                            (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-        if(rb.m_threw)
+        s << (rb.m_threw ? "THREW exception: " : (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+        if (rb.m_threw)
             s << rb.m_exception << "\n";
         else
             s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
     }
+    // clang-format on
 }
 
 } // namespace doctest

--- a/doctest/parts/private/reporters/common.h
+++ b/doctest/parts/private/reporters/common.h
@@ -13,7 +13,7 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb);
+void fulltext_log_assert_to_stream(std::ostream &s, const AssertData &rb);
 
 } // namespace doctest
 

--- a/doctest/parts/private/reporters/console.cpp
+++ b/doctest/parts/private/reporters/console.cpp
@@ -12,51 +12,47 @@ namespace doctest {
 using detail::g_cs;
 
 Whitespace::Whitespace(int nr)
-        : nrSpaces(nr) {}
+    : nrSpaces(nr) {}
 
-std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-    if(ws.nrSpaces != 0)
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws) {
+    if (ws.nrSpaces != 0)
         out << std::setw(ws.nrSpaces) << ' ';
     return out;
 }
 
-ConsoleReporter::ConsoleReporter(const ContextOptions& co)
-        : s(*co.cout)
-        , opt(co) {}
+ConsoleReporter::ConsoleReporter(const ContextOptions &co)
+    : s(*co.cout), opt(co) {}
 
-ConsoleReporter::ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-        : s(ostr)
-        , opt(co) {}
+ConsoleReporter::ConsoleReporter(const ContextOptions &co, std::ostream &ostr)
+    : s(ostr), opt(co) {}
 
 void ConsoleReporter::separator_to_stream() {
     s << Color::Yellow
       << "==============================================================================="
-          "\n";
+         "\n";
 }
 
-const char* ConsoleReporter::getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str) {
-    if(success)
+const char *ConsoleReporter::getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str) {
+    if (success)
         return success_str;
     return failureString(at);
 }
 
 Color::Enum ConsoleReporter::getSuccessOrFailColor(bool success, assertType::Enum at) {
-    return success ? Color::BrightGreen :
-                      (at & assertType::is_warn) ? Color::Yellow : Color::Red;
+    return success ? Color::BrightGreen : (at & assertType::is_warn) ? Color::Yellow : Color::Red;
 }
 
-void ConsoleReporter::successOrFailColoredStringToStream(bool success, assertType::Enum at, const char* success_str) {
-    s << getSuccessOrFailColor(success, at)
-      << getSuccessOrFailString(success, at, success_str) << ": ";
+void ConsoleReporter::successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str) {
+    s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str) << ": ";
 }
 
 void ConsoleReporter::log_contexts() {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
+    if (num_contexts) {
         auto contexts = get_active_contexts();
 
         s << Color::None << "  logged: ";
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             s << (i == 0 ? "" : "          ");
             contexts[i]->stringify(&s);
             s << "\n";
@@ -67,35 +63,35 @@ void ConsoleReporter::log_contexts() {
 }
 
 // this was requested to be made virtual so users could override it
-void ConsoleReporter::file_line_to_stream(const char* file, int line, const char* tail) {
+void ConsoleReporter::file_line_to_stream(const char *file, int line, const char *tail) {
     s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
-    << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-    << (opt.gnu_file_line ? ":" : "):") << tail;
+      << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+      << (opt.gnu_file_line ? ":" : "):") << tail;
 }
 
 void ConsoleReporter::logTestStart() {
-    if(hasLoggedCurrentTestStart)
+    if (hasLoggedCurrentTestStart)
         return;
 
     separator_to_stream();
     file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
-    if(tc->m_description)
+    if (tc->m_description)
         s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-    if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+    if (tc->m_test_suite && tc->m_test_suite[0] != '\0')
         s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-    if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+    if (strncmp(tc->m_name, "  Scenario:", 11) != 0)
         s << Color::Yellow << "TEST CASE:  ";
     s << Color::None << tc->m_name << "\n";
 
-    for(size_t i = 0; i < currentSubcaseLevel; ++i) {
-        if(subcasesStack[i].m_name[0] != '\0')
+    for (size_t i = 0; i < currentSubcaseLevel; ++i) {
+        if (subcasesStack[i].m_name[0] != '\0')
             s << "  " << subcasesStack[i].m_name << "\n";
     }
 
-    if(currentSubcaseLevel != subcasesStack.size()) {
+    if (currentSubcaseLevel != subcasesStack.size()) {
         s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
-        for(size_t i = 0; i < subcasesStack.size(); ++i) {
-            if(subcasesStack[i].m_name[0] != '\0')
+        for (size_t i = 0; i < subcasesStack.size(); ++i) {
+            if (subcasesStack[i].m_name[0] != '\0')
                 s << "  " << subcasesStack[i].m_name << "\n";
         }
     }
@@ -106,13 +102,12 @@ void ConsoleReporter::logTestStart() {
 }
 
 void ConsoleReporter::printVersion() {
-    if(opt.no_version == false)
-        s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-          << DOCTEST_VERSION_STR << "\"\n";
+    if (opt.no_version == false)
+        s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \"" << DOCTEST_VERSION_STR << "\"\n";
 }
 
 void ConsoleReporter::printIntro() {
-    if(opt.no_intro == false) {
+    if (opt.no_intro == false) {
         printVersion();
         s << Color::Cyan << "[doctest] " << Color::None
           << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
@@ -142,95 +137,95 @@ void ConsoleReporter::printHelp() {
     s << Color::Cyan << "[doctest] " << Color::None;
     s << "Query flags - the program quits after them. Available:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "?,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "help, -" DOCTEST_OPTIONS_PREFIX_DISPLAY "h                      "
-      << Whitespace(sizePrefixDisplay*0) <<  "prints this message\n";
+      << Whitespace(sizePrefixDisplay * 0) <<  "prints this message\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "v,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "version                       "
-      << Whitespace(sizePrefixDisplay*1) << "prints the version\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the version\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "c,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "count                         "
-      << Whitespace(sizePrefixDisplay*1) << "prints the number of matching tests\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the number of matching tests\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ltc, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-cases               "
-      << Whitespace(sizePrefixDisplay*1) << "lists all matching tests by name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching tests by name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lts, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-test-suites              "
-      << Whitespace(sizePrefixDisplay*1) << "lists all matching test suites\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all matching test suites\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "lr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "list-reporters                "
-      << Whitespace(sizePrefixDisplay*1) << "lists all registered reporters\n\n";
+      << Whitespace(sizePrefixDisplay * 1) << "lists all registered reporters\n\n";
     // ================================================================================== << 79
     s << Color::Cyan << "[doctest] " << Color::None;
     s << "The available <int>/<string> options/filters are:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case=<filters>           "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-case-exclude=<filters>   "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sf,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file=<filters>         "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their file\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their file\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfe, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "source-file-exclude=<filters> "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their file\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their file\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ts,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite=<filters>          "
-      << Whitespace(sizePrefixDisplay*1) << "filters     tests by their test suite\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     tests by their test suite\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "tse, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "test-suite-exclude=<filters>  "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT tests by their test suite\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT tests by their test suite\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase=<filters>             "
-      << Whitespace(sizePrefixDisplay*1) << "filters     subcases by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters     subcases by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sce, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-exclude=<filters>     "
-      << Whitespace(sizePrefixDisplay*1) << "filters OUT subcases by their name\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters OUT subcases by their name\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "r,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "reporters=<filters>           "
-      << Whitespace(sizePrefixDisplay*1) << "reporters to use (console is default)\n";
+      << Whitespace(sizePrefixDisplay * 1) << "reporters to use (console is default)\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "o,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "out=<string>                  "
-      << Whitespace(sizePrefixDisplay*1) << "output filename\n";
+      << Whitespace(sizePrefixDisplay * 1) << "output filename\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
-      << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
+      << Whitespace(sizePrefixDisplay * 1) << "how the tests should be ordered\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       <string> - [file/suite/name/rand/none]\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
-      << Whitespace(sizePrefixDisplay*1) << "seed for random ordering\n";
+      << Whitespace(sizePrefixDisplay * 1) << "seed for random ordering\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "f,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "first=<int>                   "
-      << Whitespace(sizePrefixDisplay*1) << "the first test passing the filters to\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       execute - for range-based execution\n";
+      << Whitespace(sizePrefixDisplay * 1) << "the first test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "l,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "last=<int>                    "
-      << Whitespace(sizePrefixDisplay*1) << "the last test passing the filters to\n";
-    s << Whitespace(sizePrefixDisplay*3) << "                                       execute - for range-based execution\n";
+      << Whitespace(sizePrefixDisplay * 1) << "the last test passing the filters to\n";
+    s << Whitespace(sizePrefixDisplay * 3) << "                                       execute - for range-based execution\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "aa,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "abort-after=<int>             "
-      << Whitespace(sizePrefixDisplay*1) << "stop after <int> failed assertions\n";
+      << Whitespace(sizePrefixDisplay * 1) << "stop after <int> failed assertions\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "scfl,--" DOCTEST_OPTIONS_PREFIX_DISPLAY "subcase-filter-levels=<int>   "
-      << Whitespace(sizePrefixDisplay*1) << "apply filters for the first <int> levels\n";
+      << Whitespace(sizePrefixDisplay * 1) << "apply filters for the first <int> levels\n";
     s << Color::Cyan << "\n[doctest] " << Color::None;
     s << "Bool options - can be used like flags and true is assumed. Available:\n\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "s,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "success=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "include successful assertions in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "include successful assertions in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "cs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "case-sensitive=<bool>         "
-      << Whitespace(sizePrefixDisplay*1) << "filters being treated as case sensitive\n";
+      << Whitespace(sizePrefixDisplay * 1) << "filters being treated as case sensitive\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "e,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "exit=<bool>                   "
-      << Whitespace(sizePrefixDisplay*1) << "exits after the tests finish\n";
+      << Whitespace(sizePrefixDisplay * 1) << "exits after the tests finish\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "d,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "duration=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "prints the time duration of each test\n";
+      << Whitespace(sizePrefixDisplay * 1) << "prints the time duration of each test\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "m,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "minimal=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "minimal console output (only failures)\n";
+      << Whitespace(sizePrefixDisplay * 1) << "minimal console output (only failures)\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "q,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "quiet=<bool>                  "
-      << Whitespace(sizePrefixDisplay*1) << "no console output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "no console output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nt,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-throw=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "skips exceptions-related assert checks\n";
+      << Whitespace(sizePrefixDisplay * 1) << "skips exceptions-related assert checks\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ne,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-exitcode=<bool>            "
-      << Whitespace(sizePrefixDisplay*1) << "returns (or exits) always with success\n";
+      << Whitespace(sizePrefixDisplay * 1) << "returns (or exits) always with success\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-run=<bool>                 "
-      << Whitespace(sizePrefixDisplay*1) << "skips all runtime doctest operations\n";
+      << Whitespace(sizePrefixDisplay * 1) << "skips all runtime doctest operations\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ni,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-intro=<bool>               "
-      << Whitespace(sizePrefixDisplay*1) << "omit the framework intro in the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework intro in the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nv,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-version=<bool>             "
-      << Whitespace(sizePrefixDisplay*1) << "omit the framework version in the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "omit the framework version in the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-colors=<bool>              "
-      << Whitespace(sizePrefixDisplay*1) << "disables colors in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "disables colors in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "fc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "force-colors=<bool>           "
-      << Whitespace(sizePrefixDisplay*1) << "use colors even when not in a tty\n";
+      << Whitespace(sizePrefixDisplay * 1) << "use colors even when not in a tty\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nb,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-breaks=<bool>              "
-      << Whitespace(sizePrefixDisplay*1) << "disables breakpoints in debuggers\n";
+      << Whitespace(sizePrefixDisplay * 1) << "disables breakpoints in debuggers\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ns,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-skip=<bool>                "
-      << Whitespace(sizePrefixDisplay*1) << "don't skip test cases marked as skip\n";
+      << Whitespace(sizePrefixDisplay * 1) << "don't skip test cases marked as skip\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "gfl, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "gnu-file-line=<bool>          "
-      << Whitespace(sizePrefixDisplay*1) << ":n: vs (n): for line numbers in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << ":n: vs (n): for line numbers in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
-      << Whitespace(sizePrefixDisplay*1) << "only filenames and no paths in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "only filenames and no paths in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "spp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "skip-path-prefixes=<p1:p2>    "
-      << Whitespace(sizePrefixDisplay*1) << "whenever file paths start with this prefix, remove it from the output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "whenever file paths start with this prefix, remove it from the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
-      << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
+      << Whitespace(sizePrefixDisplay * 1) << "0 instead of real line numbers in output\n";
     // ================================================================================== << 79
     // clang-format on
 
@@ -240,172 +235,172 @@ void ConsoleReporter::printHelp() {
 
 void ConsoleReporter::printRegisteredReporters() {
     printVersion();
-    auto printReporters = [this] (const detail::reporterMap& reporters, const char* type) {
-        if(reporters.size()) {
+    auto printReporters = [this](const detail::reporterMap &reporters, const char *type) {
+        if (reporters.size()) {
             s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
-            for(auto& curr : reporters)
-                s << "priority: " << std::setw(5) << curr.first.first
-                  << " name: " << curr.first.second << "\n";
+            for (auto &curr: reporters)
+                s << "priority: " << std::setw(5) << curr.first.first << " name: " << curr.first.second << "\n";
         }
     };
     printReporters(detail::getListeners(), "listeners");
     printReporters(detail::getReporters(), "reporters");
 }
 
-void ConsoleReporter::report_query(const QueryData& in) {
-    if(opt.version) {
+void ConsoleReporter::report_query(const QueryData &in) {
+    if (opt.version) {
         printVersion();
-    } else if(opt.help) {
+    } else if (opt.help) {
         printHelp();
-    } else if(opt.list_reporters) {
+    } else if (opt.list_reporters) {
         printRegisteredReporters();
-    } else if(opt.count || opt.list_test_cases) {
-        if(opt.list_test_cases) {
-            s << Color::Cyan << "[doctest] " << Color::None
-              << "listing all test case names\n";
+    } else if (opt.count || opt.list_test_cases) {
+        if (opt.list_test_cases) {
+            s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
             separator_to_stream();
         }
 
-        for(unsigned i = 0; i < in.num_data; ++i)
+        for (unsigned i = 0; i < in.num_data; ++i)
             s << Color::None << in.data[i]->m_name << "\n";
 
         separator_to_stream();
 
         s << Color::Cyan << "[doctest] " << Color::None
-          << "unskipped test cases passing the current filters: "
-          << g_cs->numTestCasesPassingFilters << "\n";
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
 
-    } else if(opt.list_test_suites) {
+    } else if (opt.list_test_suites) {
         s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
         separator_to_stream();
 
-        for(unsigned i = 0; i < in.num_data; ++i)
+        for (unsigned i = 0; i < in.num_data; ++i)
             s << Color::None << in.data[i]->m_test_suite << "\n";
 
         separator_to_stream();
 
         s << Color::Cyan << "[doctest] " << Color::None
-          << "unskipped test cases passing the current filters: "
-          << g_cs->numTestCasesPassingFilters << "\n";
+          << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
         s << Color::Cyan << "[doctest] " << Color::None
-          << "test suites with unskipped test cases passing the current filters: "
-          << g_cs->numTestSuitesPassingFilters << "\n";
+          << "test suites with unskipped test cases passing the current filters: " << g_cs->numTestSuitesPassingFilters
+          << "\n";
     }
 }
 
 void ConsoleReporter::test_run_start() {
-    if(!opt.minimal)
+    if (!opt.minimal)
         printIntro();
 }
 
-void ConsoleReporter::test_run_end(const TestRunStats& p) {
-    if(opt.minimal && p.numTestCasesFailed == 0)
+void ConsoleReporter::test_run_end(const TestRunStats &p) {
+    if (opt.minimal && p.numTestCasesFailed == 0)
         return;
 
     separator_to_stream();
     s << std::dec;
 
-    auto totwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-    auto passwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-    auto failwidth = int(std::ceil(log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+    auto totwidth = int(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)
+    ));
+    auto passwidth = int(std::ceil(log10(
+        static_cast<double>(std::max(
+            p.numTestCasesPassingFilters - p.numTestCasesFailed,
+            static_cast<unsigned>(p.numAsserts - p.numAssertsFailed)
+        )) +
+        1
+    )));
+    auto failwidth = int(std::ceil(
+        log10(static_cast<double>(std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)
+    ));
     const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
     s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
       << p.numTestCasesPassingFilters << " | "
-      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                  Color::Green)
-      << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-      << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-      << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
-    if(opt.no_skipped_summary == false) {
+      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed" << Color::None << " | "
+      << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numTestCasesFailed
+      << " failed" << Color::None << " |";
+    if (opt.no_skipped_summary == false) {
         const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-        s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
-          << " skipped" << Color::None;
+        s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped << " skipped" << Color::None;
     }
     s << "\n";
-    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
-      << p.numAsserts << " | "
-      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-      << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-      << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
-      << p.numAssertsFailed << " failed" << Color::None << " |\n";
+    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth) << p.numAsserts << " | "
+      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(passwidth)
+      << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None << " | "
+      << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth) << p.numAssertsFailed << " failed"
+      << Color::None << " |\n";
     s << Color::Cyan << "[doctest] " << Color::None
       << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
       << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
 }
 
-void ConsoleReporter::test_case_start(const TestCaseData& in) {
+void ConsoleReporter::test_case_start(const TestCaseData &in) {
     hasLoggedCurrentTestStart = false;
-    tc                        = &in;
+    tc = &in;
     subcasesStack.clear();
     currentSubcaseLevel = 0;
 }
 
-void ConsoleReporter::test_case_reenter(const TestCaseData&) {
+void ConsoleReporter::test_case_reenter(const TestCaseData &) {
     subcasesStack.clear();
 }
 
-void ConsoleReporter::test_case_end(const CurrentTestCaseStats& st) {
-    if(tc->m_no_output)
+void ConsoleReporter::test_case_end(const CurrentTestCaseStats &st) {
+    if (tc->m_no_output)
         return;
 
     // log the preamble of the test case only if there is something
     // else to print - something other than that an assert has failed
-    if(opt.duration ||
+    if (opt.duration ||
         (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
         logTestStart();
 
-    if(opt.duration)
-        s << Color::None << std::setprecision(6) << std::fixed << st.seconds
-          << " s: " << tc->m_name << "\n";
+    if (opt.duration)
+        s << Color::None << std::setprecision(6) << std::fixed << st.seconds << " s: " << tc->m_name << "\n";
 
-    if(st.failure_flags & TestCaseFailureReason::Timeout)
-        s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-          << std::fixed << tc->m_timeout << "!\n";
+    if (st.failure_flags & TestCaseFailureReason::Timeout)
+        s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6) << std::fixed << tc->m_timeout
+          << "!\n";
 
-    if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+    if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
         s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-    } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+    } else if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
         s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-    } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+    } else if (st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
         s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-    } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-        s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
-          << " times so marking it as failed!\n";
-    } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+    } else if (st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+        s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures << " times so marking it as failed!\n";
+    } else if (st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
         s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
           << " times as expected so marking it as not failed!\n";
     }
-    if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+    if (st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
         s << Color::Red << "Aborting - too many failed asserts!\n";
     }
     s << Color::None;
 }
 
-void ConsoleReporter::test_case_exception(const TestCaseException& e) {
+void ConsoleReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
-    if(tc->m_no_output)
+    if (tc->m_no_output)
         return;
 
     logTestStart();
 
     file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
     successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require : assertType::is_check);
-    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
-      << Color::Cyan << e.error_string << "\n";
+    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ");
+    s << Color::Cyan << e.error_string << "\n";
 
     int num_stringified_contexts = get_num_stringified_contexts();
-    if(num_stringified_contexts) {
+    if (num_stringified_contexts) {
         auto stringified_contexts = get_stringified_contexts();
         s << Color::None << "  logged: ";
-        for(int i = num_stringified_contexts; i > 0; --i) {
-            s << (i == num_stringified_contexts ? "" : "          ")
-              << stringified_contexts[i - 1] << "\n";
+        for (int i = num_stringified_contexts; i > 0; --i) {
+            s << (i == num_stringified_contexts ? "" : "          ") << stringified_contexts[i - 1] << "\n";
         }
     }
     s << "\n" << Color::None;
 }
 
-void ConsoleReporter::subcase_start(const SubcaseSignature& subc) {
+void ConsoleReporter::subcase_start(const SubcaseSignature &subc) {
     subcasesStack.push_back(subc);
     ++currentSubcaseLevel;
     hasLoggedCurrentTestStart = false;
@@ -416,8 +411,8 @@ void ConsoleReporter::subcase_end() {
     hasLoggedCurrentTestStart = false;
 }
 
-void ConsoleReporter::log_assert(const AssertData& rb) {
-    if((!rb.m_failed && !opt.success) || tc->m_no_output)
+void ConsoleReporter::log_assert(const AssertData &rb) {
+    if ((!rb.m_failed && !opt.success) || tc->m_no_output)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
@@ -432,8 +427,8 @@ void ConsoleReporter::log_assert(const AssertData& rb) {
     log_contexts();
 }
 
-void ConsoleReporter::log_message(const MessageData& mb) {
-    if(tc->m_no_output)
+void ConsoleReporter::log_message(const MessageData &mb) {
+    if (tc->m_no_output)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
@@ -442,13 +437,12 @@ void ConsoleReporter::log_message(const MessageData& mb) {
 
     file_line_to_stream(mb.m_file, mb.m_line, " ");
     s << getSuccessOrFailColor(false, mb.m_severity)
-      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                "MESSAGE") << ": ";
+      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE") << ": ";
     s << Color::None << mb.m_string << "\n";
     log_contexts();
 }
 
-void ConsoleReporter::test_case_skipped(const TestCaseData&) {}
+void ConsoleReporter::test_case_skipped(const TestCaseData &) {}
 
 } // namespace doctest
 

--- a/doctest/parts/private/reporters/console.h
+++ b/doctest/parts/private/reporters/console.h
@@ -16,29 +16,27 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-struct Whitespace
-{
+struct Whitespace {
     int nrSpaces;
     explicit Whitespace(int nr);
 };
 
-std::ostream& operator<<(std::ostream& out, const Whitespace& ws);
+std::ostream &operator<<(std::ostream &out, const Whitespace &ws);
 
-struct ConsoleReporter : public IReporter
-{
-    std::ostream&                 s;
-    bool                          hasLoggedCurrentTestStart;
+struct ConsoleReporter : public IReporter {
+    std::ostream &s;
+    bool hasLoggedCurrentTestStart;
     std::vector<SubcaseSignature> subcasesStack;
-    size_t                        currentSubcaseLevel;
+    size_t currentSubcaseLevel;
     DOCTEST_DECLARE_MUTEX(mutex)
 
     // caching pointers/references to objects of these types - safe to do
-    const ContextOptions& opt;
-    const TestCaseData*   tc;
+    const ContextOptions &opt;
+    const TestCaseData *tc;
 
-    ConsoleReporter(const ContextOptions& co);
+    ConsoleReporter(const ContextOptions &co);
 
-    ConsoleReporter(const ContextOptions& co, std::ostream& ostr);
+    ConsoleReporter(const ContextOptions &co, std::ostream &ostr);
 
     // =========================================================================================
     // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
@@ -46,16 +44,16 @@ struct ConsoleReporter : public IReporter
 
     void separator_to_stream();
 
-    const char* getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str);
+    const char *getSuccessOrFailString(bool success, assertType::Enum at, const char *success_str);
 
     Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at);
 
-    void successOrFailColoredStringToStream(bool success, assertType::Enum at, const char* success_str = "SUCCESS");
+    void successOrFailColoredStringToStream(bool success, assertType::Enum at, const char *success_str = "SUCCESS");
 
     void log_contexts();
 
     // this was requested to be made virtual so users could override it
-    virtual void file_line_to_stream(const char* file, int line, const char* tail = "");
+    virtual void file_line_to_stream(const char *file, int line, const char *tail = "");
 
     void logTestStart();
 
@@ -71,29 +69,29 @@ struct ConsoleReporter : public IReporter
     // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
     // =========================================================================================
 
-    void report_query(const QueryData& in) override;
+    void report_query(const QueryData &in) override;
 
     void test_run_start() override;
 
-    void test_run_end(const TestRunStats& p) override;
+    void test_run_end(const TestRunStats &p) override;
 
-    void test_case_start(const TestCaseData& in) override;
+    void test_case_start(const TestCaseData &in) override;
 
-    void test_case_reenter(const TestCaseData&) override;
+    void test_case_reenter(const TestCaseData &) override;
 
-    void test_case_end(const CurrentTestCaseStats& st) override;
+    void test_case_end(const CurrentTestCaseStats &st) override;
 
-    void test_case_exception(const TestCaseException& e) override;
+    void test_case_exception(const TestCaseException &e) override;
 
-    void subcase_start(const SubcaseSignature& subc) override;
+    void subcase_start(const SubcaseSignature &subc) override;
 
     void subcase_end() override;
 
-    void log_assert(const AssertData& rb) override;
+    void log_assert(const AssertData &rb) override;
 
-    void log_message(const MessageData& mb) override;
+    void log_message(const MessageData &mb) override;
 
-    void test_case_skipped(const TestCaseData&) override;
+    void test_case_skipped(const TestCaseData &) override;
 };
 
 DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);

--- a/doctest/parts/private/reporters/debug_output_window.cpp
+++ b/doctest/parts/private/reporters/debug_output_window.cpp
@@ -17,33 +17,33 @@ namespace detail {
 
 DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 
-DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions& co)
-        : ConsoleReporter(co, oss) {}
+DebugOutputWindowReporter::DebugOutputWindowReporter(const ContextOptions &co)
+    : ConsoleReporter(co, oss) {}
 
-#define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                    \
-    void DebugOutputWindowReporter::func(type arg) {                                                                 \
-        using detail::g_no_colors;                                                                 \
-        bool with_col = g_no_colors;                                                               \
-        g_no_colors   = false;                                                                     \
-        ConsoleReporter::func(arg);                                                                \
-        if(oss.tellp() != std::streampos{}) {                                                      \
-            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
-            oss.str("");                                                                           \
-        }                                                                                          \
-        g_no_colors = with_col;                                                                    \
+#define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                                        \
+    void DebugOutputWindowReporter::func(type arg) {                                                                   \
+        using detail::g_no_colors;                                                                                     \
+        bool with_col = g_no_colors;                                                                                   \
+        g_no_colors = false;                                                                                           \
+        ConsoleReporter::func(arg);                                                                                    \
+        if (oss.tellp() != std::streampos{}) {                                                                         \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                                            \
+            oss.str("");                                                                                               \
+        }                                                                                                              \
+        g_no_colors = with_col;                                                                                        \
     }
 
 DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature&, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature &, in)
 DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_end, DOCTEST_EMPTY, DOCTEST_EMPTY)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData&, in)
-DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData&, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData &, in)
+DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData &, in)
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 

--- a/doctest/parts/private/reporters/debug_output_window.h
+++ b/doctest/parts/private/reporters/debug_output_window.h
@@ -13,24 +13,23 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    struct DebugOutputWindowReporter : public ConsoleReporter
-    {
-        DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+struct DebugOutputWindowReporter : public ConsoleReporter {
+    DOCTEST_THREAD_LOCAL static std::ostringstream oss;
 
-        DebugOutputWindowReporter(const ContextOptions& co);
+    DebugOutputWindowReporter(const ContextOptions &co);
 
-        void test_run_start() override;
-        void test_run_end(const TestRunStats& in) override;
-        void test_case_start(const TestCaseData& in) override;
-        void test_case_reenter(const TestCaseData& in) override;
-        void test_case_end(const CurrentTestCaseStats& in) override;
-        void test_case_exception(const TestCaseException& in) override;
-        void subcase_start(const SubcaseSignature& in) override;
-        void subcase_end(DOCTEST_EMPTY DOCTEST_EMPTY) override;
-        void log_assert(const AssertData& in) override;
-        void log_message(const MessageData& in) override;
-        void test_case_skipped(const TestCaseData& in) override;
-    };
+    void test_run_start() override;
+    void test_run_end(const TestRunStats &in) override;
+    void test_case_start(const TestCaseData &in) override;
+    void test_case_reenter(const TestCaseData &in) override;
+    void test_case_end(const CurrentTestCaseStats &in) override;
+    void test_case_exception(const TestCaseException &in) override;
+    void subcase_start(const SubcaseSignature &in) override;
+    void subcase_end(DOCTEST_EMPTY DOCTEST_EMPTY) override;
+    void log_assert(const AssertData &in) override;
+    void log_message(const MessageData &in) override;
+    void test_case_skipped(const TestCaseData &in) override;
+};
 #endif // DOCTEST_PLATFORM_WINDOWS
 
 } // namespace detail

--- a/doctest/parts/private/reporters/junit.cpp
+++ b/doctest/parts/private/reporters/junit.cpp
@@ -13,66 +13,72 @@ std::string JUnitReporter::JUnitTestCaseData::getCurrentTimestamp() {
     // Also, UTC only, again because of backward compatibility (%z is C++11)
     time_t rawtime;
     std::time(&rawtime);
-    auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+    const auto timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
     std::tm timeInfo;
 #ifdef DOCTEST_PLATFORM_WINDOWS
     gmtime_s(&timeInfo, &rawtime);
-#else // DOCTEST_PLATFORM_WINDOWS
+#else  // DOCTEST_PLATFORM_WINDOWS
     gmtime_r(&rawtime, &timeInfo);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
     char timeStamp[timeStampSize];
-    const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+    const char *const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
     std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
     return std::string(timeStamp);
 }
 
-JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_type, const std::string &_details
+)
     : message(_message), type(_type), details(_details) {}
 
-JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(const std::string& _message, const std::string& _details)
+JUnitReporter::JUnitTestCaseData::JUnitTestMessage::JUnitTestMessage(
+    const std::string &_message, const std::string &_details
+)
     : message(_message), type(), details(_details) {}
 
-JUnitReporter::JUnitTestCaseData::JUnitTestCase::JUnitTestCase(const std::string& _classname, const std::string& _name)
+JUnitReporter::JUnitTestCaseData::JUnitTestCase::JUnitTestCase(const std::string &_classname, const std::string &_name)
     : classname(_classname), name(_name), time(0), failures() {}
 
-
-void JUnitReporter::JUnitTestCaseData::add(const std::string& classname, const std::string& name) {
+void JUnitReporter::JUnitTestCaseData::add(const std::string &classname, const std::string &name) {
     testcases.emplace_back(classname, name);
 }
 
 void JUnitReporter::JUnitTestCaseData::appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
-    for(auto& curr: nameStack)
-        if(curr.size())
+    for (auto &curr: nameStack)
+        if (curr.size())
             testcases.back().name += std::string("/") + curr.c_str();
 }
 
 void JUnitReporter::JUnitTestCaseData::addTime(double time) {
-    if(time < 1e-4)
+    if (time < 1e-4)
         time = 0;
     testcases.back().time = time;
     totalSeconds += time;
 }
 
-void JUnitReporter::JUnitTestCaseData::addFailure(const std::string& message, const std::string& type, const std::string& details) {
+void JUnitReporter::JUnitTestCaseData::addFailure(
+    const std::string &message, const std::string &type, const std::string &details
+) {
     testcases.back().failures.emplace_back(message, type, details);
     ++totalFailures;
 }
 
-void JUnitReporter::JUnitTestCaseData::addError(const std::string& message, const std::string& details) {
+void JUnitReporter::JUnitTestCaseData::addError(const std::string &message, const std::string &details) {
     testcases.back().errors.emplace_back(message, details);
     ++totalErrors;
 }
 
-JUnitReporter::JUnitReporter(const ContextOptions& co)
-        : xml(*co.cout)
-        , opt(co) {}
+JUnitReporter::JUnitReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
 
-unsigned JUnitReporter::line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+unsigned JUnitReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
 
-void JUnitReporter::report_query(const QueryData&) {
+void JUnitReporter::report_query(const QueryData &) {
     xml.writeDeclaration();
 }
 
@@ -80,45 +86,44 @@ void JUnitReporter::test_run_start() {
     xml.writeDeclaration();
 }
 
-void JUnitReporter::test_run_end(const TestRunStats& p) {
+void JUnitReporter::test_run_end(const TestRunStats &p) {
     // remove .exe extension - mainly to have the same output on UNIX and Windows
     std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(binary_name.rfind(".exe") != std::string::npos)
+    if (binary_name.rfind(".exe") != std::string::npos)
         binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
     xml.startElement("testsuites");
-    xml.startElement("testsuite").writeAttribute("name", binary_name)
-            .writeAttribute("errors", testCaseData.totalErrors)
-            .writeAttribute("failures", testCaseData.totalFailures)
-            .writeAttribute("tests", p.numAsserts);
-    if(opt.no_time_in_output == false) {
+    xml.startElement("testsuite")
+        .writeAttribute("name", binary_name)
+        .writeAttribute("errors", testCaseData.totalErrors)
+        .writeAttribute("failures", testCaseData.totalFailures)
+        .writeAttribute("tests", p.numAsserts);
+    if (opt.no_time_in_output == false) {
         xml.writeAttribute("time", testCaseData.totalSeconds);
         xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
     }
-    if(opt.no_version == false)
+    if (opt.no_version == false)
         xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
 
-    for(const auto& testCase : testCaseData.testcases) {
+    for (const auto &testCase: testCaseData.testcases) {
         xml.startElement("testcase")
             .writeAttribute("classname", testCase.classname)
             .writeAttribute("name", testCase.name);
-        if(opt.no_time_in_output == false)
+        if (opt.no_time_in_output == false)
             xml.writeAttribute("time", testCase.time);
         // This is not ideal, but it should be enough to mimic gtest's junit output.
         xml.writeAttribute("status", "run");
 
-        for(const auto& failure : testCase.failures) {
+        for (const auto &failure: testCase.failures) {
             xml.scopedElement("failure")
                 .writeAttribute("message", failure.message)
                 .writeAttribute("type", failure.type)
                 .writeText(failure.details, false);
         }
 
-        for(const auto& error : testCase.errors) {
-            xml.scopedElement("error")
-                .writeAttribute("message", error.message)
-                .writeText(error.details);
+        for (const auto &error: testCase.errors) {
+            xml.scopedElement("error").writeAttribute("message", error.message).writeText(error.details);
         }
 
         xml.endElement();
@@ -127,12 +132,12 @@ void JUnitReporter::test_run_end(const TestRunStats& p) {
     xml.endElement();
 }
 
-void JUnitReporter::test_case_start(const TestCaseData& in) {
+void JUnitReporter::test_case_start(const TestCaseData &in) {
     testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
     timer.start();
 }
 
-void JUnitReporter::test_case_reenter(const TestCaseData& in) {
+void JUnitReporter::test_case_reenter(const TestCaseData &in) {
     testCaseData.addTime(timer.getElapsedSeconds());
     testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
     deepestSubcaseStackNames.clear();
@@ -141,64 +146,65 @@ void JUnitReporter::test_case_reenter(const TestCaseData& in) {
     testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
 }
 
-void JUnitReporter::test_case_end(const CurrentTestCaseStats&) {
+void JUnitReporter::test_case_end(const CurrentTestCaseStats &) {
     testCaseData.addTime(timer.getElapsedSeconds());
     testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
     deepestSubcaseStackNames.clear();
 }
 
-void JUnitReporter::test_case_exception(const TestCaseException& e) {
+void JUnitReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
     testCaseData.addError("exception", e.error_string.c_str());
 }
 
-void JUnitReporter::subcase_start(const SubcaseSignature& in) {
+void JUnitReporter::subcase_start(const SubcaseSignature &in) {
     deepestSubcaseStackNames.push_back(in.m_name);
 }
 
 void JUnitReporter::subcase_end() {}
 
-void JUnitReporter::log_assert(const AssertData& rb) {
-    if(!rb.m_failed) // report only failures & ignore the `success` option
+void JUnitReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed) // report only failures & ignore the `success` option
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     std::ostringstream os;
-    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
-      << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(rb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
     fulltext_log_assert_to_stream(os, rb);
     log_contexts(os);
     testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
 }
 
-void JUnitReporter::log_message(const MessageData& mb) {
-    if(mb.m_severity & assertType::is_warn) // report only failures
+void JUnitReporter::log_message(const MessageData &mb) {
+    if (mb.m_severity & assertType::is_warn) // report only failures
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     std::ostringstream os;
-    os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(")
-      << line(mb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+    os << skipPathFromFilename(mb.m_file) << (opt.gnu_file_line ? ":" : "(") << line(mb.m_line)
+       << (opt.gnu_file_line ? ":" : "):") << std::endl;
 
     os << mb.m_string.c_str() << "\n";
     log_contexts(os);
 
-    testCaseData.addFailure(mb.m_string.c_str(),
-        mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str());
+    testCaseData.addFailure(
+        mb.m_string.c_str(), mb.m_severity & assertType::is_check ? "FAIL_CHECK" : "FAIL", os.str()
+    );
 }
 
-void JUnitReporter::test_case_skipped(const TestCaseData&) {}
+void JUnitReporter::test_case_skipped(const TestCaseData &) {}
 
-void JUnitReporter::log_contexts(std::ostringstream& s) {
+void JUnitReporter::log_contexts(std::ostringstream &s) {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
+    if (num_contexts) {
         auto contexts = get_active_contexts();
 
         s << "  logged: ";
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             s << (i == 0 ? "" : "          ");
             contexts[i]->stringify(&s);
             s << std::endl;

--- a/doctest/parts/private/reporters/junit.h
+++ b/doctest/parts/private/reporters/junit.h
@@ -11,97 +11,93 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-    // TODO:
-    // - log_message()
-    // - respond to queries
-    // - honor remaining options
-    // - more attributes in tags
-    struct JUnitReporter : public IReporter
-    {
-        detail::XmlWriter xml;
-        DOCTEST_DECLARE_MUTEX(mutex)
-        detail::Timer timer;
-        std::vector<String> deepestSubcaseStackNames;
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter {
+    detail::XmlWriter xml;
+    DOCTEST_DECLARE_MUTEX(mutex)
+    detail::Timer timer;
+    std::vector<String> deepestSubcaseStackNames;
 
-        struct JUnitTestCaseData
-        {
-            static std::string getCurrentTimestamp();
+    struct JUnitTestCaseData {
+        static std::string getCurrentTimestamp();
 
-            struct JUnitTestMessage
-            {
-                JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details);
+        struct JUnitTestMessage {
+            JUnitTestMessage(const std::string &_message, const std::string &_type, const std::string &_details);
 
-                JUnitTestMessage(const std::string& _message, const std::string& _details);
+            JUnitTestMessage(const std::string &_message, const std::string &_details);
 
-                std::string message, type, details;
-            };
-
-            struct JUnitTestCase
-            {
-                JUnitTestCase(const std::string& _classname, const std::string& _name);
-
-                std::string classname, name;
-                double time;
-                std::vector<JUnitTestMessage> failures, errors;
-            };
-
-            void add(const std::string& classname, const std::string& name);
-
-            void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack);
-
-            void addTime(double time);
-
-            void addFailure(const std::string& message, const std::string& type, const std::string& details);
-
-            void addError(const std::string& message, const std::string& details);
-
-            std::vector<JUnitTestCase> testcases;
-            double totalSeconds = 0;
-            int totalErrors = 0, totalFailures = 0;
+            std::string message, type, details;
         };
 
-        JUnitTestCaseData testCaseData;
+        struct JUnitTestCase {
+            JUnitTestCase(const std::string &_classname, const std::string &_name);
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+            std::string classname, name;
+            double time;
+            std::vector<JUnitTestMessage> failures, errors;
+        };
 
-        JUnitReporter(const ContextOptions& co);
+        void add(const std::string &classname, const std::string &name);
 
-        unsigned line(unsigned l) const;
+        void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack);
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
+        void addTime(double time);
 
-        void report_query(const QueryData&) override;
+        void addFailure(const std::string &message, const std::string &type, const std::string &details);
 
-        void test_run_start() override;
+        void addError(const std::string &message, const std::string &details);
 
-        void test_run_end(const TestRunStats& p) override;
-
-        void test_case_start(const TestCaseData& in) override;
-
-        void test_case_reenter(const TestCaseData& in) override;
-
-        void test_case_end(const CurrentTestCaseStats&) override;
-
-        void test_case_exception(const TestCaseException& e) override;
-
-        void subcase_start(const SubcaseSignature& in) override;
-
-        void subcase_end() override;
-
-        void log_assert(const AssertData& rb) override;
-
-        void log_message(const MessageData& mb) override;
-
-        void test_case_skipped(const TestCaseData&) override;
-
-        void log_contexts(std::ostringstream& s);
+        std::vector<JUnitTestCase> testcases;
+        double totalSeconds = 0;
+        int totalErrors = 0, totalFailures = 0;
     };
 
-    DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+    JUnitTestCaseData testCaseData;
+
+    // caching pointers/references to objects of these types - safe to do
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
+
+    JUnitReporter(const ContextOptions &co);
+
+    unsigned line(unsigned l) const;
+
+    // =========================================================================================
+    // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+    // =========================================================================================
+
+    void report_query(const QueryData &) override;
+
+    void test_run_start() override;
+
+    void test_run_end(const TestRunStats &p) override;
+
+    void test_case_start(const TestCaseData &in) override;
+
+    void test_case_reenter(const TestCaseData &in) override;
+
+    void test_case_end(const CurrentTestCaseStats &) override;
+
+    void test_case_exception(const TestCaseException &e) override;
+
+    void subcase_start(const SubcaseSignature &in) override;
+
+    void subcase_end() override;
+
+    void log_assert(const AssertData &rb) override;
+
+    void log_message(const MessageData &mb) override;
+
+    void test_case_skipped(const TestCaseData &) override;
+
+    void log_contexts(std::ostringstream &s);
+};
+
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
 
 } // namespace doctest
 

--- a/doctest/parts/private/reporters/xml.cpp
+++ b/doctest/parts/private/reporters/xml.cpp
@@ -7,16 +7,15 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-XmlReporter::XmlReporter(const ContextOptions& co)
-        : xml(*co.cout)
-        , opt(co) {}
+XmlReporter::XmlReporter(const ContextOptions &co)
+    : xml(*co.cout), opt(co) {}
 
 void XmlReporter::log_contexts() {
     int num_contexts = get_num_active_contexts();
-    if(num_contexts) {
-        auto              contexts = get_active_contexts();
+    if (num_contexts) {
+        auto contexts = get_active_contexts();
         std::stringstream ss;
-        for(int i = 0; i < num_contexts; ++i) {
+        for (int i = 0; i < num_contexts; ++i) {
             contexts[i]->stringify(&ss);
             xml.scopedElement("Info").writeText(ss.str());
             ss.str("");
@@ -24,68 +23,70 @@ void XmlReporter::log_contexts() {
     }
 }
 
-unsigned XmlReporter::line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+unsigned XmlReporter::line(unsigned l) const {
+    return opt.no_line_numbers ? 0 : l;
+}
 
-void XmlReporter::test_case_start_impl(const TestCaseData& in) {
+void XmlReporter::test_case_start_impl(const TestCaseData &in) {
     bool open_ts_tag = false;
-    if(tc != nullptr) { // we have already opened a test suite
-        if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+    if (tc != nullptr) { // we have already opened a test suite
+        if (std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
             xml.endElement();
             open_ts_tag = true;
         }
-    }
-    else {
+    } else {
         open_ts_tag = true; // first test case ==> first test suite
     }
 
-    if(open_ts_tag) {
+    if (open_ts_tag) {
         xml.startElement("TestSuite");
         xml.writeAttribute("name", in.m_test_suite);
     }
 
     tc = &in;
     xml.startElement("TestCase")
-            .writeAttribute("name", in.m_name)
-            .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
-            .writeAttribute("line", line(in.m_line))
-            .writeAttribute("description", in.m_description);
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+        .writeAttribute("line", line(in.m_line))
+        .writeAttribute("description", in.m_description);
 
-    if(Approx(in.m_timeout) != 0)
+    if (Approx(in.m_timeout) != 0)
         xml.writeAttribute("timeout", in.m_timeout);
-    if(in.m_may_fail)
+    if (in.m_may_fail)
         xml.writeAttribute("may_fail", true);
-    if(in.m_should_fail)
+    if (in.m_should_fail)
         xml.writeAttribute("should_fail", true);
 }
 
-void XmlReporter::report_query(const QueryData& in) {
+void XmlReporter::report_query(const QueryData &in) {
     test_run_start();
-    if(opt.list_reporters) {
-        for(auto& curr : detail::getListeners())
+    if (opt.list_reporters) {
+        for (auto &curr: detail::getListeners())
             xml.scopedElement("Listener")
-                    .writeAttribute("priority", curr.first.first)
-                    .writeAttribute("name", curr.first.second);
-        for(auto& curr : detail::getReporters())
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+        for (auto &curr: detail::getReporters())
             xml.scopedElement("Reporter")
-                    .writeAttribute("priority", curr.first.first)
-                    .writeAttribute("name", curr.first.second);
-    } else if(opt.count || opt.list_test_cases) {
-        for(unsigned i = 0; i < in.num_data; ++i) {
-            xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+                .writeAttribute("priority", curr.first.first)
+                .writeAttribute("name", curr.first.second);
+    } else if (opt.count || opt.list_test_cases) {
+        for (unsigned i = 0; i < in.num_data; ++i) {
+            xml.scopedElement("TestCase")
+                .writeAttribute("name", in.data[i]->m_name)
                 .writeAttribute("testsuite", in.data[i]->m_test_suite)
                 .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
                 .writeAttribute("line", line(in.data[i]->m_line))
                 .writeAttribute("skipped", in.data[i]->m_skip);
         }
         xml.scopedElement("OverallResultsTestCases")
-                .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-    } else if(opt.list_test_suites) {
-        for(unsigned i = 0; i < in.num_data; ++i)
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+    } else if (opt.list_test_suites) {
+        for (unsigned i = 0; i < in.num_data; ++i)
             xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
         xml.scopedElement("OverallResultsTestCases")
-                .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+            .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
         xml.scopedElement("OverallResultsTestSuites")
-                .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
+            .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
     }
     xml.endElement();
 }
@@ -96,108 +97,106 @@ void XmlReporter::test_run_start() {
     // remove .exe extension - mainly to have the same output on UNIX and Windows
     std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(binary_name.rfind(".exe") != std::string::npos)
+    if (binary_name.rfind(".exe") != std::string::npos)
         binary_name = binary_name.substr(0, binary_name.length() - 4);
 #endif // DOCTEST_PLATFORM_WINDOWS
 
     xml.startElement("doctest").writeAttribute("binary", binary_name);
-    if(opt.no_version == false)
+    if (opt.no_version == false)
         xml.writeAttribute("version", DOCTEST_VERSION_STR);
 
     // only the consequential ones (TODO: filters)
     xml.scopedElement("Options")
-            .writeAttribute("order_by", opt.order_by.c_str())
-            .writeAttribute("rand_seed", opt.rand_seed)
-            .writeAttribute("first", opt.first)
-            .writeAttribute("last", opt.last)
-            .writeAttribute("abort_after", opt.abort_after)
-            .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
-            .writeAttribute("case_sensitive", opt.case_sensitive)
-            .writeAttribute("no_throw", opt.no_throw)
-            .writeAttribute("no_skip", opt.no_skip);
+        .writeAttribute("order_by", opt.order_by.c_str())
+        .writeAttribute("rand_seed", opt.rand_seed)
+        .writeAttribute("first", opt.first)
+        .writeAttribute("last", opt.last)
+        .writeAttribute("abort_after", opt.abort_after)
+        .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+        .writeAttribute("case_sensitive", opt.case_sensitive)
+        .writeAttribute("no_throw", opt.no_throw)
+        .writeAttribute("no_skip", opt.no_skip);
 }
 
-void XmlReporter::test_run_end(const TestRunStats& p) {
-    if(tc) // the TestSuite tag - only if there has been at least 1 test case
+void XmlReporter::test_run_end(const TestRunStats &p) {
+    if (tc) // the TestSuite tag - only if there has been at least 1 test case
         xml.endElement();
 
     xml.scopedElement("OverallResultsAsserts")
-            .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
-            .writeAttribute("failures", p.numAssertsFailed);
+        .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+        .writeAttribute("failures", p.numAssertsFailed);
 
     xml.startElement("OverallResultsTestCases")
-            .writeAttribute("successes",
-                            p.numTestCasesPassingFilters - p.numTestCasesFailed)
-            .writeAttribute("failures", p.numTestCasesFailed);
-    if(opt.no_skipped_summary == false)
+        .writeAttribute("successes", p.numTestCasesPassingFilters - p.numTestCasesFailed)
+        .writeAttribute("failures", p.numTestCasesFailed);
+    if (opt.no_skipped_summary == false)
         xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
     xml.endElement();
 
     xml.endElement();
 }
 
-void XmlReporter::test_case_start(const TestCaseData& in) {
+void XmlReporter::test_case_start(const TestCaseData &in) {
     test_case_start_impl(in);
     xml.ensureTagClosed();
 }
 
-void XmlReporter::test_case_reenter(const TestCaseData&) {}
+void XmlReporter::test_case_reenter(const TestCaseData &) {}
 
-void XmlReporter::test_case_end(const CurrentTestCaseStats& st) {
+void XmlReporter::test_case_end(const CurrentTestCaseStats &st) {
     xml.startElement("OverallResultsAsserts")
-            .writeAttribute("successes",
-                            st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-            .writeAttribute("failures", st.numAssertsFailedCurrentTest)
-            .writeAttribute("test_case_success", st.testCaseSuccess);
-    if(opt.duration)
+        .writeAttribute("successes", st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+        .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+        .writeAttribute("test_case_success", st.testCaseSuccess);
+    if (opt.duration)
         xml.writeAttribute("duration", st.seconds);
-    if(tc->m_expected_failures)
+    if (tc->m_expected_failures)
         xml.writeAttribute("expected_failures", tc->m_expected_failures);
     xml.endElement();
 
     xml.endElement();
 }
 
-void XmlReporter::test_case_exception(const TestCaseException& e) {
+void XmlReporter::test_case_exception(const TestCaseException &e) {
     DOCTEST_LOCK_MUTEX(mutex)
 
-    xml.scopedElement("Exception")
-            .writeAttribute("crash", e.is_crash)
-            .writeText(e.error_string.c_str());
+    xml.scopedElement("Exception").writeAttribute("crash", e.is_crash).writeText(e.error_string.c_str());
 }
 
-void XmlReporter::subcase_start(const SubcaseSignature& in) {
+void XmlReporter::subcase_start(const SubcaseSignature &in) {
     xml.startElement("SubCase")
-            .writeAttribute("name", in.m_name)
-            .writeAttribute("filename", skipPathFromFilename(in.m_file))
-            .writeAttribute("line", line(in.m_line));
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file))
+        .writeAttribute("line", line(in.m_line));
     xml.ensureTagClosed();
 }
 
-void XmlReporter::subcase_end() { xml.endElement(); }
+void XmlReporter::subcase_end() {
+    xml.endElement();
+}
 
-void XmlReporter::log_assert(const AssertData& rb) {
-    if(!rb.m_failed && !opt.success)
+void XmlReporter::log_assert(const AssertData &rb) {
+    if (!rb.m_failed && !opt.success)
         return;
 
     DOCTEST_LOCK_MUTEX(mutex)
 
     xml.startElement("Expression")
-            .writeAttribute("success", !rb.m_failed)
-            .writeAttribute("type", assertString(rb.m_at))
-            .writeAttribute("filename", skipPathFromFilename(rb.m_file))
-            .writeAttribute("line", line(rb.m_line));
+        .writeAttribute("success", !rb.m_failed)
+        .writeAttribute("type", assertString(rb.m_at))
+        .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+        .writeAttribute("line", line(rb.m_line));
 
     xml.scopedElement("Original").writeText(rb.m_expr);
 
-    if(rb.m_threw)
+    if (rb.m_threw)
         xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
 
-    if(rb.m_at & assertType::is_throws_as)
+    if (rb.m_at & assertType::is_throws_as)
         xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-    if(rb.m_at & assertType::is_throws_with)
+    if (rb.m_at & assertType::is_throws_with)
         xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
-    if((rb.m_at & assertType::is_normal) && !rb.m_threw)
+    if ((rb.m_at & assertType::is_normal) && !rb.m_threw)
         xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
     log_contexts();
@@ -205,13 +204,13 @@ void XmlReporter::log_assert(const AssertData& rb) {
     xml.endElement();
 }
 
-void XmlReporter::log_message(const MessageData& mb) {
+void XmlReporter::log_message(const MessageData &mb) {
     DOCTEST_LOCK_MUTEX(mutex)
 
     xml.startElement("Message")
-            .writeAttribute("type", failureString(mb.m_severity))
-            .writeAttribute("filename", skipPathFromFilename(mb.m_file))
-            .writeAttribute("line", line(mb.m_line));
+        .writeAttribute("type", failureString(mb.m_severity))
+        .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+        .writeAttribute("line", line(mb.m_line));
 
     xml.scopedElement("Text").writeText(mb.m_string.c_str());
 
@@ -220,8 +219,8 @@ void XmlReporter::log_message(const MessageData& mb) {
     xml.endElement();
 }
 
-void XmlReporter::test_case_skipped(const TestCaseData& in) {
-    if(opt.no_skipped_summary == false) {
+void XmlReporter::test_case_skipped(const TestCaseData &in) {
+    if (opt.no_skipped_summary == false) {
         test_case_start_impl(in);
         xml.writeAttribute("skipped", "true");
         xml.endElement();

--- a/doctest/parts/private/reporters/xml.h
+++ b/doctest/parts/private/reporters/xml.h
@@ -11,50 +11,49 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
 namespace doctest {
 
-struct XmlReporter : public IReporter
-{
+struct XmlReporter : public IReporter {
     detail::XmlWriter xml;
     DOCTEST_DECLARE_MUTEX(mutex)
 
     // caching pointers/references to objects of these types - safe to do
-    const ContextOptions& opt;
-    const TestCaseData*   tc = nullptr;
+    const ContextOptions &opt;
+    const TestCaseData *tc = nullptr;
 
-    XmlReporter(const ContextOptions& co);
+    XmlReporter(const ContextOptions &co);
 
     void log_contexts();
 
     unsigned line(unsigned l) const;
 
-    void test_case_start_impl(const TestCaseData& in);
+    void test_case_start_impl(const TestCaseData &in);
 
     // =========================================================================================
     // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
     // =========================================================================================
 
-    void report_query(const QueryData& in) override;
+    void report_query(const QueryData &in) override;
 
     void test_run_start() override;
 
-    void test_run_end(const TestRunStats& p) override;
+    void test_run_end(const TestRunStats &p) override;
 
-    void test_case_start(const TestCaseData& in) override;
+    void test_case_start(const TestCaseData &in) override;
 
-    void test_case_reenter(const TestCaseData&) override;
+    void test_case_reenter(const TestCaseData &) override;
 
-    void test_case_end(const CurrentTestCaseStats& st) override;
+    void test_case_end(const CurrentTestCaseStats &st) override;
 
-    void test_case_exception(const TestCaseException& e) override;
+    void test_case_exception(const TestCaseException &e) override;
 
-    void subcase_start(const SubcaseSignature& in) override;
+    void subcase_start(const SubcaseSignature &in) override;
 
     void subcase_end() override;
 
-    void log_assert(const AssertData& rb) override;
+    void log_assert(const AssertData &rb) override;
 
-    void log_message(const MessageData& mb) override;
+    void log_message(const MessageData &mb) override;
 
-    void test_case_skipped(const TestCaseData& in) override;
+    void test_case_skipped(const TestCaseData &in) override;
 };
 
 DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);

--- a/doctest/parts/private/signals.cpp
+++ b/doctest/parts/private/signals.cpp
@@ -21,33 +21,31 @@ void FatalConditionHandler::freeAltStackMem() {}
 // Windows can easily distinguish between SO and SigSegV,
 // but SigInt, SigTerm, etc are handled differently.
 SignalDefs signalDefs[] = {
-        {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),
-          "SIGILL - Illegal instruction signal"},
-        {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
-        {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION),
-          "SIGSEGV - Segmentation violation signal"},
-        {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
+    {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION), "SIGILL - Illegal instruction signal"},
+    {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
+    {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION), "SIGSEGV - Segmentation violation signal"},
+    {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
 };
 
 LONG CALLBACK FatalConditionHandler::handleException(PEXCEPTION_POINTERS ExceptionInfo) {
-    // Multiple threads may enter this filter/handler at once. We want the error message to be printed on the
-    // console just once no matter how many threads have crashed.
+    // Multiple threads may enter this filter/handler at once. We want the error message to be
+    // printed on the console just once no matter how many threads have crashed.
     DOCTEST_DECLARE_STATIC_MUTEX(mutex)
     static bool execute = true;
     {
         DOCTEST_LOCK_MUTEX(mutex)
-        if(execute) {
+        if (execute) {
             bool reported = false;
-            for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+            for (size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+                if (ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
                     reportFatal(signalDefs[i].name);
                     reported = true;
                     break;
                 }
             }
-            if(reported == false)
+            if (reported == false)
                 reportFatal("Unhandled SEH exception caught");
-            if(isDebuggerActive() && !g_cs->no_breaks)
+            if (isDebuggerActive() && !g_cs->no_breaks)
                 DOCTEST_BREAK_INTO_DEBUGGER();
         }
         execute = false;
@@ -77,7 +75,7 @@ FatalConditionHandler::FatalConditionHandler() {
     original_terminate_handler = std::get_terminate();
     std::set_terminate([]() DOCTEST_NOEXCEPT {
         reportFatal("Terminate handler called");
-        if(isDebuggerActive() && !g_cs->no_breaks)
+        if (isDebuggerActive() && !g_cs->no_breaks)
             DOCTEST_BREAK_INTO_DEBUGGER();
         std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
     });
@@ -87,9 +85,9 @@ FatalConditionHandler::FatalConditionHandler() {
     // - an exception is thrown from a destructor FROM A DIFFERENT THREAD
     // - an uncaught exception is thrown FROM A DIFFERENT THREAD
     prev_sigabrt_handler = std::signal(SIGABRT, [](int signal) DOCTEST_NOEXCEPT {
-        if(signal == SIGABRT) {
+        if (signal == SIGABRT) {
             reportFatal("SIGABRT - Abort (abnormal termination) signal");
-            if(isDebuggerActive() && !g_cs->no_breaks)
+            if (isDebuggerActive() && !g_cs->no_breaks)
                 DOCTEST_BREAK_INTO_DEBUGGER();
             std::exit(EXIT_FAILURE);
         }
@@ -99,8 +97,9 @@ FatalConditionHandler::FatalConditionHandler() {
     // specifically from UnitTest::Run() inside of gtest.cc
 
     // the user does not want to see pop-up dialogs about crashes
-    prev_error_mode_1 = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
-                                      SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    prev_error_mode_1 = SetErrorMode(
+        SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX
+    );
     // This forces the abort message to go to stderr in all circumstances.
     prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
     // In the debug version, Visual Studio pops up a separate dialog
@@ -115,7 +114,7 @@ FatalConditionHandler::FatalConditionHandler() {
 }
 
 void FatalConditionHandler::reset() {
-    if(isSet) {
+    if (isSet) {
         // Unregister handler and restore the old guarantee
         SetUnhandledExceptionFilter(previousTop);
         SetThreadStackGuarantee(&guaranteeSize);
@@ -130,14 +129,16 @@ void FatalConditionHandler::reset() {
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
 
-UINT         FatalConditionHandler::prev_error_mode_1;
-int          FatalConditionHandler::prev_error_mode_2;
+UINT FatalConditionHandler::prev_error_mode_1;
+int FatalConditionHandler::prev_error_mode_2;
 unsigned int FatalConditionHandler::prev_abort_behavior;
-int          FatalConditionHandler::prev_report_mode;
-_HFILE       FatalConditionHandler::prev_report_file;
-void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
+int FatalConditionHandler::prev_report_mode;
+_HFILE FatalConditionHandler::prev_report_file;
+void(DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
 std::terminate_handler FatalConditionHandler::original_terminate_handler;
 bool FatalConditionHandler::isSet = false;
 ULONG FatalConditionHandler::guaranteeSize = 0;
@@ -145,22 +146,23 @@ LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
-SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
-                            {SIGILL, "SIGILL - Illegal instruction signal"},
-                            {SIGFPE, "SIGFPE - Floating point error signal"},
-                            {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-                            {SIGTERM, "SIGTERM - Termination request signal"},
-                            {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+SignalDefs signalDefs[] = {
+    {SIGINT, "SIGINT - Terminal interrupt signal"},
+    {SIGILL, "SIGILL - Illegal instruction signal"},
+    {SIGFPE, "SIGFPE - Floating point error signal"},
+    {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+    {SIGTERM, "SIGTERM - Termination request signal"},
+    {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}
+};
 static_assert(
-  DOCTEST_COUNTOF(signalDefs) == DOCTEST_COUNTOF(FatalConditionHandler::oldSigActions),
-  "arrays should match in size"
+    DOCTEST_COUNTOF(signalDefs) == DOCTEST_COUNTOF(FatalConditionHandler::oldSigActions), "arrays should match in size"
 );
 
 void FatalConditionHandler::handleSignal(int sig) {
-    const char* name = "<unknown signal>";
-    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-        SignalDefs& def = signalDefs[i];
-        if(sig == def.id) {
+    const char *name = "<unknown signal>";
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        SignalDefs &def = signalDefs[i];
+        if (sig == def.id) {
             name = def.name;
             break;
         }
@@ -181,24 +183,26 @@ void FatalConditionHandler::freeAltStackMem() {
 FatalConditionHandler::FatalConditionHandler() {
     isSet = true;
     stack_t sigStack;
-    sigStack.ss_sp    = altStackMem;
-    sigStack.ss_size  = altStackSize;
+    sigStack.ss_sp = altStackMem;
+    sigStack.ss_size = altStackSize;
     sigStack.ss_flags = 0;
     sigaltstack(&sigStack, &oldSigStack);
     struct sigaction sa = {};
-    sa.sa_handler       = handleSignal;
-    sa.sa_flags         = SA_ONSTACK;
-    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+    sa.sa_handler = handleSignal;
+    sa.sa_flags = SA_ONSTACK;
+    for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
         sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
+FatalConditionHandler::~FatalConditionHandler() {
+    reset();
+}
 
 void FatalConditionHandler::reset() {
-    if(isSet) {
+    if (isSet) {
         // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-        for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
             sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
         }
         // Return the old stack
@@ -207,11 +211,11 @@ void FatalConditionHandler::reset() {
     }
 }
 
-bool             FatalConditionHandler::isSet = false;
+bool FatalConditionHandler::isSet = false;
 struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-stack_t          FatalConditionHandler::oldSigStack = {};
-size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
-char*            FatalConditionHandler::altStackMem = nullptr;
+stack_t FatalConditionHandler::oldSigStack = {};
+size_t FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
+char *FatalConditionHandler::altStackMem = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH

--- a/doctest/parts/private/signals.h
+++ b/doctest/parts/private/signals.h
@@ -12,74 +12,69 @@ namespace doctest {
 namespace detail {
 
 #if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    struct FatalConditionHandler
-    {
-        static void reset();
-        static void allocateAltStackMem();
-        static void freeAltStackMem();
-    };
+struct FatalConditionHandler {
+    static void reset();
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
+};
 #else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
-    {
-        DWORD id;
-        const char* name;
-    };
+struct SignalDefs {
+    DWORD id;
+    const char *name;
+};
 
-    struct FatalConditionHandler
-    {
-        static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo);
-        static void allocateAltStackMem();
-        static void freeAltStackMem();
+struct FatalConditionHandler {
+    static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo);
+    static void allocateAltStackMem();
+    static void freeAltStackMem();
 
-        FatalConditionHandler();
+    FatalConditionHandler();
 
-        static void reset();
+    static void reset();
 
-        ~FatalConditionHandler();
+    ~FatalConditionHandler();
 
-    private:
-        static UINT         prev_error_mode_1;
-        static int          prev_error_mode_2;
-        static unsigned int prev_abort_behavior;
-        static int          prev_report_mode;
-        static _HFILE       prev_report_file;
-        static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
-        static std::terminate_handler original_terminate_handler;
-        static bool isSet;
-        static ULONG guaranteeSize;
-        static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
-    };
+private:
+    static UINT prev_error_mode_1;
+    static int prev_error_mode_2;
+    static unsigned int prev_abort_behavior;
+    static int prev_report_mode;
+    static _HFILE prev_report_file;
+    static void(DOCTEST_CDECL *prev_sigabrt_handler)(int);
+    static std::terminate_handler original_terminate_handler;
+    static bool isSet;
+    static ULONG guaranteeSize;
+    static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
+};
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
-    {
-        int         id;
-        const char* name;
-    };
+struct SignalDefs {
+    int id;
+    const char *name;
+};
 
-    struct FatalConditionHandler
-    {
-        static bool             isSet;
-        static struct sigaction oldSigActions[6];
-        static stack_t          oldSigStack;
-        static size_t           altStackSize;
-        static char*            altStackMem;
+struct FatalConditionHandler {
+    static bool isSet;
+    static struct sigaction oldSigActions[6];
+    static stack_t oldSigStack;
+    static size_t altStackSize;
+    static char *altStackMem;
 
-        static void handleSignal(int sig);
+    static void handleSignal(int sig);
 
-        static void allocateAltStackMem();
+    static void allocateAltStackMem();
 
-        static void freeAltStackMem();
+    static void freeAltStackMem();
 
-        FatalConditionHandler();
+    FatalConditionHandler();
 
-        ~FatalConditionHandler();
-        static void reset();
-    };
+    ~FatalConditionHandler();
+    static void reset();
+};
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -6,305 +6,387 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_THREAD_LOCAL class
-    {
-        std::vector<std::streampos> stack;
-        std::stringstream           ss;
+DOCTEST_THREAD_LOCAL class {
+    std::vector<std::streampos> stack;
+    std::stringstream ss;
 
-    public:
-        std::ostream* push() {
-            stack.push_back(ss.tellp());
-            return &ss;
-        }
-
-        String pop() {
-            if (stack.empty())
-                DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
-
-            std::streampos pos = stack.back();
-            stack.pop_back();
-            unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
-            ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
-            return String(ss, sz);
-        }
-    } g_oss;
-
-    std::ostream* tlssPush() {
-        return g_oss.push();
+public:
+    std::ostream *push() {
+        stack.push_back(ss.tellp());
+        return &ss;
     }
 
-    String tlssPop() {
-        return g_oss.pop();
+    String pop() {
+        if (stack.empty())
+            DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
+
+        std::streampos pos = stack.back();
+        stack.pop_back();
+        unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
+        ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
+        return String(ss, sz);
     }
+} g_oss;
+
+std::ostream *tlssPush() {
+    return g_oss.push();
+}
+
+String tlssPop() {
+    return g_oss.pop();
+}
 
 } // namespace detail
 
-    // case insensitive strcmp
-    static int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
+// case insensitive strcmp
+static int stricmp(const char *a, const char *b) {
+    for (;; a++, b++) {
+        const int d = tolower(*a) - tolower(*b);
+        if (d != 0 || !*a)
+            return d;
     }
+}
 
-    char* String::allocate(size_type sz) {
-        if (sz <= last) {
-            buf[sz] = '\0';
-            setLast(last - sz);
-            return buf;
-        } else {
-            setOnHeap();
-            data.size = sz;
-            data.capacity = data.size + 1;
-            data.ptr = new char[data.capacity];
-            data.ptr[sz] = '\0';
-            return data.ptr;
-        }
+char *String::allocate(size_type sz) {
+    if (sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size = sz;
+        data.capacity = data.size + 1;
+        data.ptr = new char[data.capacity];
+        data.ptr[sz] = '\0';
+        return data.ptr;
     }
+}
 
-    void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-    void String::setLast(size_type in) noexcept { buf[last] = char(in); }
-    void String::setSize(size_type sz) noexcept {
-        if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
-        else { data.ptr[sz] = '\0'; data.size = sz; }
+void String::setOnHeap() noexcept {
+    *reinterpret_cast<unsigned char *>(&buf[last]) = 128;
+}
+
+void String::setLast(size_type in) noexcept {
+    buf[last] = char(in);
+}
+
+void String::setSize(size_type sz) noexcept {
+    if (isOnStack()) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+    } else {
+        data.ptr[sz] = '\0';
+        data.size = sz;
     }
+}
 
-    void String::copy(const String& other) {
-        if(other.isOnStack()) {
-            memcpy(buf, other.buf, len);
-        } else {
-            memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
-        }
+void String::copy(const String &other) {
+    if (other.isOnStack()) {
+        memcpy(buf, other.buf, len);
+    } else {
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
+}
 
-    String::String() noexcept {
-        buf[0] = '\0';
-        setLast();
-    }
+String::String() noexcept {
+    buf[0] = '\0';
+    setLast();
+}
 
-    String::~String() {
-        if(!isOnStack())
+String::~String() {
+    if (!isOnStack())
+        delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+String::String(const char *in)
+    : String(in, strlen(in)) {}
+
+String::String(const char *in, size_type in_size) {
+    memcpy(allocate(in_size), in, in_size);
+}
+
+String::String(std::istream &in, size_type in_size) {
+    in.read(allocate(in_size), in_size);
+}
+
+String::String(const String &other) {
+    copy(other);
+}
+
+String &String::operator=(const String &other) {
+    if (this != &other) {
+        if (!isOnStack())
             delete[] data.ptr;
-    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-    String::String(const char* in)
-            : String(in, strlen(in)) {}
-
-    String::String(const char* in, size_type in_size) {
-        memcpy(allocate(in_size), in, in_size);
+        copy(other);
     }
 
-    String::String(std::istream& in, size_type in_size) {
-        in.read(allocate(in_size), in_size);
-    }
+    return *this;
+}
 
-    String::String(const String& other) { copy(other); }
-
-    String& String::operator=(const String& other) {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-
-            copy(other);
-        }
-
-        return *this;
-    }
-
-    String& String::operator+=(const String& other) {
-        const size_type my_old_size = size();
-        const size_type other_size  = other.size();
-        const size_type total_size  = my_old_size + other_size;
-        if(isOnStack()) {
-            if(total_size < len) {
-                // append to the current stack space
-                memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-                // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-                setLast(last - total_size);
-            } else {
-                // alloc new chunk
-                char* temp = new char[total_size + 1];
-                // copy current data to new location before writing in the union
-                memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-                // update data in union
-                setOnHeap();
-                data.size     = total_size;
-                data.capacity = data.size + 1;
-                data.ptr      = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+String &String::operator+=(const String &other) {
+    const size_type my_old_size = size();
+    const size_type other_size = other.size();
+    const size_type total_size = my_old_size + other_size;
+    if (isOnStack()) {
+        if (total_size < len) {
+            // append to the current stack space
+            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+            setLast(last - total_size);
         } else {
-            if(data.capacity > total_size) {
-                // append to the current heap block
-                data.size = total_size;
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            } else {
-                // resize
-                data.capacity *= 2;
-                if(data.capacity <= total_size)
-                    data.capacity = total_size + 1;
-                // alloc new chunk
-                char* temp = new char[data.capacity];
-                // copy current data to new location before releasing it
-                memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-                // release old chunk
-                delete[] data.ptr;
-                // update the rest of the union members
-                data.size = total_size;
-                data.ptr  = temp;
-                // transfer the rest of the data
-                memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-            }
+            // alloc new chunk
+            char *temp = new char[total_size + 1];
+            // copy current data to new location before writing in the union
+            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            // update data in union
+            setOnHeap();
+            data.size = total_size;
+            data.capacity = data.size + 1;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
-
-        return *this;
+    } else {
+        if (data.capacity > total_size) {
+            // append to the current heap block
+            data.size = total_size;
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        } else {
+            // resize
+            data.capacity *= 2;
+            if (data.capacity <= total_size)
+                data.capacity = total_size + 1;
+            // alloc new chunk
+            char *temp = new char[data.capacity];
+            // copy current data to new location before releasing it
+            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            // release old chunk
+            delete[] data.ptr;
+            // update the rest of the union members
+            data.size = total_size;
+            data.ptr = temp;
+            // transfer the rest of the data
+            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+        }
     }
 
-    String::String(String&& other) noexcept {
+    return *this;
+}
+
+String::String(String &&other) noexcept {
+    memcpy(buf, other.buf, len);
+    other.buf[0] = '\0';
+    other.setLast();
+}
+
+String &String::operator=(String &&other) noexcept {
+    if (this != &other) {
+        if (!isOnStack())
+            delete[] data.ptr;
         memcpy(buf, other.buf, len);
         other.buf[0] = '\0';
         other.setLast();
     }
+    return *this;
+}
 
-    String& String::operator=(String&& other) noexcept {
-        if(this != &other) {
-            if(!isOnStack())
-                delete[] data.ptr;
-            memcpy(buf, other.buf, len);
-            other.buf[0] = '\0';
-            other.setLast();
-        }
-        return *this;
+char String::operator[](size_type i) const {
+    return const_cast<String *>(this)->operator[](i);
+}
+
+char &String::operator[](size_type i) {
+    if (isOnStack())
+        return reinterpret_cast<char *>(buf)[i];
+    return data.ptr[i];
+}
+
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
+String::size_type String::size() const {
+    if (isOnStack())
+        return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
+    return data.size;
+}
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+String::size_type String::capacity() const {
+    if (isOnStack())
+        return len;
+    return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+    cnt = std::min(cnt, size() - pos);
+    char *cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const & {
+    cnt = std::min(cnt, size() - pos);
+    return String{c_str() + pos, cnt};
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char *begin = c_str();
+    const char *end = begin + size();
+    const char *it = begin + pos;
+    for (; it < end && *it != ch; it++) {}
+    if (it < end) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
+    }
+}
+
+String::size_type String::rfind(char ch, size_type pos) const {
+    if (size() == 0) {
+        return npos;
     }
 
-    char String::operator[](size_type i) const {
-        return const_cast<String*>(this)->operator[](i);
+    const char *begin = c_str();
+    const char *it = begin + std::min(pos, size() - 1);
+    for (; it >= begin && *it != ch; it--) {}
+    if (it >= begin) {
+        return static_cast<size_type>(it - begin);
+    } else {
+        return npos;
     }
+}
 
-    char& String::operator[](size_type i) {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf)[i];
-        return data.ptr[i];
-    }
+int String::compare(const char *other, bool no_case) const {
+    if (no_case)
+        return doctest::stricmp(c_str(), other);
+    return std::strcmp(c_str(), other);
+}
 
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-    String::size_type String::size() const {
-        if(isOnStack())
-            return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
-        return data.size;
-    }
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+int String::compare(const String &other, bool no_case) const {
+    return compare(other.c_str(), no_case);
+}
 
-    String::size_type String::capacity() const {
-        if(isOnStack())
-            return len;
-        return data.capacity;
-    }
+String operator+(const String &lhs, const String &rhs) {
+    return String(lhs) += rhs;
+}
 
-    String String::substr(size_type pos, size_type cnt) && {
-        cnt = std::min(cnt, size() - pos);
-        char* cptr = c_str();
-        memmove(cptr, cptr + pos, cnt);
-        setSize(cnt);
-        return std::move(*this);
-    }
+bool operator==(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) == 0;
+}
 
-    String String::substr(size_type pos, size_type cnt) const & {
-        cnt = std::min(cnt, size() - pos);
-        return String{ c_str() + pos, cnt };
-    }
+bool operator!=(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) != 0;
+}
 
-    String::size_type String::find(char ch, size_type pos) const {
-        const char* begin = c_str();
-        const char* end = begin + size();
-        const char* it = begin + pos;
-        for (; it < end && *it != ch; it++) { }
-        if (it < end) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
+bool operator<(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) < 0;
+}
 
-    String::size_type String::rfind(char ch, size_type pos) const {
-        if (size() == 0) { return npos; }
+bool operator>(const String &lhs, const String &rhs) {
+    return lhs.compare(rhs) > 0;
+}
 
-        const char* begin = c_str();
-        const char* it = begin + std::min(pos, size() - 1);
-        for (; it >= begin && *it != ch; it--) { }
-        if (it >= begin) { return static_cast<size_type>(it - begin); }
-        else { return npos; }
-    }
+bool operator<=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) < 0 : true;
+}
 
-    int String::compare(const char* other, bool no_case) const {
-        if(no_case)
-            return doctest::stricmp(c_str(), other);
-        return std::strcmp(c_str(), other);
-    }
+bool operator>=(const String &lhs, const String &rhs) {
+    return (lhs != rhs) ? lhs.compare(rhs) > 0 : true;
+}
 
-    int String::compare(const String& other, bool no_case) const {
-        return compare(other.c_str(), no_case);
-    }
-
-    String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
-
-    bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
-    bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
-    bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
-    bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
-    bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
-    bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-
-    std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+std::ostream &operator<<(std::ostream &s, const String &in) {
+    return s << in.c_str();
+}
 
 namespace detail {
 
-    void filldata<const void*>::fill(std::ostream* stream, const void* in) {
-        filldata<const volatile void*>::fill(stream, in);
-    }
+void filldata<const void *>::fill(std::ostream *stream, const void *in) {
+    filldata<const volatile void *>::fill(stream, in);
+}
 
-    void filldata<const volatile void*>::fill(std::ostream* stream, const volatile void* in) {
-        if (in) { *stream << in; }
-        else { *stream << "nullptr"; }
+void filldata<const volatile void *>::fill(std::ostream *stream, const volatile void *in) {
+    if (in) {
+        *stream << in;
+    } else {
+        *stream << "nullptr";
     }
+}
 
-    template <typename T>
-    String toStreamLit(T t) {
-        std::ostream* os = tlssPush();
-        os->operator<<(t);
-        return tlssPop();
-    }
+template <typename T>
+String toStreamLit(T t) {
+    std::ostream *os = tlssPush();
+    os->operator<<(t);
+    return tlssPop();
+}
 } // namespace detail
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
+String toString(const char *in) {
+    return String("\"") + (in ? in : "{null string}") + "\"";
+}
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-String toString(const std::string& in) { return in.c_str(); }
+String toString(const std::string &in) {
+    return in.c_str();
+}
 #endif // VS 2019
 
-String toString(const String& in) { return in; }
+String toString(const String &in) {
+    return in;
+}
 
-String toString(std::nullptr_t) { return "nullptr"; }
+String toString(std::nullptr_t) {
+    return "nullptr";
+}
 
-String toString(bool in) { return in ? "true" : "false"; }
+String toString(bool in) {
+    return in ? "true" : "false";
+}
 
-String toString(float in) { return detail::toStreamLit(in); }
-String toString(double in) { return detail::toStreamLit(in); }
-String toString(double long in) { return detail::toStreamLit(in); }
+String toString(float in) {
+    return detail::toStreamLit(in);
+}
+String toString(double in) {
+    return detail::toStreamLit(in);
+}
+String toString(double long in) {
+    return detail::toStreamLit(in);
+}
 
-String toString(char in) { return detail::toStreamLit(static_cast<signed>(in)); }
-String toString(char signed in) { return detail::toStreamLit(static_cast<signed>(in)); }
-String toString(char unsigned in) { return detail::toStreamLit(static_cast<unsigned>(in)); }
-String toString(short in) { return detail::toStreamLit(in); }
-String toString(short unsigned in) { return detail::toStreamLit(in); }
-String toString(signed in) { return detail::toStreamLit(in); }
-String toString(unsigned in) { return detail::toStreamLit(in); }
-String toString(long in) { return detail::toStreamLit(in); }
-String toString(long unsigned in) { return detail::toStreamLit(in); }
-String toString(long long in) { return detail::toStreamLit(in); }
-String toString(long long unsigned in) { return detail::toStreamLit(in); }
+String toString(char in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char signed in) {
+    return detail::toStreamLit(static_cast<signed>(in));
+}
+String toString(char unsigned in) {
+    return detail::toStreamLit(static_cast<unsigned>(in));
+}
+String toString(short in) {
+    return detail::toStreamLit(in);
+}
+String toString(short unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(signed in) {
+    return detail::toStreamLit(in);
+}
+String toString(unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long unsigned in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long in) {
+    return detail::toStreamLit(in);
+}
+String toString(long long unsigned in) {
+    return detail::toStreamLit(in);
+}
 
 } // namespace doctest
 

--- a/doctest/parts/private/subcase.cpp
+++ b/doctest/parts/private/subcase.cpp
@@ -10,144 +10,155 @@ namespace doctest {
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(unsigned long long a, unsigned long long b) {
-        return (a << 5) + b;
-    }
+DOCTEST_NO_SANITIZE_INTEGER
+unsigned long long hash(unsigned long long a, unsigned long long b) {
+    return (a << 5) + b;
+}
 
-    // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-    DOCTEST_NO_SANITIZE_INTEGER
-    unsigned long long hash(const char* str) {
-        unsigned long long hash = 5381;
-        char c;
-        while ((c = *str++))
-            hash = ((hash << 5) + hash) + c; // hash * 33 + c
-        return hash;
-    }
+// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+DOCTEST_NO_SANITIZE_INTEGER
+unsigned long long hash(const char *str) {
+    unsigned long long hash = 5381;
+    char c;
+    while ((c = *str++))
+        hash = ((hash << 5) + hash) + c; // hash * 33 + c
+    return hash;
+}
 
-    unsigned long long hash(const SubcaseSignature& sig) {
-        return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
-    }
+unsigned long long hash(const SubcaseSignature &sig) {
+    return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
+}
 
-    unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
-        unsigned long long running = 0;
-        auto end = sigs.begin() + count;
-        for (auto it = sigs.begin(); it != end; it++) {
-            running = hash(running, hash(*it));
-        }
-        return running;
+unsigned long long hash(const std::vector<SubcaseSignature> &sigs, size_t count) {
+    unsigned long long running = 0;
+    auto end = sigs.begin() + count;
+    for (auto it = sigs.begin(); it != end; it++) {
+        running = hash(running, hash(*it));
     }
+    return running;
+}
 
-    unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
-        unsigned long long running = 0;
-        for (const SubcaseSignature& sig : sigs) {
-            running = hash(running, hash(sig));
-        }
-        return running;
+unsigned long long hash(const std::vector<SubcaseSignature> &sigs) {
+    unsigned long long running = 0;
+    for (const SubcaseSignature &sig: sigs) {
+        running = hash(running, hash(sig));
     }
+    return running;
+}
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 
-    bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
-        return m_line == other.m_line
-            && std::strcmp(m_file, other.m_file) == 0
-            && m_name == other.m_name;
-    }
+bool SubcaseSignature::operator==(const SubcaseSignature &other) const {
+    return m_line == other.m_line && std::strcmp(m_file, other.m_file) == 0 && m_name == other.m_name;
+}
 
-    bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        if(std::strcmp(m_file, other.m_file) != 0)
-            return std::strcmp(m_file, other.m_file) < 0;
-        return m_name.compare(other.m_name) < 0;
-    }
+bool SubcaseSignature::operator<(const SubcaseSignature &other) const {
+    if (m_line != other.m_line)
+        return m_line < other.m_line;
+    if (std::strcmp(m_file, other.m_file) != 0)
+        return std::strcmp(m_file, other.m_file) < 0;
+    return m_name.compare(other.m_name) < 0;
+}
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    bool Subcase::checkFilters() {
-        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
-            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
-                return true;
-            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
-                return true;
-        }
-        return false;
+bool Subcase::checkFilters() {
+    if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+        if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+            return true;
+        if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+            return true;
     }
+    return false;
+}
 
-    Subcase::Subcase(const String& name, const char* file, int line)
-            : m_signature({name, file, line}) {
+Subcase::Subcase(const String &name, const char *file, int line)
+    : m_signature({name, file, line}) {
+    if (!g_cs->reachedLeaf) {
+        if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size() ||
+            g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+            // Going down.
+            if (checkFilters()) {
+                return;
+            }
+
+            g_cs->subcaseStack.push_back(m_signature);
+            g_cs->currentSubcaseDepth++;
+            m_entered = true;
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+        }
+    } else {
+        if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+            // This subcase is reentered via control flow.
+            g_cs->currentSubcaseDepth++;
+            m_entered = true;
+            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+        } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+                   g_cs->fullyTraversedSubcases.find(
+                       hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
+                   ) == g_cs->fullyTraversedSubcases.end()) {
+            if (checkFilters()) {
+                return;
+            }
+            // This subcase is part of the one to be executed next.
+            g_cs->nextSubcaseStack.clear();
+            g_cs->nextSubcaseStack.insert(
+                g_cs->nextSubcaseStack.end(),
+                g_cs->subcaseStack.begin(),
+                g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth
+            );
+            g_cs->nextSubcaseStack.push_back(m_signature);
+        }
+    }
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+Subcase::~Subcase() {
+    if (m_entered) {
+        g_cs->currentSubcaseDepth--;
+
         if (!g_cs->reachedLeaf) {
-            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
-                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
-                // Going down.
-                if (checkFilters()) { return; }
-
-                g_cs->subcaseStack.push_back(m_signature);
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            }
-        } else {
-            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
-                // This subcase is reentered via control flow.
-                g_cs->currentSubcaseDepth++;
-                m_entered = true;
-                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
-                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
-                    == g_cs->fullyTraversedSubcases.end()) {
-                if (checkFilters()) { return; }
-                // This subcase is part of the one to be executed next.
-                g_cs->nextSubcaseStack.clear();
-                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
-                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
-                g_cs->nextSubcaseStack.push_back(m_signature);
-            }
+            // Leaf.
+            g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+            g_cs->nextSubcaseStack.clear();
+            g_cs->reachedLeaf = true;
+        } else if (g_cs->nextSubcaseStack.empty()) {
+            // All children are finished.
+            g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
         }
-    }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
-    Subcase::~Subcase() {
-        if (m_entered) {
-            g_cs->currentSubcaseDepth--;
-
-            if (!g_cs->reachedLeaf) {
-                // Leaf.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-                g_cs->nextSubcaseStack.clear();
-                g_cs->reachedLeaf = true;
-            } else if (g_cs->nextSubcaseStack.empty()) {
-                // All children are finished.
-                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
-            }
-
-    #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
-            if(std::uncaught_exceptions() > 0
-    #else
-            if(std::uncaught_exception()
-    #endif
-                && g_cs->shouldLogCurrentException) {
-                DOCTEST_ITERATE_THROUGH_REPORTERS(
-                        test_case_exception, {"exception thrown in subcase - will translate later "
-                                                "when the whole test case has been exited (cannot "
-                                                "translate while there is an active exception)",
-                                                false});
-                g_cs->shouldLogCurrentException = false;
-            }
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L &&                              \
+    (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+        if (std::uncaught_exceptions() > 0
+#else
+        if (std::uncaught_exception()
+#endif
+            && g_cs->shouldLogCurrentException) {
+            DOCTEST_ITERATE_THROUGH_REPORTERS(
+                test_case_exception,
+                {"exception thrown in subcase - will translate later "
+                 "when the whole test case has been exited (cannot "
+                 "translate while there is an active exception)",
+                 false}
+            );
+            g_cs->shouldLogCurrentException = false;
         }
+
+        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
+}
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    Subcase::operator bool() const { return m_entered; }
+Subcase::operator bool() const {
+    return m_entered;
+}
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/private/test_case.cpp
+++ b/doctest/parts/private/test_case.cpp
@@ -8,54 +8,55 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-std::set<TestCase>& getRegisteredTests() {
+std::set<TestCase> &getRegisteredTests() {
     static std::set<TestCase> data;
     return data;
 }
 
-TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                    const String& type, int template_id) {
-    m_file              = file;
-    m_line              = line;
-    m_name              = nullptr; // will be later overridden in operator*
-    m_test_suite        = test_suite.m_test_suite;
-    m_description       = test_suite.m_description;
-    m_skip              = test_suite.m_skip;
-    m_no_breaks         = test_suite.m_no_breaks;
-    m_no_output         = test_suite.m_no_output;
-    m_may_fail          = test_suite.m_may_fail;
-    m_should_fail       = test_suite.m_should_fail;
+TestCase::TestCase(
+    funcType test, const char *file, unsigned line, const TestSuite &test_suite, const String &type, int template_id
+) {
+    m_file = file;
+    m_line = line;
+    m_name = nullptr; // will be later overridden in operator*
+    m_test_suite = test_suite.m_test_suite;
+    m_description = test_suite.m_description;
+    m_skip = test_suite.m_skip;
+    m_no_breaks = test_suite.m_no_breaks;
+    m_no_output = test_suite.m_no_output;
+    m_may_fail = test_suite.m_may_fail;
+    m_should_fail = test_suite.m_should_fail;
     m_expected_failures = test_suite.m_expected_failures;
-    m_timeout           = test_suite.m_timeout;
+    m_timeout = test_suite.m_timeout;
 
-    m_test        = test;
-    m_type        = type;
+    m_test = test;
+    m_type = type;
     m_template_id = template_id;
 }
 
-TestCase::TestCase(const TestCase& other)
-        : TestCaseData() {
+TestCase::TestCase(const TestCase &other)
+    : TestCaseData() {
     *this = other;
 }
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-TestCase& TestCase::operator=(const TestCase& other) {
+TestCase &TestCase::operator=(const TestCase &other) {
     TestCaseData::operator=(other);
-    m_test        = other.m_test;
-    m_type        = other.m_type;
+    m_test = other.m_test;
+    m_type = other.m_type;
     m_template_id = other.m_template_id;
-    m_full_name   = other.m_full_name;
+    m_full_name = other.m_full_name;
 
-    if(m_template_id != -1)
+    if (m_template_id != -1)
         m_name = m_full_name.c_str();
     return *this;
 }
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-TestCase& TestCase::operator*(const char* in) {
+TestCase &TestCase::operator*(const char *in) {
     m_name = in;
     // make a new name with an appended type for templated test case
-    if(m_template_id != -1) {
+    if (m_template_id != -1) {
         m_full_name = String(m_name) + "<" + m_type + ">";
         // redirect the name to point to the newly constructed full name
         m_name = m_full_name.c_str();
@@ -63,21 +64,21 @@ TestCase& TestCase::operator*(const char* in) {
     return *this;
 }
 
-bool TestCase::operator<(const TestCase& other) const {
+bool TestCase::operator<(const TestCase &other) const {
     // this will be used only to differentiate between test cases - not relevant for sorting
-    if(m_line != other.m_line)
+    if (m_line != other.m_line)
         return m_line < other.m_line;
     const int name_cmp = strcmp(m_name, other.m_name);
-    if(name_cmp != 0)
+    if (name_cmp != 0)
         return name_cmp < 0;
     const int file_cmp = m_file.compare(other.m_file);
-    if(file_cmp != 0)
+    if (file_cmp != 0)
         return file_cmp < 0;
     return m_template_id < other.m_template_id;
 }
 
 // used by the macros for registering tests
-int regTest(const TestCase& tc) {
+int regTest(const TestCase &tc) {
     getRegisteredTests().insert(tc);
     return 0;
 }

--- a/doctest/parts/private/test_case.h
+++ b/doctest/parts/private/test_case.h
@@ -10,8 +10,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // all the registered tests
-    std::set<TestCase>& getRegisteredTests();
+// all the registered tests
+std::set<TestCase> &getRegisteredTests();
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/test_suite.cpp
+++ b/doctest/parts/private/test_suite.cpp
@@ -7,13 +7,13 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-TestSuite& TestSuite::operator*(const char* in) {
+TestSuite &TestSuite::operator*(const char *in) {
     m_test_suite = in;
     return *this;
 }
 
 // sets the current test suite
-int setTestSuite(const TestSuite& ts) {
+int setTestSuite(const TestSuite &ts) {
     doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
     return 0;
 }
@@ -23,7 +23,7 @@ int setTestSuite(const TestSuite& ts) {
 
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite
-doctest::detail::TestSuite& getCurrentTestSuite() {
+doctest::detail::TestSuite &getCurrentTestSuite() {
     static doctest::detail::TestSuite data{};
     return data;
 }

--- a/doctest/parts/private/timer.cpp
+++ b/doctest/parts/private/timer.cpp
@@ -9,11 +9,13 @@ namespace doctest {
 namespace detail {
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
-ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
+ticks_t getCurrentTicks() {
+    return DOCTEST_CONFIG_GETCURRENTTICKS();
+}
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
 ticks_t getCurrentTicks() {
-    static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
-    if(!hz.QuadPart) {
+    static LARGE_INTEGER hz = {{0}}, hzo = {{0}};
+    if (!hz.QuadPart) {
         QueryPerformanceFrequency(&hz);
         QueryPerformanceCounter(&hzo);
     }
@@ -29,17 +31,21 @@ ticks_t getCurrentTicks() {
 }
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-void Timer::start() { m_ticks = getCurrentTicks(); }
+void Timer::start() {
+    m_ticks = getCurrentTicks();
+}
 
 unsigned int Timer::getElapsedMicroseconds() const {
     return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
 }
 
-//unsigned int Timer::getElapsedMilliseconds() const {
-//    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
-//}
+// unsigned int Timer::getElapsedMilliseconds() const {
+//     return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
+// }
 
-double Timer::getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
+double Timer::getElapsedSeconds() const {
+    return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0;
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/timer.h
+++ b/doctest/parts/private/timer.h
@@ -10,29 +10,27 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-namespace timer_large_integer
-{
+namespace timer_large_integer {
 
 #if defined(DOCTEST_PLATFORM_WINDOWS)
-    using type = ULONGLONG;
-#else // DOCTEST_PLATFORM_WINDOWS
-    using type = std::uint64_t;
+using type = ULONGLONG;
+#else  // DOCTEST_PLATFORM_WINDOWS
+using type = std::uint64_t;
 #endif // DOCTEST_PLATFORM_WINDOWS
-}
+} // namespace timer_large_integer
 
 using ticks_t = timer_large_integer::type;
 
-    ticks_t getCurrentTicks();
+ticks_t getCurrentTicks();
 
-    struct Timer
-    {
-        void         start();
-        unsigned int getElapsedMicroseconds() const;
-        double getElapsedSeconds() const;
+struct Timer {
+    void start();
+    unsigned int getElapsedMicroseconds() const;
+    double getElapsedSeconds() const;
 
-    private:
-        ticks_t m_ticks = 0;
-    };
+private:
+    ticks_t m_ticks = 0;
+};
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/xml.cpp
+++ b/doctest/parts/private/xml.cpp
@@ -9,12 +9,11 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // clang-format off
-
 // =================================================================================================
-// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h/cpp
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.cpp
 // This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
 // =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
 
 using uchar = unsigned char;
 
@@ -289,11 +288,10 @@ using uchar = unsigned char;
         }
     }
 
+/* clang-format on */ /* NOLINTEND */
 // =================================================================================================
 // End of copy-pasted code from Catch
 // =================================================================================================
-
-    // clang-format on
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/private/xml.h
+++ b/doctest/parts/private/xml.h
@@ -10,12 +10,11 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    // clang-format off
-
 // =================================================================================================
-// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h/cpp
+// The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h
 // This is done so cherry-picking bug fixes is trivial - even the style/formatting is untouched.
 // =================================================================================================
+/* clang-format off */ /* NOLINTBEGIN */
 
     class XmlEncode {
     public:
@@ -108,7 +107,10 @@ namespace detail {
         std::ostream& m_os;
     };
 
-    // clang-format on
+/* clang-format on */ /* NOLINTEND */
+// =================================================================================================
+// End of copy-pasted code from Catch
+// =================================================================================================
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/assert/comparator.h
+++ b/doctest/parts/public/assert/comparator.h
@@ -8,49 +8,48 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #ifndef DOCTEST_CONFIG_DISABLE
 
 namespace doctest {
-namespace detail  {
+namespace detail {
 
-    // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    template<class T>               struct decay_array       { using type = T; };
-    template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
-    template<class T>               struct decay_array<T[]>  { using type = T*; };
+// clang-format off
+template<class T>               struct decay_array       { using type = T; };
+template<class T, unsigned N>   struct decay_array<T[N]> { using type = T *; };
+template<class T>               struct decay_array<T[]>  { using type = T *; };
 
-    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR int value = 1; };
-    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR int value = 0; };
-    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR int value = 0; };
+template<class T>   struct not_char_pointer               { static DOCTEST_CONSTEXPR int value = 1; };
+template<>          struct not_char_pointer<char *>       { static DOCTEST_CONSTEXPR int value = 0; };
+template<>          struct not_char_pointer<const char *> { static DOCTEST_CONSTEXPR int value = 0; };
 
-    template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
+template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
+// clang-format on
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
 
-    // clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_COMPARISON_RETURN_TYPE bool
-#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#else  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+// clang-format off
 #define DOCTEST_COMPARISON_RETURN_TYPE typename types::enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
-    inline bool eq(const char* lhs, const char* rhs) { return String(lhs) == String(rhs); }
-    inline bool ne(const char* lhs, const char* rhs) { return String(lhs) != String(rhs); }
-    inline bool lt(const char* lhs, const char* rhs) { return String(lhs) <  String(rhs); }
-    inline bool gt(const char* lhs, const char* rhs) { return String(lhs) >  String(rhs); }
-    inline bool le(const char* lhs, const char* rhs) { return String(lhs) <= String(rhs); }
-    inline bool ge(const char* lhs, const char* rhs) { return String(lhs) >= String(rhs); }
+inline bool eq(const char *lhs, const char *rhs) { return String(lhs) == String(rhs); }
+inline bool ne(const char *lhs, const char *rhs) { return String(lhs) != String(rhs); }
+inline bool lt(const char *lhs, const char *rhs) { return String(lhs) <  String(rhs); }
+inline bool gt(const char *lhs, const char *rhs) { return String(lhs) >  String(rhs); }
+inline bool le(const char *lhs, const char *rhs) { return String(lhs) <= String(rhs); }
+inline bool ge(const char *lhs, const char *rhs) { return String(lhs) >= String(rhs); }
+// clang-format on
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
 
-#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
-    template <typename L, typename R>                                                              \
-    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs,                             \
-                                        const DOCTEST_REF_WRAP(R) rhs) {                           \
-        return lhs op rhs;                                                                         \
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                \
+        return lhs op rhs;                                                                                             \
     }
 
-    DOCTEST_RELATIONAL_OP(eq, ==)
-    DOCTEST_RELATIONAL_OP(ne, !=)
-    DOCTEST_RELATIONAL_OP(lt, <)
-    DOCTEST_RELATIONAL_OP(gt, >)
-    DOCTEST_RELATIONAL_OP(le, <=)
-    DOCTEST_RELATIONAL_OP(ge, >=)
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
 
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_CMP_EQ(l, r) l == r
@@ -68,31 +67,23 @@ namespace detail  {
 #define DOCTEST_CMP_LE(l, r) le(l, r)
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
-    namespace binaryAssertComparison {
-        enum Enum
-        {
-            eq = 0,
-            ne,
-            gt,
-            lt,
-            ge,
-            le
-        };
-    } // namespace binaryAssertComparison
+namespace binaryAssertComparison {
+enum Enum { eq = 0, ne, gt, lt, ge, le };
+} // namespace binaryAssertComparison
 
-    // clang-format off
-    template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
+// clang-format off
+template <int, class L, class R>         struct RelationalComparator { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
 
 #define DOCTEST_BINARY_RELATIONAL_OP(n, op) \
     template <class L, class R> struct RelationalComparator<n, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return op(lhs, rhs); } };
-    // clang-format on
+// clang-format on
 
-    DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
-    DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
-    DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
-    DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
-    DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
-    DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
+DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
+DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
+DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
+DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
+DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
+DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/assert/data.h
+++ b/doctest/parts/public/assert/data.h
@@ -8,48 +8,62 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData;
+struct DOCTEST_INTERFACE TestCaseData;
 
-    struct DOCTEST_INTERFACE AssertData
-    {
-        // common - for all asserts
-        const TestCaseData* m_test_case;
-        assertType::Enum    m_at;
-        const char*         m_file;
-        int                 m_line;
-        const char*         m_expr;
-        bool                m_failed;
+struct DOCTEST_INTERFACE AssertData {
+    // common - for all asserts
+    const TestCaseData *m_test_case;
+    assertType::Enum m_at;
+    const char *m_file;
+    int m_line;
+    const char *m_expr;
+    bool m_failed;
 
-        // exception-related - for all asserts
-        bool   m_threw;
-        String m_exception;
+    // exception-related - for all asserts
+    bool m_threw;
+    String m_exception;
 
-        // for normal asserts
-        String m_decomp;
+    // for normal asserts
+    String m_decomp;
 
-        // for specific exception-related asserts
-        bool           m_threw_as;
-        const char*    m_exception_type;
+    // for specific exception-related asserts
+    bool m_threw_as;
+    const char *m_exception_type;
 
-        class DOCTEST_INTERFACE StringContains {
-            private:
-                Contains content;
-                bool isContains;
+    class DOCTEST_INTERFACE StringContains {
+    private:
+        Contains content;
+        bool isContains;
 
-            public:
-                StringContains(const String& str) : content(str), isContains(false) { }
-                StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
+    public:
+        StringContains(const String &str)
+            : content(str), isContains(false) {}
 
-                bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
+        StringContains(Contains cntn)
+            : content(static_cast<Contains &&>(cntn)), isContains(true) {}
 
-                operator const String&() const { return content.string; }
+        bool check(const String &str) {
+            return isContains ? (content == str) : (content.string == str);
+        }
 
-                const char* c_str() const { return content.string.c_str(); }
-        } m_exception_string;
+        operator const String &() const {
+            return content.string;
+        }
 
-        AssertData(assertType::Enum at, const char* file, int line, const char* expr,
-            const char* exception_type, const StringContains& exception_string);
-    };
+        const char *c_str() const {
+            return content.string.c_str();
+        }
+    } m_exception_string;
+
+    AssertData(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const StringContains &exception_string
+    );
+};
 
 } // namespace doctest
 

--- a/doctest/parts/public/assert/expression.h
+++ b/doctest/parts/public/assert/expression.h
@@ -22,74 +22,75 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
 // this template, the template won't be instantiated due to SFINAE. Once the template is not
 // instantiated it can look for global operator using normal conversions.
 #ifdef __NVCC__
-#define SFINAE_OP(ret,op) ret
+#define SFINAE_OP(ret, op) ret
 #else
-#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
+#define SFINAE_OP(ret, op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()), ret{})
 #endif
 
-#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
-    template <typename R>                                                                          \
-    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
-    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
-        if(m_at & assertType::is_false)                                                            \
-            res = !res;                                                                            \
-        if(!res || doctest::getContextOptions()->success)                                          \
-            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
-        return Result(res);                                                                        \
+#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                                                  \
+    template <typename R>                                                                                              \
+    DOCTEST_NOINLINE SFINAE_OP(Result, op) operator op(R &&rhs) {                                                      \
+        bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs));                 \
+        if (m_at & assertType::is_false)                                                                               \
+            res = !res;                                                                                                \
+        if (!res || doctest::getContextOptions()->success)                                                             \
+            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                                                 \
+        return Result(res);                                                                                            \
     }
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+// DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    // https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
-    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
-    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+// https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
+DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+// DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in
+// operation
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
 template <typename L>
-struct Expression_lhs
-{
-    L                lhs;
+struct Expression_lhs {
+    L lhs;
     assertType::Enum m_at;
 
-    explicit Expression_lhs(L&& in, assertType::Enum at)
-            : lhs(static_cast<L&&>(in))
-            , m_at(at) {}
+    explicit Expression_lhs(L &&in, assertType::Enum at)
+        : lhs(static_cast<L &&>(in)), m_at(at) {}
 
     DOCTEST_NOINLINE operator Result() {
-// this is needed only for MSVC 2015
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+        // this is needed only for MSVC 2015
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
         bool res = static_cast<bool>(lhs);
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
-        if(m_at & assertType::is_false) {
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        if (m_at & assertType::is_false) {
             res = !res;
         }
 
-        if(!res || getContextOptions()->success) {
-            return { res, (DOCTEST_STRINGIFY(lhs)) };
+        if (!res || getContextOptions()->success) {
+            return {res, (DOCTEST_STRINGIFY(lhs))};
         }
-        return { res };
+        return {res};
     }
 
     /* This is required for user-defined conversions from Expression_lhs to L */
-    operator L() const { return lhs; }
+    operator L() const {
+        return lhs;
+    }
 
     // clang-format off
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ)
@@ -100,7 +101,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE)
     // clang-format on
 
-    // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
@@ -117,17 +119,18 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
-    // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-    // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+    // these 2 are unfortunate because they should be allowed - they have higher precedence over the
+    // comparisons, but the ExpressionDecomposer class uses the left shift operator to capture the
+    // left operand of the binary expression...
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
     DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
 };
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
@@ -135,24 +138,27 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 #endif
 
-struct DOCTEST_INTERFACE ExpressionDecomposer
-{
+struct DOCTEST_INTERFACE ExpressionDecomposer {
     assertType::Enum m_at;
 
     ExpressionDecomposer(assertType::Enum at);
 
-    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-    // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+    // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator
+    // precedence table) but then there will be warnings from GCC about "-Wparentheses" and since
+    // "_Pragma()" is problematic this will stay for now...
     // https://github.com/catchorg/Catch2/issues/870
     // https://github.com/catchorg/Catch2/issues/565
     template <typename L>
-    Expression_lhs<const L&&> operator<<(const L&& operand) { //bitfields bind to universal ref but not const rvalue ref
-        return Expression_lhs<const L&&>(static_cast<const L&&>(operand), m_at);
+    Expression_lhs<const L &&>
+    operator<<(const L &&operand) { // bitfields bind to universal ref but not const rvalue ref
+        return Expression_lhs<const L &&>(static_cast<const L &&>(operand), m_at);
     }
 
-    template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
-    Expression_lhs<const L&> operator<<(const L &operand) {
-        return Expression_lhs<const L&>(operand, m_at);
+    template <
+        typename L,
+        typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value, void>::type * = nullptr>
+    Expression_lhs<const L &> operator<<(const L &operand) {
+        return Expression_lhs<const L &>(operand, m_at);
     }
 };
 

--- a/doctest/parts/public/assert/handler.h
+++ b/doctest/parts/public/assert/handler.h
@@ -14,69 +14,74 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-    DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
+DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData &ad);
 
-    DOCTEST_INTERFACE bool decomp_assert(assertType::Enum at, const char* file, int line,
-                                         const char* expr, const Result& result);
+DOCTEST_INTERFACE bool
+decomp_assert(assertType::Enum at, const char *file, int line, const char *expr, const Result &result);
 
-#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                        \
-    do {                                                                                           \
-        if(!is_running_in_test) {                                                                  \
-            if(failed) {                                                                           \
-                ResultBuilder rb(at, file, line, expr);                                            \
-                rb.m_failed = failed;                                                              \
-                rb.m_decomp = decomp;                                                              \
-                failed_out_of_a_testing_context(rb);                                               \
-                if(isDebuggerActive() && !getContextOptions()->no_breaks)                          \
-                    DOCTEST_BREAK_INTO_DEBUGGER();                                                 \
-                if(checkIfShouldThrow(at))                                                         \
-                    throwException();                                                              \
-            }                                                                                      \
-            return !failed;                                                                        \
-        }                                                                                          \
-    } while(false)
+#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                                            \
+    do {                                                                                                               \
+        if (!is_running_in_test) {                                                                                     \
+            if (failed) {                                                                                              \
+                ResultBuilder rb(at, file, line, expr);                                                                \
+                rb.m_failed = failed;                                                                                  \
+                rb.m_decomp = decomp;                                                                                  \
+                failed_out_of_a_testing_context(rb);                                                                   \
+                if (isDebuggerActive() && !getContextOptions()->no_breaks)                                             \
+                    DOCTEST_BREAK_INTO_DEBUGGER();                                                                     \
+                if (checkIfShouldThrow(at))                                                                            \
+                    throwException();                                                                                  \
+            }                                                                                                          \
+            return !failed;                                                                                            \
+        }                                                                                                              \
+    } while (false)
 
-#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                            \
-    ResultBuilder rb(at, file, line, expr);                                                        \
-    rb.m_failed = failed;                                                                          \
-    if(rb.m_failed || getContextOptions()->success)                                                \
-        rb.m_decomp = decomp;                                                                      \
-    if(rb.log())                                                                                   \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
-    if(rb.m_failed && checkIfShouldThrow(at))                                                      \
+#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                                                \
+    ResultBuilder rb(at, file, line, expr);                                                                            \
+    rb.m_failed = failed;                                                                                              \
+    if (rb.m_failed || getContextOptions()->success)                                                                   \
+        rb.m_decomp = decomp;                                                                                          \
+    if (rb.log())                                                                                                      \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    if (rb.m_failed && checkIfShouldThrow(at))                                                                         \
     throwException()
 
-    template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE bool binary_assert(assertType::Enum at, const char* file, int line,
-                                        const char* expr, const DOCTEST_REF_WRAP(L) lhs,
-                                        const DOCTEST_REF_WRAP(R) rhs) {
-        bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+template <int comparison, typename L, typename R>
+DOCTEST_NOINLINE bool binary_assert(
+    assertType::Enum at,
+    const char *file,
+    int line,
+    const char *expr,
+    const DOCTEST_REF_WRAP(L) lhs,
+    const DOCTEST_REF_WRAP(R) rhs
+) {
+    bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-        DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+    return !failed;
+}
 
-    template <typename L>
-    DOCTEST_NOINLINE bool unary_assert(assertType::Enum at, const char* file, int line,
-                                       const char* expr, const DOCTEST_REF_WRAP(L) val) {
-        bool failed = !val;
+template <typename L>
+DOCTEST_NOINLINE bool
+unary_assert(assertType::Enum at, const char *file, int line, const char *expr, const DOCTEST_REF_WRAP(L) val) {
+    bool failed = !val;
 
-        if(at & assertType::is_false)
-            failed = !failed;
+    if (at & assertType::is_false)
+        failed = !failed;
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
-        DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
-        return !failed;
-    }
+    // ###################################################################################
+    // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+    // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+    // ###################################################################################
+    DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
+    DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
+    return !failed;
+}
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/assert/message.h
+++ b/doctest/parts/public/assert/message.h
@@ -8,55 +8,57 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE MessageData
-    {
-        String           m_string;
-        const char*      m_file;
-        int              m_line;
-        assertType::Enum m_severity;
-    };
+struct DOCTEST_INTERFACE MessageData {
+    String m_string;
+    const char *m_file;
+    int m_line;
+    assertType::Enum m_severity;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    struct DOCTEST_INTERFACE MessageBuilder : public MessageData
-    {
-        std::ostream* m_stream;
-        bool          logged = false;
+struct DOCTEST_INTERFACE MessageBuilder : public MessageData {
+    std::ostream *m_stream;
+    bool logged = false;
 
-        MessageBuilder(const char* file, int line, assertType::Enum severity);
+    MessageBuilder(const char *file, int line, assertType::Enum severity);
 
-        MessageBuilder(const MessageBuilder&) = delete;
-        MessageBuilder(MessageBuilder&&) = delete;
+    MessageBuilder(const MessageBuilder &) = delete;
+    MessageBuilder(MessageBuilder &&) = delete;
 
-        MessageBuilder& operator=(const MessageBuilder&) = delete;
-        MessageBuilder& operator=(MessageBuilder&&) = delete;
+    MessageBuilder &operator=(const MessageBuilder &) = delete;
+    MessageBuilder &operator=(MessageBuilder &&) = delete;
 
-        ~MessageBuilder();
+    ~MessageBuilder();
 
-        // the preferred way of chaining parameters for stringification
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
-        template <typename T>
-        MessageBuilder& operator,(const T& in) {
-            *m_stream << (DOCTEST_STRINGIFY(in));
-            return *this;
-        }
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    // the preferred way of chaining parameters for stringification
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+    template <typename T>
+    MessageBuilder &operator,(const T &in) {
+        *m_stream << (DOCTEST_STRINGIFY(in));
+        return *this;
+    }
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        // kept here just for backwards-compatibility - the comma operator should be preferred now
-        template <typename T>
-        MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
+    // kept here just for backwards-compatibility - the comma operator should be preferred now
+    template <typename T>
+    MessageBuilder &operator<<(const T &in) {
+        return this->operator,(in);
+    }
 
-        // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
-        // the `,` operator will be called last which is not what we want and thus the `*` operator
-        // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
-        // an operator of the MessageBuilder class is called first before the rest of the parameters
-        template <typename T>
-        MessageBuilder& operator*(const T& in) { return this->operator,(in); }
+    // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
+    // the `,` operator will be called last which is not what we want and thus the `*` operator
+    // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
+    // an operator of the MessageBuilder class is called first before the rest of the parameters
+    template <typename T>
+    MessageBuilder &operator*(const T &in) {
+        return this->operator,(in);
+    }
 
-        bool log();
-        void react();
-    };
+    bool log();
+    void react();
+};
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/assert/result.h
+++ b/doctest/parts/public/assert/result.h
@@ -17,87 +17,97 @@ namespace detail {
 // more checks could be added - like in Catch:
 // https://github.com/catchorg/Catch2/pull/1480/files
 // https://github.com/catchorg/Catch2/pull/1481/files
-#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                          \
-    template <typename R>                                                                          \
-    rt& operator op(const R&) {                                                                    \
-        static_assert(deferred_false<R>::value,                                                    \
-                      "Expression Too Complex Please Rewrite As Binary Comparison!");              \
-        return *this;                                                                              \
+#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                                              \
+    template <typename R>                                                                                              \
+    rt &operator op(const R &) {                                                                                       \
+        static_assert(deferred_false<R>::value, "Expression Too Complex Please Rewrite As Binary Comparison!");        \
+        return *this;                                                                                                  \
     }
 
-    struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
-    {
-        bool   m_passed;
-        String m_decomp;
+struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
+{
+    bool m_passed;
+    String m_decomp;
 
-        Result() = default; // TODO: Why do we need this? (To remove NOLINT)
-        Result(bool passed, const String& decomposition = String());
+    Result() = default; // TODO: Why do we need this? (To remove NOLINT)
+    Result(bool passed, const String &decomposition = String());
 
-        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
-        DOCTEST_FORBIT_EXPRESSION(Result, &)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^)
-        DOCTEST_FORBIT_EXPRESSION(Result, |)
-        DOCTEST_FORBIT_EXPRESSION(Result, &&)
-        DOCTEST_FORBIT_EXPRESSION(Result, ||)
-        DOCTEST_FORBIT_EXPRESSION(Result, ==)
-        DOCTEST_FORBIT_EXPRESSION(Result, !=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <)
-        DOCTEST_FORBIT_EXPRESSION(Result, >)
-        DOCTEST_FORBIT_EXPRESSION(Result, <=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >=)
-        DOCTEST_FORBIT_EXPRESSION(Result, =)
-        DOCTEST_FORBIT_EXPRESSION(Result, +=)
-        DOCTEST_FORBIT_EXPRESSION(Result, -=)
-        DOCTEST_FORBIT_EXPRESSION(Result, *=)
-        DOCTEST_FORBIT_EXPRESSION(Result, /=)
-        DOCTEST_FORBIT_EXPRESSION(Result, %=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <<=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >>=)
-        DOCTEST_FORBIT_EXPRESSION(Result, &=)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^=)
-        DOCTEST_FORBIT_EXPRESSION(Result, |=)
-    };
+    // forbidding some expressions based on this table:
+    // https://en.cppreference.com/w/cpp/language/operator_precedence
+    DOCTEST_FORBIT_EXPRESSION(Result, &)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^)
+    DOCTEST_FORBIT_EXPRESSION(Result, |)
+    DOCTEST_FORBIT_EXPRESSION(Result, &&)
+    DOCTEST_FORBIT_EXPRESSION(Result, ||)
+    DOCTEST_FORBIT_EXPRESSION(Result, ==)
+    DOCTEST_FORBIT_EXPRESSION(Result, !=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <)
+    DOCTEST_FORBIT_EXPRESSION(Result, >)
+    DOCTEST_FORBIT_EXPRESSION(Result, <=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >=)
+    DOCTEST_FORBIT_EXPRESSION(Result, =)
+    DOCTEST_FORBIT_EXPRESSION(Result, +=)
+    DOCTEST_FORBIT_EXPRESSION(Result, -=)
+    DOCTEST_FORBIT_EXPRESSION(Result, *=)
+    DOCTEST_FORBIT_EXPRESSION(Result, /=)
+    DOCTEST_FORBIT_EXPRESSION(Result, %=)
+    DOCTEST_FORBIT_EXPRESSION(Result, <<=)
+    DOCTEST_FORBIT_EXPRESSION(Result, >>=)
+    DOCTEST_FORBIT_EXPRESSION(Result, &=)
+    DOCTEST_FORBIT_EXPRESSION(Result, ^=)
+    DOCTEST_FORBIT_EXPRESSION(Result, |=)
+};
 
-    struct DOCTEST_INTERFACE ResultBuilder : public AssertData
-    {
-        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type = "", const String& exception_string = "");
+struct DOCTEST_INTERFACE ResultBuilder : public AssertData {
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type = "",
+        const String &exception_string = ""
+    );
 
-        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type, const Contains& exception_string);
+    ResultBuilder(
+        assertType::Enum at,
+        const char *file,
+        int line,
+        const char *expr,
+        const char *exception_type,
+        const Contains &exception_string
+    );
 
-        void setResult(const Result& res);
+    void setResult(const Result &res);
 
-        template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
-            m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if (m_failed || getContextOptions()->success) {
-                m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
-            }
-            return !m_failed;
+    template <int comparison, typename L, typename R>
+    DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {
+        m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+        }
+        return !m_failed;
+    }
+
+    template <typename L>
+    DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
+        m_failed = !val;
+
+        if (m_at & assertType::is_false) {
+            m_failed = !m_failed;
         }
 
-        template <typename L>
-        DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
-            m_failed = !val;
-
-            if (m_at & assertType::is_false) {
-                m_failed = !m_failed;
-            }
-
-            if (m_failed || getContextOptions()->success) {
-                m_decomp = (DOCTEST_STRINGIFY(val));
-            }
-
-            return !m_failed;
+        if (m_failed || getContextOptions()->success) {
+            m_decomp = (DOCTEST_STRINGIFY(val));
         }
 
-        void translateException();
+        return !m_failed;
+    }
 
-        bool log();
-        void react() const;
-    };
+    void translateException();
+
+    bool log();
+    void react() const;
+};
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/assert/type.h
+++ b/doctest/parts/public/assert/type.h
@@ -7,100 +7,99 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace assertType {
-    enum Enum
-    {
-        // macro traits
+enum Enum {
+    // macro traits
 
-        is_warn    = 1,
-        is_check   = 2 * is_warn,
-        is_require = 2 * is_check,
+    is_warn = 1,
+    is_check = 2 * is_warn,
+    is_require = 2 * is_check,
 
-        is_normal      = 2 * is_require,
-        is_throws      = 2 * is_normal,
-        is_throws_as   = 2 * is_throws,
-        is_throws_with = 2 * is_throws_as,
-        is_nothrow     = 2 * is_throws_with,
+    is_normal = 2 * is_require,
+    is_throws = 2 * is_normal,
+    is_throws_as = 2 * is_throws,
+    is_throws_with = 2 * is_throws_as,
+    is_nothrow = 2 * is_throws_with,
 
-        is_false = 2 * is_nothrow,
-        is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
+    is_false = 2 * is_nothrow,
+    is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
 
-        is_eq = 2 * is_unary,
-        is_ne = 2 * is_eq,
+    is_eq = 2 * is_unary,
+    is_ne = 2 * is_eq,
 
-        is_lt = 2 * is_ne,
-        is_gt = 2 * is_lt,
+    is_lt = 2 * is_ne,
+    is_gt = 2 * is_lt,
 
-        is_ge = 2 * is_gt,
-        is_le = 2 * is_ge,
+    is_ge = 2 * is_gt,
+    is_le = 2 * is_ge,
 
-        // macro types
+    // macro types
 
-        DT_WARN    = is_normal | is_warn,
-        DT_CHECK   = is_normal | is_check,
-        DT_REQUIRE = is_normal | is_require,
+    DT_WARN = is_normal | is_warn,
+    DT_CHECK = is_normal | is_check,
+    DT_REQUIRE = is_normal | is_require,
 
-        DT_WARN_FALSE    = is_normal | is_false | is_warn,
-        DT_CHECK_FALSE   = is_normal | is_false | is_check,
-        DT_REQUIRE_FALSE = is_normal | is_false | is_require,
+    DT_WARN_FALSE = is_normal | is_false | is_warn,
+    DT_CHECK_FALSE = is_normal | is_false | is_check,
+    DT_REQUIRE_FALSE = is_normal | is_false | is_require,
 
-        DT_WARN_THROWS    = is_throws | is_warn,
-        DT_CHECK_THROWS   = is_throws | is_check,
-        DT_REQUIRE_THROWS = is_throws | is_require,
+    DT_WARN_THROWS = is_throws | is_warn,
+    DT_CHECK_THROWS = is_throws | is_check,
+    DT_REQUIRE_THROWS = is_throws | is_require,
 
-        DT_WARN_THROWS_AS    = is_throws_as | is_warn,
-        DT_CHECK_THROWS_AS   = is_throws_as | is_check,
-        DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+    DT_WARN_THROWS_AS = is_throws_as | is_warn,
+    DT_CHECK_THROWS_AS = is_throws_as | is_check,
+    DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-        DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
-        DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
-        DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
+    DT_WARN_THROWS_WITH = is_throws_with | is_warn,
+    DT_CHECK_THROWS_WITH = is_throws_with | is_check,
+    DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
 
-        DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
-        DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
-        DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
+    DT_WARN_THROWS_WITH_AS = is_throws_with | is_throws_as | is_warn,
+    DT_CHECK_THROWS_WITH_AS = is_throws_with | is_throws_as | is_check,
+    DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
 
-        DT_WARN_NOTHROW    = is_nothrow | is_warn,
-        DT_CHECK_NOTHROW   = is_nothrow | is_check,
-        DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+    DT_WARN_NOTHROW = is_nothrow | is_warn,
+    DT_CHECK_NOTHROW = is_nothrow | is_check,
+    DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-        DT_WARN_EQ    = is_normal | is_eq | is_warn,
-        DT_CHECK_EQ   = is_normal | is_eq | is_check,
-        DT_REQUIRE_EQ = is_normal | is_eq | is_require,
+    DT_WARN_EQ = is_normal | is_eq | is_warn,
+    DT_CHECK_EQ = is_normal | is_eq | is_check,
+    DT_REQUIRE_EQ = is_normal | is_eq | is_require,
 
-        DT_WARN_NE    = is_normal | is_ne | is_warn,
-        DT_CHECK_NE   = is_normal | is_ne | is_check,
-        DT_REQUIRE_NE = is_normal | is_ne | is_require,
+    DT_WARN_NE = is_normal | is_ne | is_warn,
+    DT_CHECK_NE = is_normal | is_ne | is_check,
+    DT_REQUIRE_NE = is_normal | is_ne | is_require,
 
-        DT_WARN_GT    = is_normal | is_gt | is_warn,
-        DT_CHECK_GT   = is_normal | is_gt | is_check,
-        DT_REQUIRE_GT = is_normal | is_gt | is_require,
+    DT_WARN_GT = is_normal | is_gt | is_warn,
+    DT_CHECK_GT = is_normal | is_gt | is_check,
+    DT_REQUIRE_GT = is_normal | is_gt | is_require,
 
-        DT_WARN_LT    = is_normal | is_lt | is_warn,
-        DT_CHECK_LT   = is_normal | is_lt | is_check,
-        DT_REQUIRE_LT = is_normal | is_lt | is_require,
+    DT_WARN_LT = is_normal | is_lt | is_warn,
+    DT_CHECK_LT = is_normal | is_lt | is_check,
+    DT_REQUIRE_LT = is_normal | is_lt | is_require,
 
-        DT_WARN_GE    = is_normal | is_ge | is_warn,
-        DT_CHECK_GE   = is_normal | is_ge | is_check,
-        DT_REQUIRE_GE = is_normal | is_ge | is_require,
+    DT_WARN_GE = is_normal | is_ge | is_warn,
+    DT_CHECK_GE = is_normal | is_ge | is_check,
+    DT_REQUIRE_GE = is_normal | is_ge | is_require,
 
-        DT_WARN_LE    = is_normal | is_le | is_warn,
-        DT_CHECK_LE   = is_normal | is_le | is_check,
-        DT_REQUIRE_LE = is_normal | is_le | is_require,
+    DT_WARN_LE = is_normal | is_le | is_warn,
+    DT_CHECK_LE = is_normal | is_le | is_check,
+    DT_REQUIRE_LE = is_normal | is_le | is_require,
 
-        DT_WARN_UNARY    = is_normal | is_unary | is_warn,
-        DT_CHECK_UNARY   = is_normal | is_unary | is_check,
-        DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
+    DT_WARN_UNARY = is_normal | is_unary | is_warn,
+    DT_CHECK_UNARY = is_normal | is_unary | is_check,
+    DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
 
-        DT_WARN_UNARY_FALSE    = is_normal | is_false | is_unary | is_warn,
-        DT_CHECK_UNARY_FALSE   = is_normal | is_false | is_unary | is_check,
-        DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
-    };
+    DT_WARN_UNARY_FALSE = is_normal | is_false | is_unary | is_warn,
+    DT_CHECK_UNARY_FALSE = is_normal | is_false | is_unary | is_check,
+    DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
+};
 } // namespace assertType
 
-DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
-DOCTEST_INTERFACE const char* failureString(assertType::Enum at);
+DOCTEST_INTERFACE const char *assertString(assertType::Enum at);
+DOCTEST_INTERFACE const char *failureString(assertType::Enum at);
 
-}
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 

--- a/doctest/parts/public/color.h
+++ b/doctest/parts/public/color.h
@@ -8,28 +8,27 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace Color {
-    enum Enum
-    {
-        None = 0,
-        White,
-        Red,
-        Green,
-        Blue,
-        Cyan,
-        Yellow,
-        Grey,
+enum Enum {
+    None = 0,
+    White,
+    Red,
+    Green,
+    Blue,
+    Cyan,
+    Yellow,
+    Grey,
 
-        Bright = 0x10,
+    Bright = 0x10,
 
-        BrightRed   = Bright | Red,
-        BrightGreen = Bright | Green,
-        LightGrey   = Bright | Grey,
-        BrightWhite = Bright | White
-    };
+    BrightRed = Bright | Red,
+    BrightGreen = Bright | Green,
+    LightGrey = Bright | Grey,
+    BrightWhite = Bright | White
+};
 
-    DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
+DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, Color::Enum code);
 } // namespace Color
-}
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 

--- a/doctest/parts/public/compiler.h
+++ b/doctest/parts/public/compiler.h
@@ -14,21 +14,19 @@
 #define DOCTEST_CPLUSPLUS __cplusplus
 #endif
 
-#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
+#define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
 
 // GCC/Clang and GCC/MSVC are mutually exclusive, but Clang/MSVC are not because of clang-cl...
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
 #if _MSC_VER == _MSC_FULL_VER / 10000
 #define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
 #else // MSVC
-#define DOCTEST_MSVC                                                                               \
-    DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
 #endif // MSVC
 #endif // MSVC
 #if defined(__clang__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
 #define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
-#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) &&              \
-        !defined(__INTEL_COMPILER)
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__INTEL_COMPILER)
 #define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
 #endif // GCC
 #if defined(__INTEL_COMPILER)

--- a/doctest/parts/public/config.h
+++ b/doctest/parts/public/config.h
@@ -38,8 +38,8 @@
 #undef DOCTEST_CONFIG_WINDOWS_SEH
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
-#if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) &&             \
-        !defined(__EMSCRIPTEN__) && !defined(__wasi__)
+#if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(__EMSCRIPTEN__) &&     \
+    !defined(__wasi__)
 #define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
@@ -47,8 +47,7 @@
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
-        || defined(__wasi__)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND) || defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS

--- a/doctest/parts/public/context.h
+++ b/doctest/parts/public/context.h
@@ -7,37 +7,36 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    DOCTEST_INTERFACE extern bool is_running_in_test;
+DOCTEST_INTERFACE extern bool is_running_in_test;
 
 namespace detail {
-    using assert_handler = void (*)(const AssertData&);
-    struct ContextState;
+using assert_handler = void (*)(const AssertData &);
+struct ContextState;
 } // namespace detail
 
-class DOCTEST_INTERFACE Context
-{
-    detail::ContextState* p;
+class DOCTEST_INTERFACE Context {
+    detail::ContextState *p;
 
-    void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
+    void parseArgs(int argc, const char *const *argv, bool withDefaults = false);
 
 public:
-    explicit Context(int argc = 0, const char* const* argv = nullptr);
+    explicit Context(int argc = 0, const char *const *argv = nullptr);
 
-    Context(const Context&) = delete;
-    Context(Context&&) = delete;
+    Context(const Context &) = delete;
+    Context(Context &&) = delete;
 
-    Context& operator=(const Context&) = delete;
-    Context& operator=(Context&&) = delete;
+    Context &operator=(const Context &) = delete;
+    Context &operator=(Context &&) = delete;
 
     ~Context(); // NOLINT(performance-trivially-destructible)
 
-    void applyCommandLine(int argc, const char* const* argv);
+    void applyCommandLine(int argc, const char *const *argv);
 
-    void addFilter(const char* filter, const char* value);
+    void addFilter(const char *filter, const char *value);
     void clearFilters();
-    void setOption(const char* option, bool value);
-    void setOption(const char* option, int value);
-    void setOption(const char* option, const char* value);
+    void setOption(const char *option, bool value);
+    void setOption(const char *option, int value);
+    void setOption(const char *option, const char *value);
 
     bool shouldExit();
 
@@ -45,7 +44,7 @@ public:
 
     void setAssertHandler(detail::assert_handler ah);
 
-    void setCout(std::ostream* out);
+    void setCout(std::ostream *out);
 
     int run();
 };

--- a/doctest/parts/public/context/options.h
+++ b/doctest/parts/public/context/options.h
@@ -7,59 +7,58 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 namespace detail {
-    struct DOCTEST_INTERFACE TestCase;
+struct DOCTEST_INTERFACE TestCase;
 } // namespace detail
 
-    struct ContextOptions
-    {
-        std::ostream* cout = nullptr; // stdout stream
-        String        binary_name;    // the test binary name
+struct ContextOptions {
+    std::ostream *cout = nullptr; // stdout stream
+    String binary_name;           // the test binary name
 
-        const detail::TestCase* currentTest = nullptr;
+    const detail::TestCase *currentTest = nullptr;
 
-        // == parameters from the command line
-        String   out;       // output filename
-        String   order_by;  // how tests should be ordered
-        unsigned rand_seed; // the seed for rand ordering
+    // == parameters from the command line
+    String out;         // output filename
+    String order_by;    // how tests should be ordered
+    unsigned rand_seed; // the seed for rand ordering
 
-        unsigned first; // the first (matching) test to be executed
-        unsigned last;  // the last (matching) test to be executed
+    unsigned first; // the first (matching) test to be executed
+    unsigned last;  // the last (matching) test to be executed
 
-        int abort_after;           // stop tests after this many failed assertions
-        int subcase_filter_levels; // apply the subcase filters for the first N levels
+    int abort_after;           // stop tests after this many failed assertions
+    int subcase_filter_levels; // apply the subcase filters for the first N levels
 
-        bool success;              // include successful assertions in output
-        bool case_sensitive;       // if filtering should be case sensitive
-        bool exit;                 // if the program should be exited after the tests are ran/whatever
-        bool duration;             // print the time duration of each test case
-        bool minimal;              // minimal console output (only test failures)
-        bool quiet;                // no console output
-        bool no_throw;             // to skip exceptions-related assertion macros
-        bool no_exitcode;          // if the framework should return 0 as the exitcode
-        bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-        bool no_intro;             // to not print the intro of the framework
-        bool no_version;           // to not print the version of the framework
-        bool no_colors;            // if output to the console should be colorized
-        bool force_colors;         // forces the use of colors even when a tty cannot be detected
-        bool no_breaks;            // to not break into the debugger
-        bool no_skip;              // don't skip test cases which are marked to be skipped
-        bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-        bool no_path_in_filenames; // if the path to files should be removed from the output
-        String strip_file_prefixes;// remove the longest matching one of these prefixes from any file paths in the output
-        bool no_line_numbers;      // if source code line numbers should be omitted from the output
-        bool no_debug_output;      // no output in the debug console when a debugger is attached
-        bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
-        bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
+    bool success;               // include successful assertions in output
+    bool case_sensitive;        // if filtering should be case sensitive
+    bool exit;                  // if the program should be exited after the tests are ran/whatever
+    bool duration;              // print the time duration of each test case
+    bool minimal;               // minimal console output (only test failures)
+    bool quiet;                 // no console output
+    bool no_throw;              // to skip exceptions-related assertion macros
+    bool no_exitcode;           // if the framework should return 0 as the exitcode
+    bool no_run;                // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;              // to not print the intro of the framework
+    bool no_version;            // to not print the version of the framework
+    bool no_colors;             // if output to the console should be colorized
+    bool force_colors;          // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;             // to not break into the debugger
+    bool no_skip;               // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;         // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames;  // if the path to files should be removed from the output
+    String strip_file_prefixes; // remove the longest matching one of these prefixes from any file paths in the output
+    bool no_line_numbers;       // if source code line numbers should be omitted from the output
+    bool no_debug_output;       // no output in the debug console when a debugger is attached
+    bool no_skipped_summary;    // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;     // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
-        bool help;             // to print the help
-        bool version;          // to print the version
-        bool count;            // if only the count of matching tests is to be retrieved
-        bool list_test_cases;  // to list all tests matching the filters
-        bool list_test_suites; // to list all suites matching the filters
-        bool list_reporters;   // lists all registered reporters
-    };
+    bool help;             // to print the help
+    bool version;          // to print the version
+    bool count;            // if only the count of matching tests is to be retrieved
+    bool list_test_cases;  // to list all tests matching the filters
+    bool list_test_suites; // to list all suites matching the filters
+    bool list_reporters;   // lists all registered reporters
+};
 
-    DOCTEST_INTERFACE const ContextOptions* getContextOptions();
+DOCTEST_INTERFACE const ContextOptions *getContextOptions();
 
 } // namespace doctest
 

--- a/doctest/parts/public/context_scope.h
+++ b/doctest/parts/public/context_scope.h
@@ -8,60 +8,63 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE IContextScope
-{
+struct DOCTEST_INTERFACE IContextScope {
     DOCTEST_DECLARE_INTERFACE(IContextScope)
-    virtual void stringify(std::ostream*) const = 0;
+    virtual void stringify(std::ostream *) const = 0;
 };
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-  // ContextScope base class used to allow implementing methods of ContextScope
-  // that don't depend on the template parameter in doctest.cpp.
-  struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
-      ContextScopeBase(const ContextScopeBase&) = delete;
+// ContextScope base class used to allow implementing methods of ContextScope
+// that don't depend on the template parameter in doctest.cpp.
+struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    ContextScopeBase(const ContextScopeBase &) = delete;
 
-      ContextScopeBase& operator=(const ContextScopeBase&) = delete;
-      ContextScopeBase& operator=(ContextScopeBase&&) = delete;
+    ContextScopeBase &operator=(const ContextScopeBase &) = delete;
+    ContextScopeBase &operator=(ContextScopeBase &&) = delete;
 
-      ~ContextScopeBase() override = default;
+    ~ContextScopeBase() override = default;
 
-  protected:
-      ContextScopeBase();
-      ContextScopeBase(ContextScopeBase&& other) noexcept;
+protected:
+    ContextScopeBase();
+    ContextScopeBase(ContextScopeBase &&other) noexcept;
 
-      void destroy();
-      bool need_to_destroy{true};
-  };
+    void destroy();
+    bool need_to_destroy{true};
+};
 
-  template <typename L> class ContextScope : public ContextScopeBase
-  {
-      L lambda_;
+template <typename L>
+class ContextScope : public ContextScopeBase {
+    L lambda_;
 
-  public:
-      explicit ContextScope(const L &lambda) : lambda_(lambda) {}
-      explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
+public:
+    explicit ContextScope(const L &lambda)
+        : lambda_(lambda) {}
+    explicit ContextScope(L &&lambda)
+        : lambda_(static_cast<L &&>(lambda)) {}
 
-      ContextScope(const ContextScope&) = delete;
-      ContextScope(ContextScope&&) noexcept = default;
+    ContextScope(const ContextScope &) = delete;
+    ContextScope(ContextScope &&) noexcept = default;
 
-      ContextScope& operator=(const ContextScope&) = delete;
-      ContextScope& operator=(ContextScope&&) = delete;
+    ContextScope &operator=(const ContextScope &) = delete;
+    ContextScope &operator=(ContextScope &&) = delete;
 
-      void stringify(std::ostream* s) const override { lambda_(s); }
+    void stringify(std::ostream *s) const override {
+        lambda_(s);
+    }
 
-      ~ContextScope() override {
-          if (need_to_destroy) {
-              destroy();
-          }
-      }
-  };
+    ~ContextScope() override {
+        if (need_to_destroy) {
+            destroy();
+        }
+    }
+};
 
-  template <typename L>
-  ContextScope<L> MakeContextScope(const L &lambda) {
-      return ContextScope<L>(lambda);
-  }
+template <typename L>
+ContextScope<L> MakeContextScope(const L &lambda) {
+    return ContextScope<L>(lambda);
+}
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/debugger.h
+++ b/doctest/parts/public/debugger.h
@@ -8,7 +8,7 @@
 #ifdef DOCTEST_PLATFORM_LINUX
 #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
 // Break at the location of the failing check if possible
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
 #else
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <signal.h>
@@ -17,10 +17,11 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
 #elif defined(__ppc__) || defined(__ppc64__)
 // https://www.cocoawithlove.com/2008/03/break-into-debugger.html
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#define DOCTEST_BREAK_INTO_DEBUGGER() /* NOLINTNEXTLINE(hicpp-no-assembler) */                                         \
+    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" ::: "memory", "r0", "r3", "r4")
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
@@ -40,9 +41,9 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 namespace doctest {
 namespace detail {
-    DOCTEST_INTERFACE bool isDebuggerActive();
-} // detail
-} // doctest
+DOCTEST_INTERFACE bool isDebuggerActive();
+} // namespace detail
+} // namespace doctest
 
 #endif
 

--- a/doctest/parts/public/decorators.h
+++ b/doctest/parts/public/decorators.h
@@ -7,18 +7,21 @@
 
 namespace doctest {
 
-#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
-    struct name                                                                                    \
-    {                                                                                              \
-        type data;                                                                                 \
-        name(type in = def)                                                                        \
-                : data(in) {}                                                                      \
-        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
-        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                                      \
+    struct name {                                                                                                      \
+        type data;                                                                                                     \
+        name(type in = def)                                                                                            \
+            : data(in) {}                                                                                              \
+        void fill(detail::TestCase &state) const {                                                                     \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
+        void fill(detail::TestSuite &state) const {                                                                    \
+            state.DOCTEST_CAT(m_, name) = data;                                                                        \
+        }                                                                                                              \
     }
 
-DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
-DOCTEST_DEFINE_DECORATOR(description, const char*, "");
+DOCTEST_DEFINE_DECORATOR(test_suite, const char *, "");
+DOCTEST_DEFINE_DECORATOR(description, const char *, "");
 DOCTEST_DEFINE_DECORATOR(skip, bool, true);
 DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
 DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
@@ -27,7 +30,7 @@ DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
-} // namespace
+} // namespace doctest
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/public/exception_translator.h
+++ b/doctest/parts/public/exception_translator.h
@@ -10,37 +10,35 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-    struct DOCTEST_INTERFACE IExceptionTranslator
-    {
-        DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
-        virtual bool translate(String&) const = 0;
-    };
+struct DOCTEST_INTERFACE IExceptionTranslator {
+    DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
+    virtual bool translate(String &) const = 0;
+};
 
-    template <typename T>
-    class ExceptionTranslator : public IExceptionTranslator
-    {
-    public:
-        explicit ExceptionTranslator(String (*translateFunction)(T))
-                : m_translateFunction(translateFunction) {}
+template <typename T>
+class ExceptionTranslator : public IExceptionTranslator {
+public:
+    explicit ExceptionTranslator(String (*translateFunction)(T))
+        : m_translateFunction(translateFunction) {}
 
-        bool translate(String& res) const override {
+    bool translate(String &res) const override {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-            try {
-                throw;
-            } catch(const T& ex) {
-                res = m_translateFunction(ex);
-                return true;
-            } catch(...) {}
-#endif                              // DOCTEST_CONFIG_NO_EXCEPTIONS
-            static_cast<void>(res); // to silence -Wunused-parameter
-            return false;
-        }
+        try {
+            throw;
+        } catch (const T &ex) {
+            res = m_translateFunction(ex);
+            return true;
+        } catch (...) {}
+#endif                          // DOCTEST_CONFIG_NO_EXCEPTIONS
+        static_cast<void>(res); // to silence -Wunused-parameter
+        return false;
+    }
 
-    private:
-        String (*m_translateFunction)(T);
-    };
+private:
+    String (*m_translateFunction)(T);
+};
 
-    DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator* et);
+DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator *et);
 
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/public/exceptions.h
+++ b/doctest/parts/public/exceptions.h
@@ -11,16 +11,14 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-  struct DOCTEST_INTERFACE TestFailureException
-  {
-  };
+struct DOCTEST_INTERFACE TestFailureException {};
 
-  DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_NORETURN
+DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-  DOCTEST_INTERFACE void throwException();
+DOCTEST_INTERFACE void throwException();
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/macros.h
+++ b/doctest/parts/public/macros.h
@@ -8,8 +8,10 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace doctest {
 namespace detail {
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+template <typename T>
+int instantiationHelper(const T &) {
+    return 0;
+}
 
 } // namespace detail
 } // namespace doctest
@@ -30,249 +32,261 @@ namespace detail {
 #define DOCTEST_FUNC_SCOPE_RET(v) return v
 #else
 #define DOCTEST_FUNC_SCOPE_BEGIN do
-#define DOCTEST_FUNC_SCOPE_END while(false)
+#define DOCTEST_FUNC_SCOPE_END while (false)
 #define DOCTEST_FUNC_SCOPE_RET(v) (void)0
 #endif
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
-    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
-    b.react();                                                                                     \
+#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                                             \
+    if (b.log())                                                                                                       \
+        DOCTEST_BREAK_INTO_DEBUGGER();                                                                                 \
+    b.react();                                                                                                         \
     DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
 #ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #define DOCTEST_WRAP_IN_TRY(x) x;
 #else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#define DOCTEST_WRAP_IN_TRY(x)                                                                     \
-    try {                                                                                          \
-        x;                                                                                         \
-    } catch(...) { DOCTEST_RB.translateException(); }
+#define DOCTEST_WRAP_IN_TRY(x)                                                                                         \
+    try {                                                                                                              \
+        x;                                                                                                             \
+    } catch (...) { DOCTEST_RB.translateException(); }
 #endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #ifdef DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(...)                                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
-    static_cast<void>(__VA_ARGS__);                                                                \
+#define DOCTEST_CAST_TO_VOID(...)                                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                                           \
+    static_cast<void>(__VA_ARGS__);                                                                                    \
     DOCTEST_GCC_SUPPRESS_WARNING_POP
 #else // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 #define DOCTEST_CAST_TO_VOID(...) __VA_ARGS__;
 #endif // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 
 // registers the test by initializing a dummy var with a function
-#define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
-            doctest::detail::regTest(                                                              \
-                    doctest::detail::TestCase(                                                     \
-                            f, __FILE__, __LINE__,                                                 \
-                            doctest_detail_test_suite_ns::getCurrentTestSuite()) *                 \
-                    decorators))
+#define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                                        \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(                                                                          \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */                                                             \
+        doctest::detail::regTest(                                                                                      \
+            doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) *    \
+            decorators                                                                                                 \
+        )                                                                                                              \
+    )
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace { /* NOLINT */                                                                       \
-        struct der : public base                                                                   \
-        {                                                                                          \
-            void f();                                                                              \
-        };                                                                                         \
-        static DOCTEST_INLINE_NOINLINE void func() {                                               \
-            der v;                                                                                 \
-            v.f();                                                                                 \
-        }                                                                                          \
-        DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                 \
-    }                                                                                              \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                                         \
+    namespace { /* NOLINT */                                                                                           \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    static DOCTEST_INLINE_NOINLINE void func() {                                                                       \
+        der v;                                                                                                         \
+        v.f();                                                                                                         \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                                         \
+    }                                                                                                                  \
     DOCTEST_INLINE_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
-    static void f();                                                                               \
-    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, f, decorators)                                        \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                                            \
+    static void f();                                                                                                   \
+    DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, f, decorators)                                                            \
     static void f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                        \
-    static doctest::detail::funcType proxy() { return f; }                                         \
-    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                         \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                                            \
+    static doctest::detail::funcType proxy() {                                                                         \
+        return f;                                                                                                      \
+    }                                                                                                                  \
+    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                                             \
     static void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(decorators)                                                              \
+#define DOCTEST_TEST_CASE(decorators)                                                                                  \
     DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests in classes - requires C++17 for inline variables!
 #if DOCTEST_CPLUSPLUS >= 201703L
-#define DOCTEST_TEST_CASE_CLASS(decorators)                                                        \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_),           \
-                                                  DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_),          \
-                                                  decorators)
+#define DOCTEST_TEST_CASE_CLASS(decorators)                                                                            \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(                                                                     \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_), decorators                      \
+    )
 #else // DOCTEST_TEST_CASE_CLASS
-#define DOCTEST_TEST_CASE_CLASS(...)                                                               \
-    TEST_CASES_CAN_BE_REGISTERED_IN_CLASSES_ONLY_IN_CPP17_MODE_OR_WITH_VS_2017_OR_NEWER
+#define DOCTEST_TEST_CASE_CLASS(...) TEST_CASES_CAN_BE_REGISTERED_IN_CLASSES_ONLY_IN_CPP17_MODE_OR_WITH_VS_2017_OR_NEWER
 #endif // DOCTEST_TEST_CASE_CLASS
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c,                           \
-                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
+#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                       \
+    DOCTEST_IMPLEMENT_FIXTURE(                                                                                         \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators                   \
+    )
 
 // for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                        \
-    namespace doctest {                                                                            \
-        template <>                                                                                \
-        inline String toString<__VA_ARGS__>() {                                                    \
-            return str;                                                                            \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                                            \
+    namespace doctest {                                                                                                \
+    template <>                                                                                                        \
+    inline String toString<__VA_ARGS__>() {                                                                            \
+        return str;                                                                                                    \
+    }                                                                                                                  \
+    }                                                                                                                  \
     static_assert(true, "")
 
 #define DOCTEST_TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING_AS(#__VA_ARGS__, __VA_ARGS__)
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                 \
-    template <typename T>                                                                          \
-    static void func();                                                                            \
-    namespace { /* NOLINT */                                                                       \
-        template <typename Tuple>                                                                  \
-        struct iter;                                                                               \
-        template <typename Type, typename... Rest>                                                 \
-        struct iter<std::tuple<Type, Rest...>>                                                     \
-        {                                                                                          \
-            iter(const char* file, unsigned line, int index) {                                     \
-                doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
-                                            doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::toString<Type>(),                             \
-                                            int(line) * 1000 + index)                              \
-                                         * dec);                                                   \
-                iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
-            }                                                                                      \
-        };                                                                                         \
-        template <>                                                                                \
-        struct iter<std::tuple<>>                                                                  \
-        {                                                                                          \
-            iter(const char*, unsigned, int) {}                                                    \
-        };                                                                                         \
-    }                                                                                              \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                                     \
+    template <typename T>                                                                                              \
+    static void func();                                                                                                \
+    namespace { /* NOLINT */                                                                                           \
+    template <typename Tuple>                                                                                          \
+    struct iter;                                                                                                       \
+    template <typename Type, typename... Rest>                                                                         \
+    struct iter<std::tuple<Type, Rest...>> {                                                                           \
+        iter(const char *file, unsigned line, int index) {                                                             \
+            doctest::detail::regTest(                                                                                  \
+                doctest::detail::TestCase(                                                                             \
+                    func<Type>,                                                                                        \
+                    file,                                                                                              \
+                    line,                                                                                              \
+                    doctest_detail_test_suite_ns::getCurrentTestSuite(),                                               \
+                    doctest::toString<Type>(),                                                                         \
+                    int(line) * 1000 + index                                                                           \
+                ) *                                                                                                    \
+                dec                                                                                                    \
+            );                                                                                                         \
+            iter<std::tuple<Rest...>>(file, line, index + 1);                                                          \
+        }                                                                                                              \
+    };                                                                                                                 \
+    template <>                                                                                                        \
+    struct iter<std::tuple<>> {                                                                                        \
+        iter(const char *, unsigned, int) {}                                                                           \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename T>                                                                                              \
     static void func()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                              \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR),                      \
-                                           DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                                                  \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR), DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
-        doctest::detail::instantiationHelper(                                                      \
-            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                                     \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */                 \
+        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR) < __VA_ARGS__ > (__FILE__, __LINE__, 0))        \
+    )
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                                     \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>)     \
     static_assert(true, "")
 
-#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                                      \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)                 \
     static_assert(true, "")
 
-#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);             \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, std::tuple<__VA_ARGS__>)               \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                                             \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);                                 \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, std::tuple<__VA_ARGS__>)                                   \
+    template <typename T>                                                                                              \
     static void anon()
 
-#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                    \
+#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                                        \
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
-               doctest::detail::Subcase(name, __FILE__, __LINE__))
+#define DOCTEST_SUBCASE(name)                                                                                          \
+    if (const doctest::detail::Subcase &DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =                      \
+            doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
-#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
-    namespace ns_name { namespace doctest_detail_test_suite_ns {                                   \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() noexcept {   \
-                DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                      \
-                DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                \
-                DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")             \
-                static doctest::detail::TestSuite data{};                                          \
-                static bool                       inited = false;                                  \
-                DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                  \
-                DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                 \
-                DOCTEST_GCC_SUPPRESS_WARNING_POP                                                   \
-                if(!inited) {                                                                      \
-                    data* decorators;                                                              \
-                    inited = true;                                                                 \
-                }                                                                                  \
-                return data;                                                                       \
-            }                                                                                      \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                                                   \
+    namespace ns_name {                                                                                                \
+    namespace doctest_detail_test_suite_ns {                                                                           \
+    static DOCTEST_NOINLINE doctest::detail::TestSuite &getCurrentTestSuite() noexcept {                               \
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                                                  \
+        DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                                            \
+        DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")                                         \
+        static doctest::detail::TestSuite data{};                                                                      \
+        static bool inited = false;                                                                                    \
+        DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                                              \
+        DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                             \
+        DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                               \
+        if (!inited) {                                                                                                 \
+            data *decorators;                                                                                          \
+            inited = true;                                                                                             \
+        }                                                                                                              \
+        return data;                                                                                                   \
+    }                                                                                                                  \
+    }                                                                                                                  \
+    }                                                                                                                  \
     namespace ns_name
 
-#define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
+#define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
+#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                                           \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators)                                       \
+    )                                                                                                                  \
     static_assert(true, "")
 
 // for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+#define DOCTEST_TEST_SUITE_END                                                                                         \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */                                             \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")                                               \
+    )                                                                                                                  \
     using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
-    inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerExceptionTranslator(translatorName))                                  \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                                          \
+    inline doctest::String translatorName(signature);                                                                  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */                                      \
+        doctest::registerExceptionTranslator(translatorName)                                                           \
+    )                                                                                                                  \
     doctest::String translatorName(signature)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_),        \
-                                               signature)
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), signature)
 
 // for registering reporters
-#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerReporter<reporter>(name, priority, true))                             \
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                                        \
+        doctest::registerReporter<reporter>(name, priority, true)                                                      \
+    )                                                                                                                  \
     static_assert(true, "")
 
 // for registering listeners
-#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
-            doctest::registerReporter<reporter>(name, priority, false))                            \
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */                                        \
+        doctest::registerReporter<reporter>(name, priority, false)                                                     \
+    )                                                                                                                  \
     static_assert(true, "")
 
-// clang-format off
-// for logging - disabling formatting because it's important to have these on 2 separate lines - see PR #557
-#define DOCTEST_INFO(...)                                                                          \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
-                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
-                      __VA_ARGS__)
-// clang-format on
+#define DOCTEST_INFO(...)                                                                                              \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_), __VA_ARGS__)
 
-#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
-    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
-        [&](std::ostream* s_name) {                                                                \
-        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
-        mb_name.m_stream = s_name;                                                                 \
-        mb_name * __VA_ARGS__;                                                                     \
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                                                        \
+    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope([&](std::ostream *s_name) {           \
+        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn);                     \
+        mb_name.m_stream = s_name;                                                                                     \
+        mb_name *__VA_ARGS__;                                                                                          \
     })
 
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
 
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb * __VA_ARGS__;                                                                          \
-        if(mb.log())                                                                               \
-            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
-        mb.react();                                                                                \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                                                 \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                                     \
+        mb *__VA_ARGS__;                                                                                               \
+        if (mb.log())                                                                                                  \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                                             \
+        mb.react();                                                                                                    \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-// clang-format off
-#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-#define DOCTEST_ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
-// clang-format on
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...)                                                                        \
+    DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...)                                                                     \
+    DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_AT(file, line, ...)                                                                           \
+    DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
 
 #define DOCTEST_MESSAGE(...) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, __VA_ARGS__)
 #define DOCTEST_FAIL_CHECK(...) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, __VA_ARGS__)
@@ -282,59 +296,60 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
-    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
-                                               __LINE__, #__VA_ARGS__);                            \
-    DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-            << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
-    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                    \
+#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                      \
+    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__);     \
+    DOCTEST_WRAP_IN_TRY(                                                                                               \
+        DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__)   \
+    ) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                                    \
+    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                                        \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                                          \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
-                        __VA_ARGS__))                                                              \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                                                  \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(__VA_ARGS__))      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                                      \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 // necessary for <ASSERT>_MESSAGE
 #define DOCTEST_ASSERT_IMPLEMENT_2 DOCTEST_ASSERT_IMPLEMENT_1
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::decomp_assert(                                                                \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__,                    \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-                    << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    doctest::detail::decomp_assert(                                                                                    \
+        doctest::assertType::assert_type,                                                                              \
+        __FILE__,                                                                                                      \
+        __LINE__,                                                                                                      \
+        #__VA_ARGS__,                                                                                                  \
+        doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__                         \
+    ) DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
-    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                                            \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(                               \
+        doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__                                \
+    )
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
-                                  #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                                         \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -382,47 +397,51 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                  \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(const typename doctest::detail::types::remove_const<                           \
-                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
-                DOCTEST_RB.translateException();                                                   \
-                DOCTEST_RB.m_threw_as = true;                                                      \
-            } catch(...) { DOCTEST_RB.translateException(); }                                      \
-            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
-        } else { /* NOLINT(*-else-after-return) */                                                 \
-            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
-        }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                                      \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, #expr, #__VA_ARGS__, message                     \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (const typename doctest::detail::types::remove_const<                                              \
+                     typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type &) {                  \
+                DOCTEST_RB.translateException();                                                                       \
+                DOCTEST_RB.m_threw_as = true;                                                                          \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
-                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(...) { DOCTEST_RB.translateException(); }                                      \
-            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
-        } else { /* NOLINT(*-else-after-return) */                                                 \
-           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
-        }                                                                                          \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        if (!doctest::getContextOptions()->no_throw) {                                                                 \
+            doctest::detail::ResultBuilder DOCTEST_RB(                                                                 \
+                doctest::assertType::assert_type, __FILE__, __LINE__, expr_str, "", __VA_ARGS__                        \
+            );                                                                                                         \
+            try {                                                                                                      \
+                DOCTEST_CAST_TO_VOID(expr)                                                                             \
+            } catch (...) { DOCTEST_RB.translateException(); }                                                         \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                               \
+        } else { /* NOLINT(*-else-after-return) */                                                                     \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
-#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
-    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
-        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        try {                                                                                      \
-            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
-        } catch(...) { DOCTEST_RB.translateException(); }                                          \
-        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
-    } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                                       \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                                         \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__); \
+        try {                                                                                                          \
+            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                                          \
+        } catch (...) { DOCTEST_RB.translateException(); }                                                             \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                                                   \
+    }                                                                                                                  \
+    DOCTEST_FUNC_SCOPE_END
 
 // clang-format off
 #define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
@@ -470,43 +489,41 @@ namespace detail {
 // =================================================================================================
 #else // DOCTEST_CONFIG_DISABLE
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace /* NOLINT */ {                                                                       \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : public base                                                                   \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                                               \
+    namespace /* NOLINT */ {                                                                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
+    struct der : public base {                                                                                         \
+        void f();                                                                                                      \
+    };                                                                                                                 \
+    }                                                                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                                                  \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     static inline void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for registering tests in classes
-#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_CLASS(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x,                           \
-                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                                             \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
 
 // for converting types to strings without the <typeinfo> header and demangling
 #define DOCTEST_TYPE_TO_STRING_AS(str, ...) static_assert(true, "")
 #define DOCTEST_TYPE_TO_STRING(...) static_assert(true, "")
 
 // for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                                    \
+    template <typename type>                                                                                           \
     inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                                              \
+    template <typename type>                                                                                           \
     inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...) static_assert(true, "")
@@ -524,8 +541,8 @@ namespace detail {
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                                               \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                                                   \
     static inline doctest::String DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_)(signature)
 
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
@@ -540,8 +557,7 @@ namespace detail {
 #define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
 #define DOCTEST_FAIL(...) (static_cast<void>(0))
 
-#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
- && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED) && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
 
 #define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
 #define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
@@ -559,16 +575,18 @@ namespace detail {
 
 namespace doctest {
 namespace detail {
-#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
-    template <typename L, typename R>                                                              \
-    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+#define DOCTEST_RELATIONAL_OP(name, op)                                                                                \
+    template <typename L, typename R>                                                                                  \
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) {                                          \
+        return lhs op rhs;                                                                                             \
+    }
 
-    DOCTEST_RELATIONAL_OP(eq, ==)
-    DOCTEST_RELATIONAL_OP(ne, !=)
-    DOCTEST_RELATIONAL_OP(lt, <)
-    DOCTEST_RELATIONAL_OP(gt, >)
-    DOCTEST_RELATIONAL_OP(le, <=)
-    DOCTEST_RELATIONAL_OP(ge, >=)
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
 } // namespace detail
 } // namespace doctest
 
@@ -599,20 +617,25 @@ namespace detail {
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
-#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...)                                                                      \
+    [] {                                                                                                               \
+        static_assert(false, "Exception translation is not available when doctest is disabled.");                      \
+        return false;                                                                                                  \
+    }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(, , )
 
+// clang-format off
 #define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
 #define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
 #define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
@@ -632,6 +655,7 @@ namespace detail {
 #define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
 #define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
 #define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+// clang-format on
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
@@ -722,8 +746,16 @@ namespace detail {
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
-    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
+#define DOCTEST_EXCEPTION_EMPTY_FUNC                                                                                   \
+    [] {                                                                                                               \
+        static_assert(                                                                                                 \
+            false,                                                                                                     \
+            "Exceptions are disabled! "                                                                                \
+            "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want "                                       \
+            "to compile with exceptions disabled."                                                                     \
+        );                                                                                                             \
+        return false;                                                                                                  \
+    }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -787,49 +819,47 @@ namespace detail {
 
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 
-// clang-format off
 // KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
-#define DOCTEST_FAST_WARN_EQ             DOCTEST_WARN_EQ
-#define DOCTEST_FAST_CHECK_EQ            DOCTEST_CHECK_EQ
-#define DOCTEST_FAST_REQUIRE_EQ          DOCTEST_REQUIRE_EQ
-#define DOCTEST_FAST_WARN_NE             DOCTEST_WARN_NE
-#define DOCTEST_FAST_CHECK_NE            DOCTEST_CHECK_NE
-#define DOCTEST_FAST_REQUIRE_NE          DOCTEST_REQUIRE_NE
-#define DOCTEST_FAST_WARN_GT             DOCTEST_WARN_GT
-#define DOCTEST_FAST_CHECK_GT            DOCTEST_CHECK_GT
-#define DOCTEST_FAST_REQUIRE_GT          DOCTEST_REQUIRE_GT
-#define DOCTEST_FAST_WARN_LT             DOCTEST_WARN_LT
-#define DOCTEST_FAST_CHECK_LT            DOCTEST_CHECK_LT
-#define DOCTEST_FAST_REQUIRE_LT          DOCTEST_REQUIRE_LT
-#define DOCTEST_FAST_WARN_GE             DOCTEST_WARN_GE
-#define DOCTEST_FAST_CHECK_GE            DOCTEST_CHECK_GE
-#define DOCTEST_FAST_REQUIRE_GE          DOCTEST_REQUIRE_GE
-#define DOCTEST_FAST_WARN_LE             DOCTEST_WARN_LE
-#define DOCTEST_FAST_CHECK_LE            DOCTEST_CHECK_LE
-#define DOCTEST_FAST_REQUIRE_LE          DOCTEST_REQUIRE_LE
+#define DOCTEST_FAST_WARN_EQ DOCTEST_WARN_EQ
+#define DOCTEST_FAST_CHECK_EQ DOCTEST_CHECK_EQ
+#define DOCTEST_FAST_REQUIRE_EQ DOCTEST_REQUIRE_EQ
+#define DOCTEST_FAST_WARN_NE DOCTEST_WARN_NE
+#define DOCTEST_FAST_CHECK_NE DOCTEST_CHECK_NE
+#define DOCTEST_FAST_REQUIRE_NE DOCTEST_REQUIRE_NE
+#define DOCTEST_FAST_WARN_GT DOCTEST_WARN_GT
+#define DOCTEST_FAST_CHECK_GT DOCTEST_CHECK_GT
+#define DOCTEST_FAST_REQUIRE_GT DOCTEST_REQUIRE_GT
+#define DOCTEST_FAST_WARN_LT DOCTEST_WARN_LT
+#define DOCTEST_FAST_CHECK_LT DOCTEST_CHECK_LT
+#define DOCTEST_FAST_REQUIRE_LT DOCTEST_REQUIRE_LT
+#define DOCTEST_FAST_WARN_GE DOCTEST_WARN_GE
+#define DOCTEST_FAST_CHECK_GE DOCTEST_CHECK_GE
+#define DOCTEST_FAST_REQUIRE_GE DOCTEST_REQUIRE_GE
+#define DOCTEST_FAST_WARN_LE DOCTEST_WARN_LE
+#define DOCTEST_FAST_CHECK_LE DOCTEST_CHECK_LE
+#define DOCTEST_FAST_REQUIRE_LE DOCTEST_REQUIRE_LE
 
-#define DOCTEST_FAST_WARN_UNARY          DOCTEST_WARN_UNARY
-#define DOCTEST_FAST_CHECK_UNARY         DOCTEST_CHECK_UNARY
-#define DOCTEST_FAST_REQUIRE_UNARY       DOCTEST_REQUIRE_UNARY
-#define DOCTEST_FAST_WARN_UNARY_FALSE    DOCTEST_WARN_UNARY_FALSE
-#define DOCTEST_FAST_CHECK_UNARY_FALSE   DOCTEST_CHECK_UNARY_FALSE
+#define DOCTEST_FAST_WARN_UNARY DOCTEST_WARN_UNARY
+#define DOCTEST_FAST_CHECK_UNARY DOCTEST_CHECK_UNARY
+#define DOCTEST_FAST_REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
+#define DOCTEST_FAST_WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
+#define DOCTEST_FAST_CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
 #define DOCTEST_FAST_REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id,__VA_ARGS__)
-// clang-format on
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
 
 // BDD style macros
 // clang-format off
-#define DOCTEST_SCENARIO(name) DOCTEST_TEST_CASE("  Scenario: " name)
-#define DOCTEST_SCENARIO_CLASS(name) DOCTEST_TEST_CASE_CLASS("  Scenario: " name)
-#define DOCTEST_SCENARIO_TEMPLATE(name, T, ...)  DOCTEST_TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
+#define DOCTEST_SCENARIO(name)                                        DOCTEST_TEST_CASE("  Scenario: " name)
+#define DOCTEST_SCENARIO_CLASS(name)                            DOCTEST_TEST_CASE_CLASS("  Scenario: " name)
+#define DOCTEST_SCENARIO_TEMPLATE(name, T, ...)              DOCTEST_TEST_CASE_TEMPLATE("  Scenario: " name, T, __VA_ARGS__)
 #define DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE("  Scenario: " name, T, id)
 
-#define DOCTEST_GIVEN(name)     DOCTEST_SUBCASE("   Given: " name)
-#define DOCTEST_WHEN(name)      DOCTEST_SUBCASE("    When: " name)
-#define DOCTEST_AND_WHEN(name)  DOCTEST_SUBCASE("And when: " name)
-#define DOCTEST_THEN(name)      DOCTEST_SUBCASE("    Then: " name)
-#define DOCTEST_AND_THEN(name)  DOCTEST_SUBCASE("     And: " name)
+#define DOCTEST_GIVEN(name)    DOCTEST_SUBCASE("   Given: " name)
+#define DOCTEST_WHEN(name)     DOCTEST_SUBCASE("    When: " name)
+#define DOCTEST_AND_WHEN(name) DOCTEST_SUBCASE("And when: " name)
+#define DOCTEST_THEN(name)     DOCTEST_SUBCASE("    Then: " name)
+#define DOCTEST_AND_THEN(name) DOCTEST_SUBCASE("     And: " name)
 // clang-format on
 
 // == SHORT VERSIONS OF THE MACROS
@@ -883,6 +913,7 @@ namespace detail {
 #define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
 #define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
+// clang-format off
 #define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
 #define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
 #define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
@@ -904,6 +935,7 @@ namespace detail {
 #define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
 #define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
 #define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+// clang-format on
 
 #define SCENARIO(name) DOCTEST_SCENARIO(name)
 #define SCENARIO_CLASS(name) DOCTEST_SCENARIO_CLASS(name)

--- a/doctest/parts/public/matchers/approx.h
+++ b/doctest/parts/public/matchers/approx.h
@@ -7,84 +7,84 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE Approx
-{
+struct DOCTEST_INTERFACE Approx {
     Approx(double value);
 
     Approx operator()(double value) const;
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
+    explicit Approx(
+        const T &value,
+        typename detail::types::enable_if<std::is_constructible<double, T>::value>::type * = static_cast<T *>(nullptr)
+    ) {
         *this = static_cast<double>(value);
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& epsilon(double newEpsilon);
+    Approx &epsilon(double newEpsilon);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
-            const T& newEpsilon) {
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type epsilon(const T &newEpsilon) {
         m_epsilon = static_cast<double>(newEpsilon);
         return *this;
     }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& scale(double newScale);
+    Approx &scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
-            const T& newScale) {
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx &>::type scale(const T &newScale) {
         m_scale = static_cast<double>(newScale);
         return *this;
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format off
-    DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator==(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator!=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator<=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator<=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator>=(double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator>=(const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator< (double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator< (const Approx & lhs, double rhs);
-    DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx & rhs);
-    DOCTEST_INTERFACE friend bool operator> (const Approx & lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator==(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator!=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator<=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator<=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator>=(double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator>=(const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator< (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator< (const Approx &lhs, double rhs);
+    DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx &rhs);
+    DOCTEST_INTERFACE friend bool operator> (const Approx &lhs, double rhs);
+    // clang-format on
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-#define DOCTEST_APPROX_PREFIX \
-    template <typename T> friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
+#define DOCTEST_APPROX_PREFIX                                                                                          \
+    template <typename T>                                                                                              \
+    friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
 
-    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(static_cast<double>(lhs), rhs); }
-    DOCTEST_APPROX_PREFIX operator==(const Approx& lhs, const T& rhs) { return operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator!=(const T& lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
-    DOCTEST_APPROX_PREFIX operator!=(const Approx& lhs, const T& rhs) { return !operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
+    // clang-format off
+    DOCTEST_APPROX_PREFIX operator==(const T &lhs, const Approx &rhs) { return operator==(static_cast<double>(lhs), rhs); }
+    DOCTEST_APPROX_PREFIX operator==(const Approx &lhs, const T &rhs) { return operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const T &lhs, const Approx &rhs) { return !operator==(lhs, rhs); }
+    DOCTEST_APPROX_PREFIX operator!=(const Approx &lhs, const T &rhs) { return !operator==(rhs, lhs); }
+    DOCTEST_APPROX_PREFIX operator<=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const Approx &lhs, const T &rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const T &lhs, const Approx &rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const Approx &lhs, const T &rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
+    // clang-format off
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-
-    // clang-format on
 
     double m_epsilon;
     double m_scale;
     double m_value;
 };
 
-DOCTEST_INTERFACE String toString(const Approx& in);
+DOCTEST_INTERFACE String toString(const Approx &in);
 
 } // namespace doctest
 

--- a/doctest/parts/public/matchers/contains.h
+++ b/doctest/parts/public/matchers/contains.h
@@ -9,19 +9,19 @@ namespace doctest {
 
 class DOCTEST_INTERFACE Contains {
 public:
-    explicit Contains(const String& string);
+    explicit Contains(const String &string);
 
-    bool checkWith(const String& other) const;
+    bool checkWith(const String &other) const;
 
     String string;
 };
 
-DOCTEST_INTERFACE String toString(const Contains& in);
+DOCTEST_INTERFACE String toString(const Contains &in);
 
-DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
-DOCTEST_INTERFACE bool operator==(const Contains& lhs, const String& rhs);
-DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
-DOCTEST_INTERFACE bool operator!=(const Contains& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator==(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator==(const Contains &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const Contains &rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains &lhs, const String &rhs);
 
 } // namespace doctest
 

--- a/doctest/parts/public/matchers/is_nan.h
+++ b/doctest/parts/public/matchers/is_nan.h
@@ -8,11 +8,16 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 
 template <typename F>
-struct DOCTEST_INTERFACE_DECL IsNaN
-{
-    F value; bool flipped;
-    IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
-    IsNaN<F> operator!() const { return { value, !flipped }; }
+struct DOCTEST_INTERFACE_DECL IsNaN {
+    F value;
+    bool flipped;
+    IsNaN(F f, bool flip = false)
+        : value(f), flipped(flip) {}
+
+    IsNaN<F> operator!() const {
+        return {value, !flipped};
+    }
+
     operator bool() const;
 };
 

--- a/doctest/parts/public/path.h
+++ b/doctest/parts/public/path.h
@@ -7,7 +7,7 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
+DOCTEST_INTERFACE const char *skipPathFromFilename(const char *file);
 
 } // namespace doctest
 

--- a/doctest/parts/public/reporter.h
+++ b/doctest/parts/public/reporter.h
@@ -14,119 +14,115 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 
 namespace TestCaseFailureReason {
-    enum Enum
-    {
-        None                     = 0,
-        AssertFailure            = 1,   // an assertion has failed in the test case
-        Exception                = 2,   // test case threw an exception
-        Crash                    = 4,   // a crash...
-        TooManyFailedAsserts     = 8,   // the abort-after option
-        Timeout                  = 16,  // see the timeout decorator
-        ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
-        ShouldHaveFailedAndDid   = 64,  // see the should_fail decorator
-        DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
-        FailedExactlyNumTimes    = 256, // see the expected_failures decorator
-        CouldHaveFailedAndDid    = 512  // see the may_fail decorator
-    };
+enum Enum {
+    None = 0,
+    AssertFailure = 1,              // an assertion has failed in the test case
+    Exception = 2,                  // test case threw an exception
+    Crash = 4,                      // a crash...
+    TooManyFailedAsserts = 8,       // the abort-after option
+    Timeout = 16,                   // see the timeout decorator
+    ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
+    ShouldHaveFailedAndDid = 64,    // see the should_fail decorator
+    DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
+    FailedExactlyNumTimes = 256,    // see the expected_failures decorator
+    CouldHaveFailedAndDid = 512     // see the may_fail decorator
+};
 } // namespace TestCaseFailureReason
 
-    struct DOCTEST_INTERFACE CurrentTestCaseStats
-    {
-        int    numAssertsCurrentTest;
-        int    numAssertsFailedCurrentTest;
-        double seconds;
-        int    failure_flags; // use TestCaseFailureReason::Enum
-        bool   testCaseSuccess;
-    };
+struct DOCTEST_INTERFACE CurrentTestCaseStats {
+    int numAssertsCurrentTest;
+    int numAssertsFailedCurrentTest;
+    double seconds;
+    int failure_flags; // use TestCaseFailureReason::Enum
+    bool testCaseSuccess;
+};
 
-    struct DOCTEST_INTERFACE TestCaseException
-    {
-        String error_string;
-        bool   is_crash;
-    };
+struct DOCTEST_INTERFACE TestCaseException {
+    String error_string;
+    bool is_crash;
+};
 
-    struct DOCTEST_INTERFACE TestRunStats
-    {
-        unsigned numTestCases;
-        unsigned numTestCasesPassingFilters;
-        unsigned numTestSuitesPassingFilters;
-        unsigned numTestCasesFailed;
-        int      numAsserts;
-        int      numAssertsFailed;
-    };
+struct DOCTEST_INTERFACE TestRunStats {
+    unsigned numTestCases;
+    unsigned numTestCasesPassingFilters;
+    unsigned numTestSuitesPassingFilters;
+    unsigned numTestCasesFailed;
+    int numAsserts;
+    int numAssertsFailed;
+};
 
-    struct QueryData
-    {
-        const TestRunStats*  run_stats = nullptr;
-        const TestCaseData** data      = nullptr;
-        unsigned             num_data  = 0;
-    };
+struct QueryData {
+    const TestRunStats *run_stats = nullptr;
+    const TestCaseData **data = nullptr;
+    unsigned num_data = 0;
+};
 
-    struct DOCTEST_INTERFACE IReporter
-    {
-        // The constructor has to accept "const ContextOptions&" as a single argument
-        // which has most of the options for the run + a pointer to the stdout stream
-        // Reporter(const ContextOptions& in)
+struct DOCTEST_INTERFACE IReporter {
+    // The constructor has to accept "const ContextOptions&" as a single argument
+    // which has most of the options for the run + a pointer to the stdout stream
+    // Reporter(const ContextOptions& in)
 
-        // called when a query should be reported (listing test cases, printing the version, etc.)
-        virtual void report_query(const QueryData&) = 0;
+    // called when a query should be reported (listing test cases, printing the version, etc.)
+    virtual void report_query(const QueryData &) = 0;
 
-        // called when the whole test run starts
-        virtual void test_run_start() = 0;
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const TestRunStats&) = 0;
+    // called when the whole test run starts
+    virtual void test_run_start() = 0;
+    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+    virtual void test_run_end(const TestRunStats &) = 0;
 
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const TestCaseData&) = 0;
-        // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-        virtual void test_case_reenter(const TestCaseData&) = 0;
-        // called when a test case has ended
-        virtual void test_case_end(const CurrentTestCaseStats&) = 0;
+    // called when a test case is started (safe to cache a pointer to the input)
+    virtual void test_case_start(const TestCaseData &) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData &) = 0;
+    // called when a test case has ended
+    virtual void test_case_end(const CurrentTestCaseStats &) = 0;
 
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const TestCaseException&) = 0;
+    // called when an exception is thrown from the test case (or it crashes)
+    virtual void test_case_exception(const TestCaseException &) = 0;
 
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const SubcaseSignature&) = 0;
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() = 0;
+    // called whenever a subcase is entered (don't cache pointers to the input)
+    virtual void subcase_start(const SubcaseSignature &) = 0;
+    // called whenever a subcase is exited (don't cache pointers to the input)
+    virtual void subcase_end() = 0;
 
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const AssertData&) = 0;
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const MessageData&) = 0;
+    // called for each assert (don't cache pointers to the input)
+    virtual void log_assert(const AssertData &) = 0;
+    // called for each message (don't cache pointers to the input)
+    virtual void log_message(const MessageData &) = 0;
 
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const TestCaseData&) = 0;
+    // called when a test case is skipped either because it doesn't pass the filters,
+    // has a skip decorator or isn't in the execution range (between first and last)
+    // (safe to cache a pointer to the input)
+    virtual void test_case_skipped(const TestCaseData &) = 0;
 
-        DOCTEST_DECLARE_INTERFACE(IReporter)
+    DOCTEST_DECLARE_INTERFACE(IReporter)
 
-        // can obtain all currently active contexts and stringify them if one wishes to do so
-        static int                         get_num_active_contexts();
-        static const IContextScope* const* get_active_contexts();
+    // can obtain all currently active contexts and stringify them if one wishes to do so
+    static int get_num_active_contexts();
+    static const IContextScope *const *get_active_contexts();
 
-        // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-        static int           get_num_stringified_contexts();
-        static const String* get_stringified_contexts();
-    };
+    // can iterate through contexts which have been stringified automatically
+    // in their destructors when an exception has been thrown
+    static int get_num_stringified_contexts();
+    static const String *get_stringified_contexts();
+};
 
 namespace detail {
-    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
+using reporterCreatorFunc = IReporter *(*)(const ContextOptions &);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+DOCTEST_INTERFACE void registerReporterImpl(const char *name, int prio, reporterCreatorFunc c, bool isReporter);
 
-    template <typename Reporter>
-    IReporter* reporterCreator(const ContextOptions& o) {
-        return new Reporter(o);
-    }
+template <typename Reporter>
+IReporter *reporterCreator(const ContextOptions &o) {
+    return new Reporter(o);
+}
 } // namespace detail
 
-    template <typename Reporter>
-    int registerReporter(const char* name, int priority, bool isReporter) {
-        detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
-        return 0;
-    }
+template <typename Reporter>
+int registerReporter(const char *name, int priority, bool isReporter) {
+    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+    return 0;
+}
 } // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -16,19 +16,19 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-namespace std { // NOLINT(cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
-typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
+namespace std {                          // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr) nullptr_t;     // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void *)) size_t; // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+class basic_ostream;                                    // NOLINT(fuchsia-virtual-inheritance)
 typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
-template<class traits>
+template <class traits>
 // NOLINTNEXTLINE
-basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
+basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const char *);
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
@@ -49,8 +49,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
 namespace doctest {
-  using std::size_t;
-}
+using std::size_t;
+} // namespace doctest
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 

--- a/doctest/parts/public/std/type_traits.h
+++ b/doctest/parts/public/std/type_traits.h
@@ -16,37 +16,77 @@ namespace detail {
 namespace types {
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-  using namespace std;
+using namespace std;
 #else
-  template <bool COND, typename T = void>
-  struct enable_if { };
+template <bool COND, typename T = void>
+struct enable_if {};
 
-  template <typename T>
-  struct enable_if<true, T> { using type = T; };
+template <typename T>
+struct enable_if<true, T> {
+    using type = T;
+};
 
-  struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
-  struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
+struct true_type {
+    static DOCTEST_CONSTEXPR bool value = true;
+};
 
-  template <typename T> struct remove_reference { using type = T; };
-  template <typename T> struct remove_reference<T&> { using type = T; };
-  template <typename T> struct remove_reference<T&&> { using type = T; };
+struct false_type {
+    static DOCTEST_CONSTEXPR bool value = false;
+};
 
-  template <typename T> struct is_rvalue_reference : false_type { };
-  template <typename T> struct is_rvalue_reference<T&&> : true_type { };
+template <typename T>
+struct remove_reference {
+    using type = T;
+};
 
-  template<typename T> struct remove_const { using type = T; };
-  template <typename T> struct remove_const<const T> { using type = T; };
+template <typename T>
+struct remove_reference<T &> {
+    using type = T;
+};
 
-  // Compiler intrinsics
-  template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
-  template <typename T> struct underlying_type { using type = __underlying_type(T); };
+template <typename T>
+struct remove_reference<T &&> {
+    using type = T;
+};
 
-  template <typename T> struct is_pointer : false_type { };
-  template <typename T> struct is_pointer<T*> : true_type { };
+template <typename T>
+struct is_rvalue_reference : false_type {};
 
-  template <typename T> struct is_array : false_type { };
-  // NOLINTNEXTLINE(*-avoid-c-arrays)
-  template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+template <typename T>
+struct is_rvalue_reference<T &&> : true_type {};
+
+template <typename T>
+struct remove_const {
+    using type = T;
+};
+
+template <typename T>
+struct remove_const<const T> {
+    using type = T;
+};
+
+// Compiler intrinsics
+template <typename T>
+struct is_enum {
+    static DOCTEST_CONSTEXPR bool value = __is_enum(T);
+};
+
+template <typename T>
+struct underlying_type {
+    using type = __underlying_type(T);
+};
+
+template <typename T>
+struct is_pointer : false_type {};
+
+template <typename T>
+struct is_pointer<T *> : true_type {};
+
+template <typename T>
+struct is_array : false_type {};
+// NOLINTNEXTLINE(*-avoid-c-arrays)
+template <typename T, size_t SIZE>
+struct is_array<T[SIZE]> : true_type {};
 #endif
 
 } // namespace types

--- a/doctest/parts/public/std/utility.h
+++ b/doctest/parts/public/std/utility.h
@@ -8,22 +8,22 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-  // <utility>
-  template <typename T>
-  T&& declval();
+// <utility>
+template <typename T>
+T &&declval();
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
 
-  template <class T>
-  DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
-      return static_cast<T&&>(t);
-  }
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T &&forward(typename types::remove_reference<T>::type &&t) DOCTEST_NOEXCEPT {
+    return static_cast<T &&>(t);
+}
 
-  template <typename T>
-  struct deferred_false : types::false_type { };
+template <typename T>
+struct deferred_false : types::false_type {};
 
 } // namespace detail
 } // namespace doctest

--- a/doctest/parts/public/string.h
+++ b/doctest/parts/public/string.h
@@ -13,202 +13,216 @@ namespace doctest {
 #define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
 #endif
 
-    // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
-    // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
-    // - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
-    // - if small - capacity left before going on the heap - using the lowest 5 bits
-    // - if small - 2 bits are left unused - the second and third highest ones
-    // - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
-    //              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
-    // Idea taken from this lecture about the string implementation of facebook/folly - fbstring
-    // https://www.youtube.com/watch?v=kPR8h4-qZdk
-    // TODO:
-    // - optimizations - like not deleting memory unnecessarily in operator= and etc.
-    // - resize/reserve/clear
-    // - replace
-    // - back/front
-    // - iterator stuff
-    // - find & friends
-    // - push_back/pop_back
-    // - assign/insert/erase
-    // - relational operators as free functions - taking const char* as one of the params
-    class DOCTEST_INTERFACE String
+// A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings
+// with length of up to 23 chars on the stack before going on the heap -
+// the last byte of the buffer is used for:
+// - "is small" bit - the highest bit - if "0" then it is small - otherwise its "1" (128)
+// - if small - capacity left before going on the heap - using the lowest 5 bits
+// - if small - 2 bits are left unused - the second and third highest ones
+// - if small - acts as a null terminator if strlen() is 23 (24 including the null terminator)
+//              and the "is small" bit remains "0" ("as well as the capacity left") so its OK
+// Idea taken from this lecture about the string implementation of facebook/folly - fbstring
+// https://www.youtube.com/watch?v=kPR8h4-qZdk
+// TODO:
+// - optimizations - like not deleting memory unnecessarily in operator= and etc.
+// - resize/reserve/clear
+// - replace
+// - back/front
+// - iterator stuff
+// - find & friends
+// - push_back/pop_back
+// - assign/insert/erase
+// - relational operators as free functions - taking const char* as one of the params
+class DOCTEST_INTERFACE String {
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len = 24;
+    static DOCTEST_CONSTEXPR size_type last = len - 1;
+
+    struct view // len should be more than sizeof(view) - because of the final byte for flags
     {
-    public:
-        using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
-
-    private:
-        static DOCTEST_CONSTEXPR size_type len  = 24;
-        static DOCTEST_CONSTEXPR size_type last = len - 1;
-
-        struct view // len should be more than sizeof(view) - because of the final byte for flags
-        {
-            char*    ptr;
-            size_type size;
-            size_type capacity;
-        };
-
-        union
-        {
-            char buf[len]; // NOLINT(*-avoid-c-arrays)
-            view data;
-        };
-
-        char* allocate(size_type sz);
-
-        bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
-        void setOnHeap() noexcept;
-        void setLast(size_type in = last) noexcept;
-        void setSize(size_type sz) noexcept;
-
-        void copy(const String& other);
-
-    public:
-        static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
-
-        String() noexcept;
-        ~String();
-
-        String(const char* in);
-        String(const char* in, size_type in_size);
-
-        String(std::istream& in, size_type in_size);
-
-        String(const String& other);
-        String& operator=(const String& other);
-
-        String& operator+=(const String& other);
-
-        String(String&& other) noexcept;
-        String& operator=(String&& other) noexcept;
-
-        char  operator[](size_type i) const;
-        char& operator[](size_type i);
-
-        // the only functions I'm willing to leave in the interface - available for inlining
-        const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-        char*       c_str() {
-            if (isOnStack()) {
-                return reinterpret_cast<char*>(buf);
-            }
-            return data.ptr;
-        }
-
-        size_type size() const;
-        size_type capacity() const;
-
-        String substr(size_type pos, size_type cnt = npos) &&;
-        String substr(size_type pos, size_type cnt = npos) const &;
-
-        size_type find(char ch, size_type pos = 0) const;
-        size_type rfind(char ch, size_type pos = npos) const;
-
-        int compare(const char* other, bool no_case = false) const;
-        int compare(const String& other, bool no_case = false) const;
-
-        friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+        char *ptr;
+        size_type size;
+        size_type capacity;
     };
 
-    DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
+    union {
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
+        view data;
+    };
 
-    DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
-    DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
+    char *allocate(size_type sz);
+
+    bool isOnStack() const noexcept {
+        return (buf[last] & 128) == 0;
+    }
+
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
+
+    void copy(const String &other);
+
+public:
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
+    ~String();
+
+    String(const char *in);
+    String(const char *in, size_type in_size);
+
+    String(std::istream &in, size_type in_size);
+
+    String(const String &other);
+    String &operator=(const String &other);
+
+    String &operator+=(const String &other);
+
+    String(String &&other) noexcept;
+    String &operator=(String &&other) noexcept;
+
+    char operator[](size_type i) const;
+    char &operator[](size_type i);
+
+    // the only functions I'm willing to leave in the interface - available for inlining
+    const char *c_str() const {
+        return const_cast<String *>(this)->c_str(); // NOLINT
+    }
+
+    char *c_str() {
+        if (isOnStack()) {
+            return reinterpret_cast<char *>(buf);
+        }
+        return data.ptr;
+    }
+
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const &;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
+
+    int compare(const char *other, bool no_case = false) const;
+    int compare(const String &other, bool no_case = false) const;
+
+    friend DOCTEST_INTERFACE std::ostream &operator<<(std::ostream &s, const String &in);
+};
+
+DOCTEST_INTERFACE String operator+(const String &lhs, const String &rhs);
+
+DOCTEST_INTERFACE bool operator==(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator!=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator<=(const String &lhs, const String &rhs);
+DOCTEST_INTERFACE bool operator>=(const String &lhs, const String &rhs);
 
 namespace detail {
 
 // MSVS 2015 :(
 #if !DOCTEST_CLANG && defined(_MSC_VER) && _MSC_VER <= 1900
-    template <typename T, typename = void>
-    struct has_global_insertion_operator : types::false_type { };
+template <typename T, typename = void>
+struct has_global_insertion_operator : types::false_type {};
 
-    template <typename T>
-    struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+template <typename T>
+struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
 
-    template <typename T, typename = void>
-    struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+template <typename T, typename = void>
+struct has_insertion_operator {
+    static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value;
+};
 
-    template <typename T, bool global>
-    struct insert_hack;
+template <typename T, bool global>
+struct insert_hack;
 
-    template <typename T>
-    struct insert_hack<T, true> {
-        static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
-    };
+template <typename T>
+struct insert_hack<T, true> {
+    static void insert(std::ostream &os, const T &t) {
+        ::operator<<(os, t);
+    }
+};
 
-    template <typename T>
-    struct insert_hack<T, false> {
-        static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
-    };
+template <typename T>
+struct insert_hack<T, false> {
+    static void insert(std::ostream &os, const T &t) {
+        operator<<(os, t);
+    }
+};
 
-    template <typename T>
-    using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
+template <typename T>
+using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
 #else
-    template <typename T, typename = void>
-    struct has_insertion_operator : types::false_type { };
+template <typename T, typename = void>
+struct has_insertion_operator : types::false_type {};
 #endif
 
+template <typename T>
+struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream &>(), declval<const T &>()), void())>
+    : types::true_type {};
+
+template <typename T>
+struct should_stringify_as_underlying_type {
+    static DOCTEST_CONSTEXPR bool value =
+        detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
+};
+
+DOCTEST_INTERFACE std::ostream *tlssPush();
+DOCTEST_INTERFACE String tlssPop();
+
+template <bool C>
+struct StringMakerBase {
     template <typename T>
-    struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
-
-    template <typename T>
-    struct should_stringify_as_underlying_type {
-        static DOCTEST_CONSTEXPR bool value = detail::types::is_enum<T>::value && !doctest::detail::has_insertion_operator<T>::value;
-    };
-
-    DOCTEST_INTERFACE std::ostream* tlssPush();
-    DOCTEST_INTERFACE String tlssPop();
-
-    template <bool C>
-    struct StringMakerBase {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
+    static String convert(const DOCTEST_REF_WRAP(T)) {
 #ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
-            static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+        static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
 #endif
-            return "{?}";
-        }
-    };
-
-    template <typename T>
-    struct filldata;
-
-    template <typename T>
-    void filloss(std::ostream* stream, const T& in) {
-        filldata<T>::fill(stream, in);
+        return "{?}";
     }
+};
 
-    template <typename T, size_t N>
-    void filloss(std::ostream* stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
-        // T[N], T(&)[N], T(&&)[N] have same behaviour.
-        // Hence remove reference.
-        filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
-    }
+template <typename T>
+struct filldata;
 
+template <typename T>
+void filloss(std::ostream *stream, const T &in) {
+    filldata<T>::fill(stream, in);
+}
+
+template <typename T, size_t N>
+void filloss(std::ostream *stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
+    // T[N], T(&)[N], T(&&)[N] have same behaviour.
+    // Hence remove reference.
+    filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
+}
+
+template <typename T>
+String toStream(const T &in) {
+    std::ostream *stream = tlssPush();
+    filloss(stream, in);
+    return tlssPop();
+}
+
+template <>
+struct StringMakerBase<true> {
     template <typename T>
-    String toStream(const T& in) {
-        std::ostream* stream = tlssPush();
-        filloss(stream, in);
-        return tlssPop();
+    static String convert(const DOCTEST_REF_WRAP(T) in) {
+        return toStream(in);
     }
-
-    template <>
-    struct StringMakerBase<true> {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
-            return toStream(in);
-        }
-    };
+};
 
 } // namespace detail
 
-    template <typename T>
-    struct StringMaker : public detail::StringMakerBase<
-        detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
-    {};
+template <typename T>
+struct StringMaker : public detail::StringMakerBase<
+                         detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value ||
+                         detail::types::is_array<T>::value> {};
 
 #ifndef DOCTEST_STRINGIFY
 #ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
@@ -218,137 +232,144 @@ namespace detail {
 #endif
 #endif
 
-    template <typename T>
-    String toString() {
-    #if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
-        String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
-        String::size_type beginPos = ret.find('<');
-        return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
-    #else
-        String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
-        String::size_type begin = ret.find('=') + 2;
-        return ret.substr(begin, ret.size() - begin - 1);
-    #endif // Compiler
-    }
+template <typename T>
+String toString() {
+#if DOCTEST_CLANG == 0 && DOCTEST_GCC == 0 && DOCTEST_ICC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif // Compiler
+}
 
-    template <typename T, typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        return StringMaker<T>::convert(value);
-    }
+template <
+    typename T,
+    typename detail::types::enable_if<!detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    return StringMaker<T>::convert(value);
+}
 
-    inline String&& toString(String&& in) { return static_cast<String&&>(in); }
+inline String &&toString(String &&in) {
+    return static_cast<String &&>(in);
+}
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE String toString(const char* in);
+DOCTEST_INTERFACE String toString(const char *in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-    // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
-    DOCTEST_INTERFACE String toString(const std::string& in);
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string &in);
 #endif // VS 2019
 
-    DOCTEST_INTERFACE String toString(const String& in);
+DOCTEST_INTERFACE String toString(const String &in);
 
-    DOCTEST_INTERFACE String toString(std::nullptr_t);
+DOCTEST_INTERFACE String toString(std::nullptr_t);
 
-    DOCTEST_INTERFACE String toString(bool in);
+DOCTEST_INTERFACE String toString(bool in);
 
-    DOCTEST_INTERFACE String toString(float in);
-    DOCTEST_INTERFACE String toString(double in);
-    DOCTEST_INTERFACE String toString(double long in);
+DOCTEST_INTERFACE String toString(float in);
+DOCTEST_INTERFACE String toString(double in);
+DOCTEST_INTERFACE String toString(double long in);
 
-    DOCTEST_INTERFACE String toString(char in);
-    DOCTEST_INTERFACE String toString(char signed in);
-    DOCTEST_INTERFACE String toString(char unsigned in);
-    DOCTEST_INTERFACE String toString(short in);
-    DOCTEST_INTERFACE String toString(short unsigned in);
-    DOCTEST_INTERFACE String toString(signed in);
-    DOCTEST_INTERFACE String toString(unsigned in);
-    DOCTEST_INTERFACE String toString(long in);
-    DOCTEST_INTERFACE String toString(long unsigned in);
-    DOCTEST_INTERFACE String toString(long long in);
-    DOCTEST_INTERFACE String toString(long long unsigned in);
+DOCTEST_INTERFACE String toString(char in);
+DOCTEST_INTERFACE String toString(char signed in);
+DOCTEST_INTERFACE String toString(char unsigned in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-    template <typename T, typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
-    String toString(const DOCTEST_REF_WRAP(T) value) {
-        using UT = typename detail::types::underlying_type<T>::type;
-        return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
-    }
+template <
+    typename T,
+    typename detail::types::enable_if<detail::should_stringify_as_underlying_type<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
 namespace detail {
-    template <typename T>
-    struct filldata
-    {
-        static void fill(std::ostream* stream, const T& in) {
-    #if defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename T>
+struct filldata {
+    static void fill(std::ostream *stream, const T &in) {
+#if defined(_MSC_VER) && _MSC_VER <= 1900
         insert_hack_t<T>::insert(*stream, in);
-    #else
+#else
         operator<<(*stream, in);
-    #endif // _MSV_VER
-        }
-    };
+#endif // _MSV_VER
+    }
+};
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
-    // NOLINTBEGIN(*-avoid-c-arrays)
-    template <typename T, size_t N>
-    struct filldata<T[N]> {
-        static void fill(std::ostream* stream, const T(&in)[N]) {
-            *stream << "[";
-            for (size_t i = 0; i < N; i++) {
-                if (i != 0) { *stream << ", "; }
-                *stream << (DOCTEST_STRINGIFY(in[i]));
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <typename T, size_t N>
+struct filldata<T[N]> {
+    static void fill(std::ostream *stream, const T (&in)[N]) {
+        *stream << "[";
+        for (size_t i = 0; i < N; i++) {
+            if (i != 0) {
+                *stream << ", ";
             }
-            *stream << "]";
+            *stream << (DOCTEST_STRINGIFY(in[i]));
         }
-    };
-    // NOLINTEND(*-avoid-c-arrays)
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+        *stream << "]";
+    }
+};
+// NOLINTEND(*-avoid-c-arrays)
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    // Specialized since we don't want the terminating null byte!
-    // NOLINTBEGIN(*-avoid-c-arrays)
-    template <size_t N>
-    struct filldata<const char[N]> {
-        static void fill(std::ostream* stream, const char (&in)[N]) {
-            *stream << String(in, in[N - 1] ? N : N - 1);
-        } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-    };
-    // NOLINTEND(*-avoid-c-arrays)
+// Specialized since we don't want the terminating null byte!
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <size_t N>
+struct filldata<const char[N]> {
+    static void fill(std::ostream *stream, const char (&in)[N]) {
+        *stream << String(in, in[N - 1] ? N : N - 1);
+    } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+};
+// NOLINTEND(*-avoid-c-arrays)
 
-    template <>
-    struct filldata<const void*> {
-        DOCTEST_INTERFACE static void fill(std::ostream* stream, const void* in);
-    };
+template <>
+struct filldata<const void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const void *in);
+};
 
-    template <>
-    struct filldata<const volatile void*> {
-        DOCTEST_INTERFACE static void fill(std::ostream* stream, const volatile void* in);
-    };
+template <>
+struct filldata<const volatile void *> {
+    DOCTEST_INTERFACE static void fill(std::ostream *stream, const volatile void *in);
+};
 
-    template <typename T>
-    struct filldata<T*> {
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
-        static void fill(std::ostream* stream, const T* in) {
+template <typename T>
+struct filldata<T *> {
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4180)
+    static void fill(std::ostream *stream, const T *in) {
         DOCTEST_MSVC_SUPPRESS_WARNING_POP
         DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmicrosoft-cast")
-            filldata<const volatile void*>::fill(stream,
-        #if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
-                reinterpret_cast<const volatile void*>(in)
-        #else
-                *reinterpret_cast<const volatile void* const*>(&in)
-        #endif // DOCTEST_GCC
-            );
+        filldata<const volatile void *>::fill(
+            stream,
+#if DOCTEST_GCC == 0 || DOCTEST_GCC >= DOCTEST_COMPILER(4, 9, 0)
+            reinterpret_cast<const volatile void *>(in)
+#else
+            *reinterpret_cast<const volatile void *const *>(&in)
+#endif // DOCTEST_GCC
+        );
         DOCTEST_CLANG_SUPPRESS_WARNING_POP
-        }
-    };
-
-    #ifndef DOCTEST_CONFIG_DISABLE
-    template <typename L, typename R>
-    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
-                               const DOCTEST_REF_WRAP(R) rhs) {
-        return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
     }
-    #endif // DOCTEST_CONFIG_DISABLE
-} //namespace detail
+};
+
+#ifndef DOCTEST_CONFIG_DISABLE
+template <typename L, typename R>
+String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char *op, const DOCTEST_REF_WRAP(R) rhs) {
+    return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
+}
+#endif // DOCTEST_CONFIG_DISABLE
+} // namespace detail
 
 } // namespace doctest
 

--- a/doctest/parts/public/subcase.h
+++ b/doctest/parts/public/subcase.h
@@ -7,34 +7,32 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-struct DOCTEST_INTERFACE SubcaseSignature
-{
-    String      m_name;
-    const char* m_file;
-    int         m_line;
+struct DOCTEST_INTERFACE SubcaseSignature {
+    String m_name;
+    const char *m_file;
+    int m_line;
 
-    bool operator==(const SubcaseSignature& other) const;
-    bool operator<(const SubcaseSignature& other) const;
+    bool operator==(const SubcaseSignature &other) const;
+    bool operator<(const SubcaseSignature &other) const;
 };
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
-struct DOCTEST_INTERFACE Subcase
-{
+struct DOCTEST_INTERFACE Subcase {
     SubcaseSignature m_signature;
-    bool             m_entered = false;
+    bool m_entered = false;
 
-    Subcase(const String& name, const char* file, int line);
-    Subcase(const Subcase&) = delete;
-    Subcase(Subcase&&) = delete;
-    Subcase& operator=(const Subcase&) = delete;
-    Subcase& operator=(Subcase&&) = delete;
+    Subcase(const String &name, const char *file, int line);
+    Subcase(const Subcase &) = delete;
+    Subcase(Subcase &&) = delete;
+    Subcase &operator=(const Subcase &) = delete;
+    Subcase &operator=(Subcase &&) = delete;
     ~Subcase();
 
     operator bool() const;
 
-    private:
-        bool checkFilters();
+private:
+    bool checkFilters();
 };
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/test_case.h
+++ b/doctest/parts/public/test_case.h
@@ -8,62 +8,67 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
 namespace doctest {
 
-    struct DOCTEST_INTERFACE TestCaseData
-    {
-        String      m_file;       // the file in which the test was registered (using String - see #350)
-        unsigned    m_line;       // the line where the test was registered
-        const char* m_name;       // name of the test case
-        const char* m_test_suite; // the test suite in which the test was added
-        const char* m_description;
-        bool        m_skip;
-        bool        m_no_breaks;
-        bool        m_no_output;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
-    };
+struct DOCTEST_INTERFACE TestCaseData {
+    String m_file;            // the file in which the test was registered (using String - see #350)
+    unsigned m_line;          // the line where the test was registered
+    const char *m_name;       // name of the test case
+    const char *m_test_suite; // the test suite in which the test was added
+    const char *m_description;
+    bool m_skip;
+    bool m_no_breaks;
+    bool m_no_output;
+    bool m_may_fail;
+    bool m_should_fail;
+    int m_expected_failures;
+    double m_timeout;
+};
 
 #ifndef DOCTEST_CONFIG_DISABLE
 namespace detail {
 
-    using funcType = void (*)();
+using funcType = void (*)();
 
-    struct DOCTEST_INTERFACE TestCase : public TestCaseData
-    {
-        funcType m_test; // a function pointer to the test case
+struct DOCTEST_INTERFACE TestCase : public TestCaseData {
+    funcType m_test; // a function pointer to the test case
 
-        String m_type; // for templated test cases - gets appended to the real name
-        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
-        String m_full_name; // contains the name (only for templated test cases!) + the template type
+    String m_type;      // for templated test cases - gets appended to the real name
+    int m_template_id;  // an ID used to distinguish between the different versions of a templated
+                        // test case
+    String m_full_name; // contains the name (only for templated test cases!) + the template type
 
-        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                  const String& type = String(), int template_id = -1);
+    TestCase(
+        funcType test,
+        const char *file,
+        unsigned line,
+        const TestSuite &test_suite,
+        const String &type = String(),
+        int template_id = -1
+    );
 
-        TestCase(const TestCase& other);
-        TestCase(TestCase&&) = delete;
+    TestCase(const TestCase &other);
+    TestCase(TestCase &&) = delete;
 
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-        TestCase& operator=(const TestCase& other);
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+    TestCase &operator=(const TestCase &other);
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        TestCase& operator=(TestCase&&) = delete;
+    TestCase &operator=(TestCase &&) = delete;
 
-        TestCase& operator*(const char* in);
+    TestCase &operator*(const char *in);
 
-        template <typename T>
-        TestCase& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
+    template <typename T>
+    TestCase &operator*(const T &in) {
+        in.fill(*this);
+        return *this;
+    }
 
-        bool operator<(const TestCase& other) const;
+    bool operator<(const TestCase &other) const;
 
-        ~TestCase() = default;
-    };
+    ~TestCase() = default;
+};
 
-    // forward declarations of functions used by the macros
-    DOCTEST_INTERFACE int regTest(const TestCase& tc);
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int regTest(const TestCase &tc);
 
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE

--- a/doctest/parts/public/test_suite.h
+++ b/doctest/parts/public/test_suite.h
@@ -10,29 +10,28 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 namespace doctest {
 namespace detail {
 
-struct DOCTEST_INTERFACE TestSuite
-{
-    const char* m_test_suite = nullptr;
-    const char* m_description = nullptr;
-    bool        m_skip = false;
-    bool        m_no_breaks = false;
-    bool        m_no_output = false;
-    bool        m_may_fail = false;
-    bool        m_should_fail = false;
-    int         m_expected_failures = 0;
-    double      m_timeout = 0;
+struct DOCTEST_INTERFACE TestSuite {
+    const char *m_test_suite = nullptr;
+    const char *m_description = nullptr;
+    bool m_skip = false;
+    bool m_no_breaks = false;
+    bool m_no_output = false;
+    bool m_may_fail = false;
+    bool m_should_fail = false;
+    int m_expected_failures = 0;
+    double m_timeout = 0;
 
-    TestSuite& operator*(const char* in);
+    TestSuite &operator*(const char *in);
 
     template <typename T>
-    TestSuite& operator*(const T& in) {
+    TestSuite &operator*(const T &in) {
         in.fill(*this);
         return *this;
     }
 };
 
 // forward declarations of functions used by the macros
-DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
+DOCTEST_INTERFACE int setTestSuite(const TestSuite &ts);
 
 } // namespace detail
 
@@ -41,12 +40,12 @@ DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
 // in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
 namespace doctest_detail_test_suite_ns {
-DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
+DOCTEST_INTERFACE doctest::detail::TestSuite &getCurrentTestSuite();
 
 // this is here to clear the 'current test suite' for the current translation unit - at the top
-DOCTEST_GLOBAL_NO_WARNINGS( /* NOLINT(cert-err58-cpp) */
-    DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),
-    doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")
+DOCTEST_GLOBAL_NO_WARNINGS(/* NOLINT(cert-err58-cpp) */
+                           DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),
+                           doctest::detail::setTestSuite(doctest::detail::TestSuite() * "")
 )
 
 } // namespace doctest_detail_test_suite_ns

--- a/doctest/parts/public/utility.h
+++ b/doctest/parts/public/utility.h
@@ -5,16 +5,15 @@
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 
-#define DOCTEST_DECLARE_INTERFACE(name)                                                            \
-    virtual ~name();                                                                               \
-    name() = default;                                                                              \
-    name(const name&) = delete;                                                                    \
-    name(name&&) = delete;                                                                         \
-    name& operator=(const name&) = delete;                                                         \
-    name& operator=(name&&) = delete;
+#define DOCTEST_DECLARE_INTERFACE(name)                                                                                \
+    virtual ~name();                                                                                                   \
+    name() = default;                                                                                                  \
+    name(const name &) = delete;                                                                                       \
+    name(name &&) = delete;                                                                                            \
+    name &operator=(const name &) = delete;                                                                            \
+    name &operator=(name &&) = delete;
 
-#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
-    name::~name() = default;
+#define DOCTEST_DEFINE_INTERFACE(name) name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -26,20 +25,24 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH
 #endif // __COUNTER__
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
-#define DOCTEST_REF_WRAP(x) x&
+#define DOCTEST_REF_WRAP(x) x &
 #else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x
 #endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 
-namespace doctest { namespace detail {
+namespace doctest {
+namespace detail {
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-function")
-    static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
+static DOCTEST_CONSTEXPR int consume(const int *, int) noexcept {
+    return 0;
+}
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
-}}
+} // namespace detail
+} // namespace doctest
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
-    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                                  \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                                                \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP

--- a/doctest/parts/public/version.h
+++ b/doctest/parts/public/version.h
@@ -14,12 +14,13 @@
 #define DOCTEST_TOSTR_IMPL(x) #x
 #define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
 
-#define DOCTEST_VERSION_STR                                                                        \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
-    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
+// clang-format off
+#define DOCTEST_VERSION_STR                                                                                            \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                                           \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                                           \
     DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
+// clang-format on
 
-#define DOCTEST_VERSION                                                                            \
-    (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
 
 #endif // DOCTEST_PARTS_PUBLIC_VERSION

--- a/doctest/parts/public/warnings.h
+++ b/doctest/parts/public/warnings.h
@@ -13,7 +13,7 @@
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
 #define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
 #define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                \
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                                    \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
 #else // DOCTEST_CLANG
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
@@ -27,8 +27,7 @@
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
 #define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
 #define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
 #else // DOCTEST_GCC
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_GCC_SUPPRESS_WARNING(w)
@@ -40,8 +39,7 @@
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
 #define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)                                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
 #else // DOCTEST_MSVC
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w)
@@ -55,139 +53,139 @@
 
 // both the header and the implementation suppress all of these,
 // so it only makes sense to aggregate them like so
-#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                        \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")                                              \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                      \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                       \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                         \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                 \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                     \
-                                                                                                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    /* these 4 also disabled globally via cmake: */                                                \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */        \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                \
-    /* common ones */                                                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */        \
-    /* static analysis */                                                                          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */       \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-warning-option")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                                             \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunsafe-buffer-usage")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-macros")                                                                  \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                                          \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                                     \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                                         \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    /* these 4 also disabled globally via cmake: */                                                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                                    \
+    /* common ones */                                                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
+    /* static analysis */                                                                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
 
-#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \
-    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                               \
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                                           \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                                                   \
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH                                                      \
-    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                          \
-                                                                                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")                                                 \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")                                            \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                             \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")                                                   \
-                                                                                                   \
+#define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_PUSH                                                                          \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")                                                                     \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")                                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")                                                                       \
+                                                                                                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */
 
 #define DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
-#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH                                                     \
-    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                          \
-                                                                                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")                                        \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")                                      \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")                              \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")                                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")                                                \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")                                           \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")                                   \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")                                             \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                 \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                     \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-function")                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                       \
-                                                                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")                                   \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")                                                       \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")                                    \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")                                               \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                              \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                         \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                            \
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                         \
-                                                                                                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4577) /* 'noexcept' with no exception handling mode specified */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string in argument is not a string literal */    \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4800) /* forcing value to bool (performance warning) */          \
+#define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH                                                                         \
+    DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                                              \
+                                                                                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")                                                          \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")                                                  \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")                                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")                                                                    \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")                                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")                                                                 \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                     \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-function")                                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")                                                \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wnrvo")                                                                           \
+                                                                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")                                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")                                                                           \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")                                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")                                                        \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")                                                                  \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")                                                                \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnrvo")                                                                             \
+                                                                                                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4267) /* conversion from 'x' to 'y', possible loss of data */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4530) /* exception handler, but unwind semantics not enabled */                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4577) /* 'noexcept' with no exception handling mode specified */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string in argument is not a string literal */                        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4800) /* forcing value to bool (performance warning) */                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(5245) /* unreferenced function with internal linkage removed */
 
 #define DOCTEST_SUPPRESS_PRIVATE_WARNINGS_POP DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
-#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */       \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */     \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */      \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                  \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */           \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */     \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */  \
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */                           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                                    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                                      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */                                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */                     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */                         \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5262) /* implicit fall-through */
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP


### PR DESCRIPTION
- Related: #1005 

## Description
Applies the discussed direction from the above PR to `.clang-tidy`, granting us an LLVM baseline. Adjustments were made to represent the de-facto state of the repository, so not all rules were transfered over if their implementation was rare or incorrect. Keeping as a draft so that certain revealed elements can be further discussed and potentially adjusted/removed as necessary:
- Only formatter used atm is `clang-tidy`, meaning a lot of vestigal code coverage checkers remain (lgtm, OCLINT, etc). While not outright inhibiting, they *are* revealing their clutter more than ever
- Do we want to continue enforcing a 100-width limit? The majority of clang-format ignores that existed (now removed) were because this limit was constantly breached by macros. We can continue to selectively ignore if desired, or set the limit to `0` to drop the hardcap entirely

Almost every file is being changed anyway, so we aren't beholden to existing formatting styles in the first place. Though it'd obviously be preferable to have whatever noise *is* caused by this to only happen once, so we should wholly agree on the direction taken early