### PR TITLE
chore: Register unit-tests for coverage job only

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install -y ninja-build lcov
 
       - name: Generate
-        run: cmake -B build -S . -G Ninja -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage"
+        run: cmake -B build -S . -G Ninja -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -D CMAKE_INTERNAL_COVERAGE=ON
 
       - name: Build
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(DOCTEST_NO_INSTALL  "Skip the installation process" OFF)
 option(DOCTEST_USE_STD_HEADERS  "Use std headers" OFF)
 
 option(DOCTEST_INTERNAL_WERROR "Enables -Werror" OFF)
+option(DOCTEST_INTERNAL_COVERAGE "Set for running coverage" OFF)
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,12 @@ set(unit_test_sources
 add_executable(unit_tests ${unit_test_sources} main.cpp)
 target_link_libraries(unit_tests doctest)
 
+# While our unit-tests compile, there's sufficient errors that we can't really enable globally.
+# For now, we're going to run the tests, and hopefully try to smooth over these errors later.
+if(CMAKE_INTERNAL_COVERAGE)
+    add_test(NAME unit_tests COMMAND unit_tests)
+endif()
+
 # For unit-tests, we don't want to enforce the same level of warning-correctness
 # as with our examples. So, we inhibit some extras here
 macro(add_compiler_flags)


### PR DESCRIPTION
## Description

Adds missing `add_test()` to `tests/CMakeLists.txt`. Without this, when running tests both on CI/CD and locally, we'd build the tests but not actually execute them.

Unfortunately, there's sufficient differences in our CI/CD targets that execution fails for a decent number of tests, mainly around stringification and `Approx`. For now, we'll register tests for the coverage job only, and will look at enabling these for as many toolchains as possible in the future.

## GitHub Issues

#1016