### PR TITLE
chore: Ignore the .vs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ XCBuildData/
 *.exp
 *.ilk
 *.pdb
+.vs/
 
 # Ninja
 build.ninja


### PR DESCRIPTION
When using MSVC to open a "CMake" file it generates a .vs folder with its own cruft in it.

Now ignoring it.