### PR TITLE
chore: Add basic project unit-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ if(MAIN_PROJECT AND DOCTEST_WITH_TESTS)
     add_subdirectory(examples/combining_the_same_tests_built_differently_in_multiple_shared_objects)
     add_subdirectory(scripts/playground)
     add_subdirectory(examples/mpi)
+    add_subdirectory(tests)
 endif()
 
 set(DOCTEST_CMAKE_HELPER "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/doctest.cmake" CACHE PATH "Absolute path to to doctest helper file. `include(${DOCTEST_CMAKE_HELPER})`")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(unit_test_sources
+    doctest/assert/test_expression.cpp
+    doctest/assert/test_message.cpp
+    doctest/assert/test_type.cpp
+    doctest/matchers/test_approx.cpp
+    doctest/matchers/test_contains.cpp
+    doctest/matchers/test_is_nan.cpp
+    doctest/test_exception_translator.cpp
+    doctest/test_path.cpp
+    doctest/test_string.cpp)
+
+# doctest_with_main currently has multiple definitions of various symbols
+# due to them being implemented inline. Once this is resolved, we can drop
+# main.cpp and just use doctest_with_main instead
+add_executable(unit_tests ${unit_test_sources} main.cpp)
+target_link_libraries(unit_tests doctest)
+
+# For unit-tests, we don't want to enforce the same level of warning-correctness
+# as with our examples. So, we inhibit some extras here
+macro(add_compiler_flags)
+    foreach(flag ${ARGV})
+        target_compile_options(unit_tests PRIVATE ${flag})
+    endforeach()
+endmacro()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    add_compiler_flags(-Wno-address)
+    add_compiler_flags(-Wno-effc++)
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+        add_compiler_flags(-Wno-pessimizing-move)
+    endif()
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compiler_flags(-Wno-double-promotion)
+    add_compiler_flags(-Wno-exit-time-destructors)
+    add_compiler_flags(-Wno-global-constructors)
+    add_compiler_flags(-Wno-missing-variable-declarations)
+    add_compiler_flags(-Wno-padded)
+    add_compiler_flags(-Wno-pessimizing-move)
+endif()
+
+if(MSVC)
+    add_compiler_flags(/wd5263)
+endif()

--- a/tests/doctest/assert/test_expression.cpp
+++ b/tests/doctest/assert/test_expression.cpp
@@ -1,0 +1,182 @@
+#include <doctest/doctest.h>
+#include <utility>
+
+namespace {
+
+/**
+ * ExpressionDecomposer sucks to use in isolation.
+ * For now, we can use this macro to decompose an expression.
+ * Key precondition: the expression must resolve to a truthy value!
+ *
+ * Explanation of the macro body itself:
+ *  - We use CHECK_FALSE to ensure that Expression_lhs<T>::operator Result
+ *    sees a `false`, hence believes it needs to actually do decomposition,
+ *    Without this it just yields a blank string.
+ *  - We cast to `const Result &` because otherwise, we have an `Expression_lhs<T> &&`
+ *    which yields a `Result &&`, and this just breaks in fun ways
+ *  - We cast `.m_decomp` to `String` simply to ensure we get a copy of it, so we don't dangle
+ *
+ * In the future, we should just make the Expression API a little nicer to work with,
+ * so we can perform these checks a lot more easily.
+ */
+#define DECOMPOSE(...)                                                                          \
+  static_cast<doctest::String>(                                                                 \
+    static_cast<const doctest::detail::Result &>(                                               \
+      doctest::detail::ExpressionDecomposer(doctest::assertType::DT_CHECK_FALSE) << __VA_ARGS__ \
+    ).m_decomp                                                                                  \
+  )                                                                                             \
+
+} // namespace
+
+TEST_SUITE("Expression decomposition") {
+
+    // Collection of lvalues / basis for xvalues / prvalues
+    const auto _false  = false;
+    const auto _true   = true;
+    const auto _1      = int { 1 };
+    const auto _2      = int { 2 };
+    const auto _foo    = doctest::String("foo");
+    const auto _bar    = doctest::String("bar");
+    const auto _foobar = doctest::String("foobar");
+
+    const int *ptr      = &_1;
+    const int  array[2] = { 1, 2 };
+
+    struct { int value: 4; } bitfield = { 1 };
+
+    struct Object { int var = 1; void method() { } };
+    const auto member_var    = &Object::var;
+    const auto member_method = &Object::method;
+    const auto object        = Object();
+
+    enum         { X = 1, Y = 2 };
+    enum class C { X = 1, Y = 2 };
+
+    inline void function() { }
+
+    // Generate an xvalue from a prvalue
+    template <typename T>
+    T &&xvalue(T &&value) { return static_cast<T &&>(value); }
+
+
+    TEST_CASE("Unary decomposition") {
+        SUBCASE("boolean [lvalue]") {
+            CHECK(DECOMPOSE(_true) == "true");
+        }
+
+        SUBCASE("boolean [prvalue]") {
+            CHECK(DECOMPOSE(true) == "true");
+        }
+
+        SUBCASE("boolean [xvalue]") {
+            CHECK(DECOMPOSE(xvalue(true)) == "true");
+        }
+
+        SUBCASE("Array subscript [lvalue]") {
+            CHECK(DECOMPOSE(array[0]) == "1");
+        }
+
+        SUBCASE("Bitfield member [xvalue]") {
+            CHECK(DECOMPOSE(bitfield.value) == "1");
+        }
+
+        SUBCASE("Pointer-to-member [lvalue]") {
+            CHECK(DECOMPOSE(member_var)    == "{?}");
+            CHECK(DECOMPOSE(member_method) == "{?}");
+        }
+
+        SUBCASE("Pointer-to-member [prvalue]") {
+            CHECK(DECOMPOSE(&Object::var)    == "{?}");
+            CHECK(DECOMPOSE(&Object::method) == "{?}");
+        }
+
+        SUBCASE("Resolved pointer-to-member [lvalue]") {
+            CHECK(DECOMPOSE(object.*member_var) == "1");
+        }
+
+        SUBCASE("Unscoped enumerator [prvalue]") {
+            CHECK(DECOMPOSE(X) == "1");
+        }
+
+        SUBCASE("Scoped enumerator [prvalue]") {
+            CHECK(DECOMPOSE(C::X) == "1");
+        }
+
+        SUBCASE("Function [lvalue]") {
+            CHECK(DECOMPOSE(function) == "{?}");
+        }
+    }
+
+    TEST_CASE("Binary decomposition") {
+        // For a few of these checks, we don't actually have stringification available
+        // As a result, a few checks will resolve to {?} == {?} or similar
+        // This is fine, since we really just want to make sure that the decomposition
+        // is able to accept these values; the stringification is another module's problem.
+
+        SUBCASE("boolean [lvalue]") {
+            CHECK(DECOMPOSE(_true == _true)  == "true == true");
+            CHECK(DECOMPOSE(_true != _false) == "true != false");
+        }
+
+        SUBCASE("boolean [prvalue]") {
+            CHECK(DECOMPOSE(true == true)  == "true == true");
+            CHECK(DECOMPOSE(true != false) == "true != false");
+        }
+
+        SUBCASE("boolean [xvalue]") {
+            CHECK(DECOMPOSE(xvalue(true) == xvalue(true))  == "true == true");
+            CHECK(DECOMPOSE(xvalue(true) != xvalue(false)) == "true != false");
+        }
+
+        SUBCASE("integer [lvalue]") {
+            CHECK(DECOMPOSE(_1 == _1) == "1 == 1");
+            CHECK(DECOMPOSE(_1 != _2) == "1 != 2");
+            CHECK(DECOMPOSE(_1 <  _2) == "1 <  2");
+            CHECK(DECOMPOSE(_2 >  _1) == "2 >  1");
+            CHECK(DECOMPOSE(_1 <= _2) == "1 <= 2");
+            CHECK(DECOMPOSE(_2 >= _1) == "2 >= 1");
+        }
+
+        SUBCASE("String [prvalue]") {
+            CHECK(DECOMPOSE(_foo + _bar == _foobar) == "foobar == foobar");
+        }
+
+        SUBCASE("Pointer dereference [lvalue]") {
+            CHECK(DECOMPOSE(*ptr == _1) == "1 == 1");
+        }
+
+        SUBCASE("Array subscript [lvalue]") {
+            CHECK(DECOMPOSE(array[0] != array[1]) == "1 != 2");
+        }
+
+        SUBCASE("Bitfield member [xvalue]") {
+            CHECK(DECOMPOSE(bitfield.value == _1) == "1 == 1");
+        }
+
+        SUBCASE("Pointer-to-member [lvalue]") {
+            CHECK(DECOMPOSE(member_var    == member_var)    == "{?} == {?}");
+            CHECK(DECOMPOSE(member_method == member_method) == "{?} == {?}");
+        }
+
+        SUBCASE("Pointer-to-member [prvalue]") {
+            CHECK(DECOMPOSE(&Object::var    == &Object::var)    == "{?} == {?}");
+            CHECK(DECOMPOSE(&Object::method == &Object::method) == "{?} == {?}");
+        }
+
+        SUBCASE("Resolved pointer-to-member [lvalue]") {
+            CHECK(DECOMPOSE(object.*member_var == _1) == "1 == 1");
+        }
+
+        SUBCASE("Unscoped enumerator [prvalue]") {
+            CHECK(DECOMPOSE(X != Y) == "1 != 2");
+        }
+
+        SUBCASE("Scoped enumerator [prvalue]") {
+            CHECK(DECOMPOSE(C::X != C::Y) == "1 != 2");
+        }
+
+        SUBCASE("Function [lvalue]") {
+            CHECK(DECOMPOSE(function == function) == "{?} == {?}");
+        }
+    }
+}

