### PR TITLE
ci: Report coverage on parts instead of doctest.h

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,9 @@ jobs:
         run: cmake -B build -S . -G Ninja -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -D DOCTEST_INTERNAL_COVERAGE=ON
 
       - name: Build
-        run: cmake --build build
+        run: |
+          python scripts/assemble.py --remap
+          cmake --build build
 
       - name: Test
         run: ctest --test-dir build --no-tests=error
@@ -46,7 +48,7 @@ jobs:
       - name: LCOV
         run: |
           mkdir coverage
-          lcov -c -d build/ -o coverage/lcov.info --include "*/doctest/doctest.h"
+          lcov -c -d build/ -o coverage/lcov.info --include "*/doctest/parts/*"
 
       - name: Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Description

Slightly reworks single-header generation for the `coverage.yml` jobs to help coax `lcov` into reporting coverage based off source files. With #941 complete, we have a decent set of source files which would provide a much better basis for reading our coverage report; trying to read the coverage report for an 8000+ line file is a bit of a hassle.

This is implemented by adding a `--remap` option to `scripts/assemble.py`. This will add `#line <number> <file>` directives when inlining content, which in turn allows most compilers to report better. Since this affects compilers, it should also in turn affect the .gcno and .gcda files, and in turn allow `lcov` to report coverage as-if it was from the constituent `.cpp` and `.h` parts files.

The checked-in `doctest/doctest.h` remains the same -- the coverage job simply re-generates the file via `python scripts/assemble.py --remap` before compilation to ensure the `#line` directives are present.

## GitHub Issues

N/A