### PR TITLE
fix: Correctly handle empty strings in String::rfind

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install -y ninja-build lcov
 
       - name: Generate
-        run: cmake -B build -S . -G Ninja -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -D CMAKE_INTERNAL_COVERAGE=ON
+        run: cmake -B build -S . -G Ninja -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -D DOCTEST_INTERNAL_COVERAGE=ON
 
       - name: Build
         run: cmake --build build

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -7518,6 +7518,8 @@ namespace detail {
     }
 
     String::size_type String::rfind(char ch, size_type pos) const {
+        if (size() == 0) { return npos; }
+
         const char* begin = c_str();
         const char* it = begin + std::min(pos, size() - 1);
         for (; it >= begin && *it != ch; it--) { }

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -226,6 +226,8 @@ namespace detail {
     }
 
     String::size_type String::rfind(char ch, size_type pos) const {
+        if (size() == 0) { return npos; }
+
         const char* begin = c_str();
         const char* it = begin + std::min(pos, size() - 1);
         for (; it >= begin && *it != ch; it--) { }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(unit_tests doctest)
 
 # While our unit-tests compile, there's sufficient errors that we can't really enable globally.
 # For now, we're going to run the tests, and hopefully try to smooth over these errors later.
-if(CMAKE_INTERNAL_COVERAGE)
+if(DOCTEST_INTERNAL_COVERAGE)
     add_test(NAME unit_tests COMMAND unit_tests)
 endif()
 

--- a/tests/doctest/test_string.cpp
+++ b/tests/doctest/test_string.cpp
@@ -332,13 +332,12 @@ TEST_SUITE("String searching") {
     }
 
     TEST_CASE("Reverse-searching") {
-        // See #1018 for why this is disabled
-        // SUBCASE("Empty source string") {
-        //     auto string = String("");
-        //     CHECK(string.rfind('x') == npos);
-        //     CHECK(string.rfind('y') == npos);
-        //     CHECK(string.rfind('z') == npos);
-        // }
+        SUBCASE("Empty source string") {
+            auto string = String("");
+            CHECK(string.rfind('x') == npos);
+            CHECK(string.rfind('y') == npos);
+            CHECK(string.rfind('z') == npos);
+        }
 
         SUBCASE("Non-empty source string") {
             auto string = String("doctest");


### PR DESCRIPTION
## Description

Adds an edge-case check for `size() == 0` in `String::rfind`. 

On systems where `String::size_type != uintptr_t`, `it + npos` is not guaranteed to be `it - 1`, and instead may be `it + (large-number)`. This passes the later `it >= begin` check which presumably intended to catch `it + npos`.

## GitHub Issues

Fixes #1018 