--- a/tests/doctest/assert/test_message.cpp
+++ b/tests/doctest/assert/test_message.cpp
@@ -1,0 +1,21 @@
+#include <doctest/doctest.h>
+#include <cstdint>
+
+TEST_CASE("Building messages") {
+    doctest::detail::MessageBuilder mb("file.c", 123, doctest::assertType::DT_CHECK);
+
+    const auto lhs = uint32_t { 42 };
+    const auto rhs = uint32_t { 24 };
+    mb * "ERROR: ", lhs, " == ", rhs, " was FALSE";
+
+    // String is generated as part of MessageBuilder::log,
+    // but calling this interacts with the overall test
+    // So, below is the relevant part of ::log that generates the string
+    mb.logged = true;
+    mb.m_string = doctest::detail::tlssPop();
+
+    CHECK(mb.m_string   == "ERROR: 42 == 24 was FALSE");
+    CHECK(mb.m_file     == "file.c");
+    CHECK(mb.m_line     == 123);
+    CHECK(mb.m_severity == doctest::assertType::DT_CHECK);
+}

--- a/tests/doctest/assert/test_type.cpp
+++ b/tests/doctest/assert/test_type.cpp
@@ -1,0 +1,130 @@
+#define DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#include <doctest/doctest.h>
+
+TEST_CASE("Assertion stringification") {
+    using namespace doctest;
+
+    CHECK(assertString(assertType::DT_WARN) == "WARN");
+    CHECK(assertString(assertType::DT_CHECK) == "CHECK");
+    CHECK(assertString(assertType::DT_REQUIRE) == "REQUIRE");
+
+    CHECK(assertString(assertType::DT_WARN_FALSE) == "WARN_FALSE");
+    CHECK(assertString(assertType::DT_CHECK_FALSE) == "CHECK_FALSE");
+    CHECK(assertString(assertType::DT_REQUIRE_FALSE) == "REQUIRE_FALSE");
+
+    CHECK(assertString(assertType::DT_WARN_THROWS) == "WARN_THROWS");
+    CHECK(assertString(assertType::DT_CHECK_THROWS) == "CHECK_THROWS");
+    CHECK(assertString(assertType::DT_REQUIRE_THROWS) == "REQUIRE_THROWS");
+
+    CHECK(assertString(assertType::DT_WARN_THROWS_AS) == "WARN_THROWS_AS");
+    CHECK(assertString(assertType::DT_CHECK_THROWS_AS) == "CHECK_THROWS_AS");
+    CHECK(assertString(assertType::DT_REQUIRE_THROWS_AS) == "REQUIRE_THROWS_AS");
+
+    CHECK(assertString(assertType::DT_WARN_THROWS_WITH) == "WARN_THROWS_WITH");
+    CHECK(assertString(assertType::DT_CHECK_THROWS_WITH) == "CHECK_THROWS_WITH");
+    CHECK(assertString(assertType::DT_REQUIRE_THROWS_WITH) == "REQUIRE_THROWS_WITH");
+
+    CHECK(assertString(assertType::DT_WARN_THROWS_WITH_AS) == "WARN_THROWS_WITH_AS");
+    CHECK(assertString(assertType::DT_CHECK_THROWS_WITH_AS) == "CHECK_THROWS_WITH_AS");
+    CHECK(assertString(assertType::DT_REQUIRE_THROWS_WITH_AS) == "REQUIRE_THROWS_WITH_AS");
+
+    CHECK(assertString(assertType::DT_WARN_NOTHROW) == "WARN_NOTHROW");
+    CHECK(assertString(assertType::DT_CHECK_NOTHROW) == "CHECK_NOTHROW");
+    CHECK(assertString(assertType::DT_REQUIRE_NOTHROW) == "REQUIRE_NOTHROW");
+
+    CHECK(assertString(assertType::DT_WARN_EQ) == "WARN_EQ");
+    CHECK(assertString(assertType::DT_CHECK_EQ) == "CHECK_EQ");
+    CHECK(assertString(assertType::DT_REQUIRE_EQ) == "REQUIRE_EQ");
+
+    CHECK(assertString(assertType::DT_WARN_NE) == "WARN_NE");
+    CHECK(assertString(assertType::DT_CHECK_NE) == "CHECK_NE");
+    CHECK(assertString(assertType::DT_REQUIRE_NE) == "REQUIRE_NE");
+
+    CHECK(assertString(assertType::DT_WARN_GT) == "WARN_GT");
+    CHECK(assertString(assertType::DT_CHECK_GT) == "CHECK_GT");
+    CHECK(assertString(assertType::DT_REQUIRE_GT) == "REQUIRE_GT");
+
+    CHECK(assertString(assertType::DT_WARN_LT) == "WARN_LT");
+    CHECK(assertString(assertType::DT_CHECK_LT) == "CHECK_LT");
+    CHECK(assertString(assertType::DT_REQUIRE_LT) == "REQUIRE_LT");
+
+    CHECK(assertString(assertType::DT_WARN_GE) == "WARN_GE");
+    CHECK(assertString(assertType::DT_CHECK_GE) == "CHECK_GE");
+    CHECK(assertString(assertType::DT_REQUIRE_GE) == "REQUIRE_GE");
+
+    CHECK(assertString(assertType::DT_WARN_LE) == "WARN_LE");
+    CHECK(assertString(assertType::DT_CHECK_LE) == "CHECK_LE");
+    CHECK(assertString(assertType::DT_REQUIRE_LE) == "REQUIRE_LE");
+
+    CHECK(assertString(assertType::DT_WARN_UNARY) == "WARN_UNARY");
+    CHECK(assertString(assertType::DT_CHECK_UNARY) == "CHECK_UNARY");
+    CHECK(assertString(assertType::DT_REQUIRE_UNARY) == "REQUIRE_UNARY");
+
+    CHECK(assertString(assertType::DT_WARN_UNARY_FALSE) == "WARN_UNARY_FALSE");
+    CHECK(assertString(assertType::DT_CHECK_UNARY_FALSE) == "CHECK_UNARY_FALSE");
+    CHECK(assertString(assertType::DT_REQUIRE_UNARY_FALSE) == "REQUIRE_UNARY_FALSE");
+}
+
+TEST_CASE("Failure stringification") {
+    using namespace doctest;
+
+    CHECK(failureString(assertType::DT_WARN) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_FALSE) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_FALSE) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_FALSE) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_THROWS) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_THROWS) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_THROWS) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_THROWS_AS) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_THROWS_AS) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_THROWS_AS) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_THROWS_WITH) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_THROWS_WITH) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_THROWS_WITH) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_THROWS_WITH_AS) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_THROWS_WITH_AS) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_THROWS_WITH_AS) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_NOTHROW) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_NOTHROW) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_NOTHROW) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_EQ) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_EQ) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_EQ) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_NE) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_NE) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_NE) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_GT) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_GT) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_GT) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_LT) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_LT) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_LT) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_GE) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_GE) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_GE) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_LE) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_LE) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_LE) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_UNARY) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_UNARY) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_UNARY) == "FATAL ERROR");
+
+    CHECK(failureString(assertType::DT_WARN_UNARY_FALSE) == "WARNING");
+    CHECK(failureString(assertType::DT_CHECK_UNARY_FALSE) == "ERROR");
+    CHECK(failureString(assertType::DT_REQUIRE_UNARY_FALSE) == "FATAL ERROR");
+}

