### PR TITLE
feat: Warn on failure to create output-file

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5984,6 +5984,12 @@ namespace {
                 // to a file if specified
                 fstr.open(p->out.c_str(), std::fstream::out);
                 p->cout = &fstr;
+                if (!fstr.is_open()) {
+                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
+                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
+                    p->cout = &std::cout;
+                }
+
             } else {
     #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
                 // stdout by default

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -429,6 +429,12 @@ namespace {
                 // to a file if specified
                 fstr.open(p->out.c_str(), std::fstream::out);
                 p->cout = &fstr;
+                if (!fstr.is_open()) {
+                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Could not open " << p->out << " for writing!" << std::endl;
+                    std::cerr << Color::Cyan << "[doctest] " << Color::None << "Defaulting to std::cout instead" << std::endl;
+                    p->cout = &std::cout;
+                }
+
             } else {
     #ifndef DOCTEST_CONFIG_NO_INCLUDE_IOSTREAM
                 // stdout by default


### PR DESCRIPTION
## Description

Adds a special case to `Context::run` to confirm that the `--out` file was created. As `std::filesystem` is only available on C++17, for the time being we choose to warn then swap to `std::cout`. The reason for not special-casing C++17 and above is it will produce a split in behaviour that is not easily testable.

Tested by explicitly running `exe --out=bad/dir` and verifying the message was produced, and test output was instead sent to `stdout`.

## GitHub Issues

Closes #676