--- a/tests/doctest/matchers/test_approx.cpp
+++ b/tests/doctest/matchers/test_approx.cpp
@@ -1,0 +1,318 @@
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <tuple>
+using doctest::Approx;
+
+namespace {
+/** Represents a closed-interval of real values */
+struct bounds {
+    double min, max;
+
+    static bounds determine(const Approx &m) {
+        // For the current implementation of Approx::operator==
+        //    |x - C| < Ɛ(s + max(|x|, |C|))
+        // ...we can derive a closed-form solution for the lower and upper bound by case-analysis
+        // This isn't included as it's relatively easily reproducible
+        const auto e = m.m_epsilon;
+        const auto s = m.m_scale;
+        const auto C = m.m_value;
+
+        if (std::isinf(C)) { return { C, C }; }
+        const auto min = std::min((C - e*s) / (1 - e), C - e*(s + std::abs(C)));
+        const auto max = std::max((C + e*s) / (1 - e), C + e*(s + std::abs(C)));
+        return { min, max };
+    }
+};
+
+doctest::String toString(bounds b) {
+    return "{ .min = " + doctest::toString(b.min) + ", .max = " + doctest::toString(b.max) + " }";
+}
+} // namespace
+
+TEST_CASE_TEMPLATE("Construction with non-double values", T, float, double, long double) {
+    const auto m = Approx(T(1)).epsilon(T(2)).scale(T(3));
+
+    CHECK(m.m_value   == Approx(1.0));
+    CHECK(m.m_epsilon == Approx(2.0));
+    CHECK(m.m_scale   == Approx(3.0));
+}
+
+TEST_CASE_TEMPLATE("Verification of relational operators", T, float, double, long double) {
+    const auto m = Approx(100.0).epsilon(0.01).scale(3);
+    CAPTURE(bounds::determine(m)); // [98.97, 101.04]
+
+    const auto too_small = T( 98.96); // Would be 98.97, but float loses too much precision
+    const auto     small = T( 98.98);
+    const auto    center = T(100.00);
+    const auto     large = T(101.04);
+    const auto too_large = T(101.05);
+
+    SUBCASE("operator==") {
+        CHECK_FALSE(too_small == m);
+        CHECK      (small     == m);
+        CHECK      (center    == m);
+        CHECK      (large     == m);
+        CHECK_FALSE(too_large == m);
+
+        CHECK_FALSE(m == too_small);
+        CHECK      (m == small);
+        CHECK      (m == center);
+        CHECK      (m == large);
+        CHECK_FALSE(m == too_large);
+    }
+
+    SUBCASE("operator!=") {
+        CHECK      (too_small != m);
+        CHECK_FALSE(small     != m);
+        CHECK_FALSE(center    != m);
+        CHECK_FALSE(large     != m);
+        CHECK      (too_large != m);
+
+        CHECK      (m != too_small);
+        CHECK_FALSE(m != small);
+        CHECK_FALSE(m != center);
+        CHECK_FALSE(m != large);
+        CHECK      (m != too_large);
+    }
+
+    SUBCASE("operator<") {
+        CHECK      (too_small < m);
+        CHECK_FALSE(small     < m);
+        CHECK_FALSE(center    < m);
+        CHECK_FALSE(large     < m);
+        CHECK_FALSE(too_large < m);
+
+        CHECK_FALSE(m < too_small);
+        CHECK_FALSE(m < small);
+        CHECK_FALSE(m < center);
+        CHECK_FALSE(m < large);
+        CHECK      (m < too_large);
+    }
+
+    SUBCASE("operator<=") {
+        CHECK      (too_small <= m);
+        CHECK      (    small <= m);
+        CHECK      (   center <= m);
+        CHECK      (   large  <= m);
+        CHECK_FALSE(too_large <= m);
+
+        CHECK_FALSE(m <= too_small);
+        CHECK      (m <= small);
+        CHECK      (m <= center);
+        CHECK      (m <= large);
+        CHECK      (m <= too_large);
+    }
+
+    SUBCASE("operator>") {
+        CHECK_FALSE(too_small > m);
+        CHECK_FALSE(small     > m);
+        CHECK_FALSE(center    > m);
+        CHECK_FALSE(large     > m);
+        CHECK      (too_large > m);
+
+        CHECK      (m > too_small);
+        CHECK_FALSE(m > small);
+        CHECK_FALSE(m > center);
+        CHECK_FALSE(m > large);
+        CHECK_FALSE(m > too_large);
+    }
+
+    SUBCASE("operator>=") {
+        CHECK_FALSE(too_small >= m);
+        CHECK      (small     >= m);
+        CHECK      (center    >= m);
+        CHECK      (large     >= m);
+        CHECK      (too_large >= m);
+
+        CHECK      (m >= too_small);
+        CHECK      (m >= small);
+        CHECK      (m >= center);
+        CHECK      (m >= large);
+        CHECK_FALSE(m >= too_large);
+    }
+}
+
+TEST_CASE("Comparison with finite floating-point values" * doctest::expected_failures(2)) {
+    const auto epsilon = std::numeric_limits<double>::epsilon();
+    const auto inf     = std::numeric_limits<double>::infinity();
+
+    SUBCASE("Matcher focused around 0") {
+        const auto m = Approx(0.0);
+        CAPTURE(bounds::determine(m)); // [-1.19211e-5, 1.19211e-5]
+
+        CHECK(-1.19211e-5 != m);
+        CHECK(-1.19210e-5 == m);
+        CHECK( 0.0        == m);
+        CHECK(+1.19210e-5 == m);
+        CHECK(+1.19211e-5 != m);
+    }
+
+    SUBCASE("Matcher focused around 0 with an error of 0% and no scaling") {
+        const auto m = Approx(0.0).epsilon(0.0).scale(0);
+        CAPTURE(bounds::determine(m)); // [0, 0]
+
+        CHECK(-epsilon != m);
+        CHECK( 0.0     == m); // FAIL
+        CHECK(+epsilon != m);
+    }
+
+    SUBCASE("Matcher focused around 0 with an error of 100% and no scaling") {
+        const auto m = Approx(0.0).epsilon(1.0).scale(0);
+        CAPTURE(bounds::determine(m)); // [-NaN, +NaN]
+
+        CHECK(-epsilon != m);
+        CHECK( 0.0     == m); // FAIL
+        CHECK(+epsilon != m);
+    }
+
+    SUBCASE("Matcher focused around smallest positive normalized value") {
+        const auto m = Approx(std::numeric_limits<double>::min());
+        CAPTURE(bounds::determine(m)); // [-1.19211e-5, 1.19211e-5]
+
+        CHECK(-1.19211e-5 != m);
+        CHECK(-1.19210e-5 == m);
+        CHECK( 0.0        == m);
+        CHECK(+1.19210e-5 == m);
+        CHECK(+1.19211e-5 != m);
+    }
+
+    SUBCASE("Matcher focused around maximum normalized value") {
+        const auto m = Approx(std::numeric_limits<double>::max());
+        CAPTURE(bounds::determine(m)); // [1.79767e308, inf]
+        CHECK(m != 1.79767e308);
+        CHECK(m == 1.79768e308);
+        CHECK(m != inf);
+    }
+
+    SUBCASE("Matcher focused around minimum normalized value") {
+        const auto m = Approx(std::numeric_limits<double>::lowest());
+        CAPTURE(bounds::determine(m)); // [-inf, -1.79767e308]
+
+        CHECK(m != -1.79767e308);
+        CHECK(m == -1.79768e308);
+        CHECK(m != -inf);
+    }
+
+    SUBCASE("Matcher focused around 10 with an error of 10% and no scaling") {
+        const auto m = Approx(10.0).epsilon(0.1).scale(0);
+        CAPTURE(bounds::determine(m)); // [9, 11.1111...]
+
+        CHECK( 9.000 != m);
+        CHECK( 9.001 == m);
+        CHECK(10.000 == m);
+        CHECK(11.111 == m);
+        CHECK(11.112 != m);
+    }
+
+    SUBCASE("Matcher focused around 25 with an error of 1% and no scaling") {
+        const auto m = Approx(25.0).epsilon(0.01).scale(0);
+        CAPTURE(bounds::determine(m)); // [24.7500, 25.2525]
+
+        CHECK(24.7500 != m);
+        CHECK(24.7501 == m);
+        CHECK(25.0000 == m);
+        CHECK(25.2525 == m);
+        CHECK(25.2526 != m);
+    }
+
+    SUBCASE("Matcher focused around 100 with an error of 100% and no scaling") {
+        const auto m = Approx(100.0).epsilon(1.0).scale(0);
+        CAPTURE(bounds::determine(m)); // [0, inf]
+
+        CHECK(0.0   != m);
+        CHECK(1e-15 != m);
+        CHECK(1e-14 == m);
+        CHECK(100.0 == m);
+        CHECK(1e+18 == m);
+        CHECK(1e+19 != m);
+    }
+
+    SUBCASE("Matcher focused around 75 with an error of 1% and a scale of 3") {
+        const auto m = Approx(75).epsilon(0.01).scale(3);
+        CAPTURE(bounds::determine(m)); // [74.2200, 75.7879]
+
+        CHECK(74.2200 != m);
+        CHECK(74.2201 == m);
+        CHECK(75.0000 == m);
+        CHECK(75.7878 == m);
+        CHECK(75.7879 != m);
+    }
+}
+
+TEST_CASE("Comparison with non-finite floating-point values") {
+    SUBCASE("Matcher focused around infinity") {
+        const auto inf = std::numeric_limits<float>::infinity();
+        const auto m   = Approx(inf);
+        CAPTURE(bounds::determine(m)); // [inf, inf]
+
+        CHECK_FALSE(inf == m);
+        CHECK      (inf != m);
+        CHECK_FALSE(inf <  m);
+        CHECK_FALSE(inf <= m);
+        CHECK_FALSE(inf >  m);
+        CHECK_FALSE(inf >= m);
+    }
+
+    SUBCASE("Matcher focused around negative-infinity") {
+        const auto inf = std::numeric_limits<float>::infinity();
+        const auto m   = Approx(-inf);
+        CAPTURE(bounds::determine(m)); // [-inf, -inf]
+
+        CHECK_FALSE(-inf == m);
+        CHECK      (-inf != m);
+        CHECK_FALSE(-inf <  m);
+        CHECK_FALSE(-inf <= m);
+        CHECK_FALSE(-inf >  m);
+        CHECK_FALSE(-inf >= m);
+     }
+
+    SUBCASE("Matcher focused around a quiet NaN") {
+        const auto qnan = std::numeric_limits<float>::quiet_NaN();
+        const auto m    = Approx(qnan);
+        CAPTURE(bounds::determine(m)); // [nan, nan]
+
+        CHECK_FALSE(qnan == m);
+        CHECK      (qnan != m);
+        CHECK_FALSE(qnan <  m);
+        CHECK_FALSE(qnan <= m);
+        CHECK_FALSE(qnan >  m);
+        CHECK_FALSE(qnan >= m);
+     }
+
+    SUBCASE("Matcher focused around a signalling NaN") {
+        const auto snan = std::numeric_limits<float>::signaling_NaN();
+        const auto m    = Approx(snan);
+        CAPTURE(bounds::determine(m)); // [nan, nan]
+
+        CHECK_FALSE(snan == m);
+        CHECK      (snan != m);
+        CHECK_FALSE(snan <  m);
+        CHECK_FALSE(snan <= m);
+        CHECK_FALSE(snan >  m);
+        CHECK_FALSE(snan >= m);
+     }
+}
+
+TEST_CASE("Stringification") {
+    SUBCASE("Matcher without epsilon or scale set") {
+        constexpr auto inf = std::numeric_limits<double>::infinity();
+        constexpr auto nan = std::numeric_limits<double>::signaling_NaN();
+
+        CHECK(doctest::toString(Approx( 0  )) == "Approx( 0 )");
+        CHECK(doctest::toString(Approx( 1  )) == "Approx( 1 )");
+        CHECK(doctest::toString(Approx( 1.5)) == "Approx( 1.5 )");
+        CHECK(doctest::toString(Approx(-1.5)) == "Approx( -1.5 )");
+        CHECK(doctest::toString(Approx( inf)) == "Approx( inf )");
+        CHECK(doctest::toString(Approx(-inf)) == "Approx( -inf )");
+        CHECK(doctest::toString(Approx( nan)) == "Approx( nan )");
+        CHECK(doctest::toString(Approx(-nan)) == "Approx( -nan )");
+    }
+
+    SUBCASE("Matcher with both epsilon and scale set") {
+        CHECK(doctest::toString(Approx(0).epsilon(1).scale(2)) == "Approx( 0 )");
+    }
+}

--- a/tests/doctest/matchers/test_contains.cpp
+++ b/tests/doctest/matchers/test_contains.cpp
@@ -1,0 +1,19 @@
+#include <doctest/doctest.h>
+using doctest::Contains;
+
+TEST_CASE("Stringification") {
+  CHECK(doctest::toString(Contains(""))        == "Contains(  )");
+  CHECK(doctest::toString(Contains("doctest")) == "Contains( doctest )");
+}
+
+TEST_CASE("Matching against string values") {
+  CHECK("" == doctest::Contains(""));
+  CHECK("" != doctest::Contains("doctest"));
+
+  CHECK("doctest" == doctest::Contains(""));
+  CHECK("doctest" == doctest::Contains("doc"));
+  CHECK("doctest" == doctest::Contains("test"));
+  CHECK("doctest" == doctest::Contains("doctest"));
+  CHECK("doctest" != doctest::Contains("dctst"));
+  CHECK("doctest" != doctest::Contains("DOCTEST"));
+}

--- a/tests/doctest/matchers/test_is_nan.cpp
+++ b/tests/doctest/matchers/test_is_nan.cpp
@@ -1,0 +1,75 @@
+#include <doctest/doctest.h>
+#include <limits>
+#include <random>
+using doctest::IsNaN;
+
+TEST_CASE_TEMPLATE("Stringification", F, float, double, long double) {
+    constexpr auto inf  = std::numeric_limits<F>::infinity();
+    constexpr auto qnan = std::numeric_limits<F>::quiet_NaN();
+    constexpr auto snan = std::numeric_limits<F>::signaling_NaN();
+
+    const auto flip = true;
+    CHECK(doctest::toString(IsNaN<F>(0)) == "IsNaN( 0 )");
+    CHECK(doctest::toString(IsNaN<F>(0, flip)) == "! IsNaN( 0 )");
+    CHECK(doctest::toString(IsNaN<F>(1.5)) == "IsNaN( 1.5 )");
+    CHECK(doctest::toString(IsNaN<F>(1.5, flip)) == "! IsNaN( 1.5 )");
+    CHECK(doctest::toString(IsNaN<F>(-1.5)) == "IsNaN( -1.5 )");
+    CHECK(doctest::toString(IsNaN<F>(-1.5, flip)) == "! IsNaN( -1.5 )");
+
+    CHECK(doctest::toString(IsNaN<F>(inf)) == "IsNaN( inf )");
+    CHECK(doctest::toString(IsNaN<F>(qnan)) == "IsNaN( nan )");
+    CHECK(doctest::toString(IsNaN<F>(snan)) == "IsNaN( nan )");
+    CHECK(doctest::toString(IsNaN<F>(-inf)) == "IsNaN( -inf )");
+    CHECK(doctest::toString(IsNaN<F>(-qnan)) == "IsNaN( -nan )");
+    CHECK(doctest::toString(IsNaN<F>(-snan)) == "IsNaN( -nan )");
+
+}
+
+TEST_CASE_TEMPLATE("Matching against floating values", F, float, double, long double) {
+    const auto flip = true;
+
+    SUBCASE("Finite values") {
+        std::random_device trng; // Cannot use auto as non-movable type
+
+        auto csprng = std::mt19937(trng());
+        auto min    = std::numeric_limits<F>::lowest() / 2;
+        auto max    = std::numeric_limits<F>::max() / 2;
+        auto dist   = std::uniform_real_distribution<F>(min, max);
+        for(auto count = 0; count < 100; count++) {
+            auto value = dist(csprng);
+            CHECK_FALSE(IsNaN<F>(value));
+            CHECK      (IsNaN<F>(value, flip));
+        }
+    }
+
+    SUBCASE("Infinite values") {
+        constexpr auto inf = std::numeric_limits<F>::infinity();
+
+        CHECK_FALSE(IsNaN<F>(inf));
+        CHECK_FALSE(IsNaN<F>(-inf));
+
+        CHECK(IsNaN<F>( inf, flip));
+        CHECK(IsNaN<F>(-inf, flip));
+    }
+
+    SUBCASE("Quiet NaN value") {
+        constexpr auto qnan = std::numeric_limits<F>::quiet_NaN();
+
+        CHECK(IsNaN<F>(qnan));
+        CHECK(IsNaN<F>(-qnan));
+
+        CHECK_FALSE(IsNaN<F>( qnan, flip));
+        CHECK_FALSE(IsNaN<F>(-qnan, flip));
+
+    }
+
+    SUBCASE("Signalling NaN value") {
+        constexpr auto snan = std::numeric_limits<F>::signaling_NaN();
+
+        CHECK(IsNaN<F>( snan));
+        CHECK(IsNaN<F>(-snan));
+
+        CHECK_FALSE(IsNaN<F>( snan, flip));
+        CHECK_FALSE(IsNaN<F>(-snan, flip));
+    }
+}

--- a/tests/doctest/test_exception_translator.cpp
+++ b/tests/doctest/test_exception_translator.cpp
@@ -1,0 +1,75 @@
+// Our CI/CD helpfully runs this test with -fno-exceptions,
+// which obviously means we can't test exception translation!
+// -fno-exceptions is annoying to detect, but thankfully
+// our runner also sets DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#if !defined(DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS)
+
+#include <doctest/doctest.h>
+#include <type_traits>
+
+namespace {
+
+using doctest::detail::ExceptionTranslator;
+
+/** Example exceptions... */
+struct exception1 { };
+struct exception2 { };
+struct exception3 { };
+
+/** ...and their translators */
+const ExceptionTranslator<exception1> translator1([](exception1) { return doctest::String("exception1"); });
+const ExceptionTranslator<exception2> translator2([](exception2) { return doctest::String("exception2"); });
+const ExceptionTranslator<exception3> translator3([](exception3) { return doctest::String("exception3"); });
+
+/**
+ * Utility to raise an exception, call the functor, then resolve the exception
+ * I would normally have parametrized the return-type to `result_of<Fn()>::type`,
+ * but this is not available on a few compilers in our toolchain, hence ignoring this.
+ * */
+template <typename Ex, typename Fn>
+inline doctest::String with_ambient_exception(Ex e, Fn f) {
+    try { throw e; } // NOLINT(hicpp-exception-baseclass)
+    catch (... ) { return f(); }
+}
+
+} // namespace
+
+TEST_CASE("Translating custom exceptions") {
+    SUBCASE("Throwing exception1") {
+        auto result = with_ambient_exception(exception1 { }, [] {
+            auto result_ = doctest::String();
+            REQUIRE( translator1.translate(result_));
+            REQUIRE(!translator2.translate(result_));
+            REQUIRE(!translator3.translate(result_));
+            return result_;
+        });
+
+        CHECK(result == "exception1");
+    }
+
+    SUBCASE("Throwing exception1") {
+        auto result = with_ambient_exception(exception2 { }, [] {
+            auto result_ = doctest::String();
+            REQUIRE(!translator1.translate(result_));
+            REQUIRE( translator2.translate(result_));
+            REQUIRE(!translator3.translate(result_));
+            return result_;
+        });
+
+        CHECK(result == "exception2");
+    }
+
+    SUBCASE("Throwing exception1") {
+        auto result = with_ambient_exception(exception3 { }, [] {
+            auto result_ = doctest::String();
+            REQUIRE(!translator1.translate(result_));
+            REQUIRE(!translator2.translate(result_));
+            REQUIRE( translator3.translate(result_));
+            return result_;
+        });
+
+        CHECK(result == "exception3");
+    }
+}
+
+#endif // !defined(DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS)

--- a/tests/doctest/test_path.cpp
+++ b/tests/doctest/test_path.cpp
@@ -1,0 +1,64 @@
+#define DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#include <doctest/doctest.h>
+
+namespace {
+class DummyContextOptions {
+private:
+    doctest::ContextOptions _old_options;
+
+public:
+    doctest::ContextOptions *options;
+
+    inline DummyContextOptions() {
+        // Safe since this function is backed by g_cs, which is mutable
+        options = const_cast<doctest::ContextOptions *>(doctest::getContextOptions());
+
+        // Retain a copy
+        _old_options = *options;
+    }
+
+    inline ~DummyContextOptions() {
+        *options = _old_options;
+    }
+};
+} // namespace
+
+TEST_CASE("Determining basename from path") {
+    using doctest::skipPathFromFilename;
+    DummyContextOptions context { };
+
+    SUBCASE("With no_path_in_filenames enabled") {
+        context.options->no_path_in_filenames = true;
+
+        CHECK(skipPathFromFilename("")                          == "");
+        CHECK(skipPathFromFilename("file.c")                    == "file.c");
+        CHECK(skipPathFromFilename("path/to/file.c")            == "file.c");
+        CHECK(skipPathFromFilename("path\\to\\file.c")          == "file.c");
+        CHECK(skipPathFromFilename("another/path/to/file.c")    == "file.c");
+        CHECK(skipPathFromFilename("another\\path\\to\\file.c") == "file.c");
+    }
+
+    SUBCASE("With no_path_in_filenames disabled, and strip_file_prefixes empty") {
+        context.options->no_path_in_filenames = false;
+        context.options->strip_file_prefixes  = "";
+
+        CHECK(skipPathFromFilename("")                          == "");
+        CHECK(skipPathFromFilename("file.c")                    == "file.c");
+        CHECK(skipPathFromFilename("path/to/file.c")            == "path/to/file.c");
+        CHECK(skipPathFromFilename("path\\to\\file.c")          == "path\\to\\file.c");
+        CHECK(skipPathFromFilename("another/path/to/file.c")    == "another/path/to/file.c");
+        CHECK(skipPathFromFilename("another\\path\\to\\file.c") == "another\\path\\to\\file.c");
+    }
+
+    SUBCASE("With no_path_in_filenames disabled, and strip_file_prefixes set to 'path'") {
+        context.options->no_path_in_filenames = false;
+        context.options->strip_file_prefixes  = "path";
+
+        CHECK(skipPathFromFilename("")                          == "");
+        CHECK(skipPathFromFilename("file.c")                    == "file.c");
+        CHECK(skipPathFromFilename("path/to/file.c")            == "/to/file.c");
+        CHECK(skipPathFromFilename("path\\to\\file.c")          == "\\to\\file.c");
+        CHECK(skipPathFromFilename("another/path/to/file.c")    == "another/path/to/file.c");
+        CHECK(skipPathFromFilename("another\\path\\to\\file.c") == "another\\path\\to\\file.c");
+    }
+}

--- a/tests/doctest/test_string.cpp
+++ b/tests/doctest/test_string.cpp
@@ -1,0 +1,534 @@
+#define DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#include <doctest/doctest.h>
+#include <limits>
+#include <sstream>
+using doctest::String;
+
+namespace {
+
+/** Determines the address of the actual string content */
+inline const void *data_address(const String &s) {
+  return reinterpret_cast<const void *>(s.c_str());
+}
+/**
+ * Determines if the String object is on the stack,
+ * i.e. the private String::isOnStack method would return true
+ * This is mostly to check we're hitting small-string optimizations
+ */
+inline bool is_on_stack(const String &s) {
+    return reinterpret_cast<const void *>(&s) == data_address(s);
+}
+
+/** Convenience alias for !is_on_stack */
+inline bool is_on_heap(const String &s) {
+    return !is_on_stack(s);
+}
+
+// For type-level stringification tests
+struct X;
+struct Y;
+struct Z;
+namespace nested { struct Type; }
+
+} // namespace
+
+TEST_SUITE("String construction") {
+    TEST_CASE("Default construction") {
+        auto string = String();
+
+        CHECK(string.c_str() == "");
+        CHECK(string.size() == 0u);
+        CHECK(string.capacity() == 24u);
+        CHECK(is_on_stack(string));
+    }
+
+    TEST_CASE("Construction from string-literal") {
+        SUBCASE("Small-string-optimizable string literal") {
+            auto string = String("doctest");
+
+            CHECK(string.c_str() == "doctest");
+            CHECK(string.size() == 7u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Large string literal") {
+            auto string = String("a very big string literal");
+
+            CHECK(string.c_str() == "a very big string literal");
+            CHECK(string.size() == 25u);
+            CHECK(string.capacity() == 26u);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Construction from sized string-literal") {
+        SUBCASE("Small-string-optimizable string literal") {
+            auto string = String("a particularly long string", 6);
+
+            CHECK(string.c_str() == "a part");
+            CHECK(string.size() == 6u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Large string literal, size set to below threshold") {
+            auto string = String("a very big string literal", 23);
+
+            CHECK(string.c_str() == "a very big string liter");
+            CHECK(string.size() == 23u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Large string literal, size set to threshold") {
+            auto string = String("a very big string literal", 24);
+
+            CHECK(string.c_str() == "a very big string litera");
+            CHECK(string.size() == 24u);
+            CHECK(string.capacity() == 25u);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Construction from an input-stream") {
+        std::stringstream ss { };
+        ss << "a very big string literal";
+
+        SUBCASE("Size set to below threshold") {
+            auto string = String(ss, 17);
+
+            CHECK(string.c_str() == "a very big string");
+            CHECK(string.size() == 17u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Size set to threshold") {
+            auto string = String(ss, 24);
+
+            CHECK(string.c_str() == "a very big string litera");
+            CHECK(string.size() == 24u);
+            CHECK(string.capacity() == 25u);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Construction from a substring") {
+        auto base = String("an extraordinarily large string literal");
+        REQUIRE(base.size() == 39u);
+        REQUIRE(base.capacity() == 40u);
+        REQUIRE(is_on_heap(base));
+
+        SUBCASE("Substring over [0, 0] with const source") {
+            auto string = base.substr(0, 0);
+
+            CHECK(string.c_str() == "");
+            CHECK(string.size() == 0u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Substring over [0, 0] with rvalue source") {
+            auto string = std::move(base).substr(0, 0);
+
+            CHECK(string.c_str() == "");
+            CHECK(string.size() == 0u);
+            CHECK(string.capacity() == 40u);
+            CHECK(is_on_heap(string));
+        }
+
+        SUBCASE("Substring over [3, 24] with const source") {
+            auto string = base.substr(3, 21); // NOLINT(bugprone-use-after-move) NOLINT(hicpp-invalid-access-moved)
+
+            CHECK(string.c_str() == "extraordinarily large");
+            CHECK(string.size() == 21u);
+            CHECK(string.capacity() == 24u);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Substring over [19, 31] with rvalue source") {
+            auto string = std::move(base).substr(19, 12); // NOLINT(bugprone-use-after-move) NOLINT(hicpp-invalid-access-moved)
+
+            CHECK(string.c_str() == "large string");
+            CHECK(string.size() == 12u);
+            CHECK(string.capacity() == 40u);
+            CHECK(is_on_heap(string));
+        }
+
+        SUBCASE("Substring over [0, SIZE_MAX] with const source") {
+            auto string = base.substr(0, std::numeric_limits<String::size_type>::max()); // NOLINT(bugprone-use-after-move) NOLINT(hicpp-invalid-access-moved)
+
+            CHECK(string.c_str() == "an extraordinarily large string literal");
+            CHECK(string.size() == 39u);
+            CHECK(string.capacity() == 40u);
+            CHECK(is_on_heap(string));
+        }
+
+        SUBCASE("Substring over [0, SIZE_MAX] with rvalue source") {
+            auto string = base.substr(0, std::numeric_limits<String::size_type>::max()); // NOLINT(bugprone-use-after-move) NOLINT(hicpp-invalid-access-moved)
+
+            CHECK(string.c_str() == "an extraordinarily large string literal");
+            CHECK(string.size() == 39u);
+            CHECK(string.capacity() == 40u);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Copy-construction") {
+        const auto stack_string = String("stack-string");
+        const auto heap_string  = String("a very long string that will be on heap");
+        REQUIRE(is_on_stack(stack_string));
+        REQUIRE(is_on_heap(heap_string));
+
+        SUBCASE("Copying stack-string") {
+            auto string = String(stack_string);
+            CHECK(string == stack_string);
+        }
+
+        SUBCASE("Copying heap-string") {
+            auto string = String(heap_string);
+            CHECK(string == heap_string);
+        }
+    }
+
+    TEST_CASE("Copy-assign construction") {
+        const auto stack_string = String("stack-string");
+        const auto heap_string  = String("a very long string that will be on heap");
+        REQUIRE(is_on_stack(stack_string));
+        REQUIRE(is_on_heap(heap_string));
+
+        SUBCASE("Copying stack-string to existing stack-string") {
+            auto string = String("another stack-string");
+            REQUIRE(is_on_stack(string));
+
+            string = stack_string;
+            CHECK(string == stack_string);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Copying stack-string to existing heap-string") {
+            auto string = String("another very long string that will be on heap");
+            REQUIRE(is_on_heap(string));
+
+            string = stack_string;
+            CHECK(string == stack_string);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Copying heap-string to existing stack-string") {
+            auto string = String("another stack-string");
+            REQUIRE(is_on_stack(string));
+
+            string = heap_string;
+            CHECK(string == heap_string);
+            CHECK(is_on_heap(string));
+        }
+
+        SUBCASE("Copying heap-string to existing heap-string") {
+            auto string = String("another very long string that will be on heap");
+            REQUIRE(is_on_heap(string));
+
+            string = heap_string;
+            CHECK(string == heap_string);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Move-construction") {
+        const auto stack_string = String("stack-string");
+        const auto heap_string  = String("a very long string that will be on heap");
+        REQUIRE(is_on_stack(stack_string));
+        REQUIRE(is_on_heap(heap_string));
+
+        SUBCASE("Moving stack-string") {
+            auto string = std::move(String(stack_string));
+            CHECK(string == stack_string);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Moving heap-string") {
+            auto string = std::move(String(heap_string));
+            CHECK(string == heap_string);
+            CHECK(is_on_heap(string));
+        }
+    }
+
+    TEST_CASE("Move-assign construction") {
+        const auto stack_string = String("stack-string");
+        const auto heap_string  = String("a very long string that will be on heap");
+        REQUIRE(is_on_stack(stack_string));
+        REQUIRE(is_on_heap(heap_string));
+
+        SUBCASE("Moving stack-string to existing stack-string") {
+            auto string = String("another stack-string");
+            REQUIRE(is_on_stack(string));
+
+            string = std::move(String(stack_string));
+            CHECK(string == stack_string);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Moving stack-string to existing heap-string") {
+            auto string = String("another very long string that will be on heap");
+            REQUIRE(is_on_heap(string));
+
+            string = std::move(String(stack_string));
+            CHECK(string == stack_string);
+            CHECK(is_on_stack(string));
+        }
+
+        SUBCASE("Moving heap-string to existing stack-string") {
+            auto string = String("another stack-string");
+            REQUIRE(is_on_stack(string));
+
+            string = std::move(String(heap_string));
+            CHECK(string == heap_string);
+            CHECK(is_on_heap(string));
+        }
+
+        SUBCASE("Moving heap-string to existing heap-string") {
+            auto string = String("another very long string that will be on heap");
+            REQUIRE(is_on_heap(string));
+
+            string = std::move(String(heap_string));
+            CHECK(string == heap_string);
+            CHECK(is_on_heap(string));
+        }
+    }
+}
+
+TEST_SUITE("String searching") {
+    // For some reason, String::npos produces an undefined-reference link error
+    // So for these tests, we have to invent our own...
+    const auto npos = String::size_type(-1);
+
+    TEST_CASE("Forward-searching") {
+        SUBCASE("Empty source string") {
+            auto string = String("");
+            CHECK(string.find('x') == npos);
+            CHECK(string.find('y') == npos);
+            CHECK(string.find('z') == npos);
+        }
+
+        SUBCASE("Non-empty source string") {
+            auto string = String("doctest");
+
+            CHECK(string.find('x') == npos);
+
+            CHECK(string.find('d')    == 0u);
+            CHECK(string.find('d', 1) == npos);
+
+            CHECK(string.find('c')    == 2u);
+            CHECK(string.find('c', 1) == 2u);
+            CHECK(string.find('c', 2) == 2u);
+            CHECK(string.find('c', 3) == npos);
+
+            CHECK(string.find('t')    == 3u);
+            CHECK(string.find('t', 2) == 3u);
+            CHECK(string.find('t', 3) == 3u);
+            CHECK(string.find('t', 4) == 6u);
+        }
+    }
+
+    TEST_CASE("Reverse-searching") {
+        // See #1018 for why this is disabled
+        // SUBCASE("Empty source string") {
+        //     auto string = String("");
+        //     CHECK(string.rfind('x') == npos);
+        //     CHECK(string.rfind('y') == npos);
+        //     CHECK(string.rfind('z') == npos);
+        // }
+
+        SUBCASE("Non-empty source string") {
+            auto string = String("doctest");
+
+            CHECK(string.rfind('x') == npos);
+
+            CHECK(string.rfind('d')    == 0u);
+            CHECK(string.rfind('d', 1) == 0u);
+
+            CHECK(string.rfind('c')    == 2u);
+            CHECK(string.rfind('c', 1) == npos);
+            CHECK(string.rfind('c', 2) == 2u);
+            CHECK(string.rfind('c', 3) == 2u);
+
+            CHECK(string.rfind('t')    == 6u);
+            CHECK(string.rfind('t', 2) == npos);
+            CHECK(string.rfind('t', 3) == 3u);
+            CHECK(string.rfind('t', 4) == 3u);
+        }
+    }
+}
+
+TEST_CASE("String comparison") {
+    SUBCASE("Case-sensitive C-style comparison") {
+        CHECK(String(""       ).compare(""       ) == 0);
+        CHECK(String(""       ).compare("doctest") <  0);
+        CHECK(String("doctest").compare(""       ) >  0);
+        CHECK(String("doctest").compare("Doctest") >  0);
+    }
+
+    SUBCASE("Case-insensitive C-style comparison") {
+        const auto caseless = true;
+        CHECK(String(""       ).compare("",        caseless) == 0);
+        CHECK(String(""       ).compare("doctest", caseless) <  0);
+        CHECK(String("doctest").compare("",        caseless) >  0);
+        CHECK(String("doctest").compare("Doctest", caseless) == 0);
+    }
+
+    SUBCASE("operator<") {
+        CHECK_FALSE(String("")        < String(""));
+        CHECK      (String("")        < String("doctest"));
+        CHECK_FALSE(String("doctest") < String(""));
+        CHECK_FALSE(String("doctest") < String("doctest"));
+
+        CHECK      (String("x") < String("y"));
+        CHECK_FALSE(String("y") < String("x"));
+    }
+
+    SUBCASE("operator>=") {
+        CHECK      (String("")        >= String(""));
+        CHECK_FALSE(String("")        >= String("doctest"));
+        CHECK      (String("doctest") >= String(""));
+        CHECK      (String("doctest") >= String("doctest"));
+
+        CHECK_FALSE(String("x") >= String("y"));
+        CHECK      (String("y") >= String("x"));
+    }
+
+    SUBCASE("operator>") {
+        CHECK_FALSE(String("")        > String(""));
+        CHECK_FALSE(String("")        > String("doctest"));
+        CHECK      (String("doctest") > String(""));
+        CHECK_FALSE(String("doctest") > String("doctest"));
+
+        CHECK_FALSE(String("x") > String("y"));
+        CHECK      (String("y") > String("x"));
+    }
+
+    SUBCASE("operator<=") {
+        CHECK      (String("")        <= String(""));
+        CHECK      (String("")        <= String("doctest"));
+        CHECK_FALSE(String("doctest") <= String(""));
+        CHECK      (String("doctest") <= String("doctest"));
+
+        CHECK      (String("x") <= String("y"));
+        CHECK_FALSE(String("y") <= String("x"));
+    }
+}
+
+TEST_SUITE("String manipulation") {
+    TEST_CASE("Appending to a new string") {
+        CHECK(String("")    + String("")     == String(""));
+        CHECK(String("doc") + String("")     == String("doc"));
+        CHECK(String("")    + String("test") == String("test"));
+        CHECK(String("doc") + String("test") == String("doctest"));
+    }
+
+    TEST_CASE("Appending in-place") {
+        auto result = String("");
+
+        result += String("doc");
+        CHECK(result == String("doc"));
+
+        result += String("");
+        CHECK(result == String("doc"));
+
+        result += String("test");
+        CHECK(result == String("doctest"));
+
+        result += String("");
+        CHECK(result == String("doctest"));
+    }
+}
+
+TEST_SUITE("Type stringification") {
+    using namespace doctest;
+
+    TEST_CASE("Fundamental types") {
+        CHECK(toString<void          >() == "void");
+        CHECK(toString<bool          >() == "bool");
+        CHECK(toString<std::nullptr_t>() == "std::nullptr_t");
+
+        CHECK(toString<char              >() == "char");
+        CHECK(toString<char16_t          >() == "char16_t");
+        CHECK(toString<char32_t          >() == "char32_t");
+
+        CHECK(toString<signed char       >() == "signed char");
+        CHECK(toString<unsigned char     >() == "unsigned char");
+        CHECK(toString<short             >() == "short int");
+        CHECK(toString<unsigned short    >() == "short unsigned int");
+        CHECK(toString<int               >() == "int");
+        CHECK(toString<unsigned int      >() == "unsigned int");
+        CHECK(toString<long              >() == "long int");
+        CHECK(toString<unsigned long     >() == "long unsigned int");
+        CHECK(toString<long long         >() == "long long int");
+        CHECK(toString<unsigned long long>() == "long long unsigned int");
+
+        CHECK(toString<float      >() == "float");
+        CHECK(toString<double     >() == "double");
+        CHECK(toString<long double>() == "long double");
+
+        CHECK(toString<volatile const void *const>() == "const volatile void* const");
+    }
+
+    TEST_CASE("Doctest internal types") {
+        CHECK(toString<doctest::String      >() == "String");
+        CHECK(toString<doctest::Approx      >() == "Approx");
+        CHECK(toString<doctest::Contains    >() == "Contains");
+        CHECK(toString<doctest::IsNaN<float>>() == "IsNaN<float>");
+    }
+
+    TEST_CASE("Custom types") {
+        CHECK(toString<X           >() == "{anonymous}::X");
+        CHECK(toString<Y           >() == "{anonymous}::Y");
+        CHECK(toString<Z           >() == "{anonymous}::Z");
+        CHECK(toString<nested::Type>() == "{anonymous}::nested::Type");
+    }
+}
+
+TEST_SUITE("Value stringification") {
+    using namespace doctest;
+
+    // Some types can't be braced-initialized, so...
+    template <typename T>
+    T lit(T value) { return value; }
+
+    TEST_CASE("Fundamental types") {
+        // Cannot instantiate 'void' so excluded
+        SUBCASE("bool") {
+            CHECK(toString(false) == "false");
+            CHECK(toString(true)  == "true");
+        }
+
+        SUBCASE("nullptr") {
+            CHECK(toString(nullptr) == "nullptr");
+        }
+
+        SUBCASE("Character types") {
+            CHECK(toString(lit<char         >('X' )) == "88");
+            CHECK(toString(lit<char16_t     >(u'X')) == "{?}");
+            CHECK(toString(lit<char32_t     >(U'X')) == "{?}");
+        }
+
+        SUBCASE("Integral types") {
+            CHECK(toString(lit<unsigned      char >(12)) == "12");
+            CHECK(toString(lit<  signed      char >(23)) == "23");
+            CHECK(toString(lit<              short>(34)) == "34");
+            CHECK(toString(lit<unsigned      short>(45)) == "45");
+            CHECK(toString(lit<              int  >(56)) == "56");
+            CHECK(toString(lit<unsigned      int  >(67)) == "67");
+            CHECK(toString(lit<              long >(78)) == "78");
+            CHECK(toString(lit<unsigned      long >(89)) == "89");
+            CHECK(toString(lit<         long long >(90)) == "90");
+            CHECK(toString(lit<unsigned long long >(99)) == "99");
+        }
+
+        SUBCASE("Floating types") {
+            CHECK(toString(lit<      float>(1.5)) == "1.5");
+            CHECK(toString(lit<     double>(2.5)) == "2.5");
+            CHECK(toString(lit<long double>(3.5)) == "3.5");
+        }
+    }
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,3 @@
+#define DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>


### PR DESCRIPTION
## Description

Adds basic unit-tests to the following files:

- `doctest/assert/expression.h`
- `doctest/asserts/message.h`
- `doctest/assert/type.h`
- `doctest/matchers/approx.h`
- `doctest/matchers/contains.h`
- `doctest/matchers/is_nan.h`
- `doctest/exception_translator.h`
- `doctest/path.h`
- `doctest/string.h`

While these tests aren't perfect, they've already uncovered a few issues with the codebase (#1017, #1018, #1019).

## GitHub Issues

#1016