### PR TITLE
chore: Add project integration tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,12 +32,13 @@ function(doctest_add_unit_test)
         target_link_libraries(${EXE_NAME} doctest)
     endif()
 
-    set(TEST_ARGS)
     if(NOT DOCTEST_INTERNAL_COVERAGE)
         # Stringification is mostly compiler-specific, so these are excluded for now
         set(TEST_ARGS
             "-tce=Stringification*"
-            "-tse=Stringification*,Type stringification*,Value stringification*")
+            "-tse=Stringification*,Type stringification*,Value stringification*,INTERNAL")
+    else()
+        set(TEST_ARGS "-tse=INTERNAL")
     endif()
     add_test(NAME "${ARG_SOURCE}" COMMAND ${EXE_NAME} ${TEST_ARGS})
 
@@ -80,6 +81,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     endif()
 endif()
 
+# Unit tests
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_expression.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_message.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_type.cpp)
@@ -94,3 +96,11 @@ doctest_add_unit_test(WITH_MAIN SOURCE doctest/test_filters.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/test_path.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/test_string.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/test_xml.cpp EXCEPT ${GCC_4_8})
+
+# Integration tests
+doctest_add_unit_test(WITH_MAIN SOURCE integration/test_bdd.cpp     EXCEPT ${GCC_4_8})
+doctest_add_unit_test(WITH_MAIN SOURCE integration/test_capture.cpp EXCEPT ${GCC_4_8})
+doctest_add_unit_test(WITH_MAIN SOURCE integration/test_info.cpp    EXCEPT ${GCC_4_8})
+doctest_add_unit_test(WITH_MAIN SOURCE integration/test_message.cpp EXCEPT ${GCC_4_8})
+
+doctest_add_unit_test(SOURCE integration/test_assert_out_of_test_context.cpp EXCEPT ${GCC_4_8})

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(common INTERFACE)
-target_include_directories(common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(common SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/common/thirdparty/subprocess.h
+++ b/tests/common/thirdparty/subprocess.h
@@ -1,0 +1,1203 @@
+/*
+   The latest version of this library is available on GitHub;
+   https://github.com/sheredom/subprocess.h
+*/
+
+/*
+   This is free and unencumbered software released into the public domain.
+
+   Anyone is free to copy, modify, publish, use, compile, sell, or
+   distribute this software, either in source code form or as a compiled
+   binary, for any purpose, commercial or non-commercial, and by any
+   means.
+
+   In jurisdictions that recognize copyright laws, the author or authors
+   of this software dedicate any and all copyright interest in the
+   software to the public domain. We make this dedication for the benefit
+   of the public at large and to the detriment of our heirs and
+   successors. We intend this dedication to be an overt act of
+   relinquishment in perpetuity of all present and future rights to this
+   software under copyright law.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+
+   For more information, please refer to <http://unlicense.org/>
+*/
+
+#ifndef SHEREDOM_SUBPROCESS_H_INCLUDED
+#define SHEREDOM_SUBPROCESS_H_INCLUDED
+
+#if defined(_MSC_VER)
+#pragma warning(push, 1)
+
+/* disable warning: '__cplusplus' is not defined as a preprocessor macro,
+ * replacing with '0' for '#if/#elif' */
+#pragma warning(disable : 4668)
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#if defined(__TINYC__)
+#define SUBPROCESS_ATTRIBUTE(a) __attribute((a))
+#else
+#define SUBPROCESS_ATTRIBUTE(a) __attribute__((a))
+#endif
+
+#if defined(_MSC_VER)
+#define subprocess_pure
+#define subprocess_weak __inline
+#define subprocess_tls __declspec(thread)
+#elif defined(__MINGW32__)
+#define subprocess_pure SUBPROCESS_ATTRIBUTE(pure)
+#define subprocess_weak static SUBPROCESS_ATTRIBUTE(used)
+#define subprocess_tls __thread
+#elif defined(__clang__) || defined(__GNUC__) || defined(__TINYC__)
+#define subprocess_pure SUBPROCESS_ATTRIBUTE(pure)
+#define subprocess_weak SUBPROCESS_ATTRIBUTE(weak)
+#define subprocess_tls __thread
+#else
+#error Non clang, non gcc, non MSVC compiler found!
+#endif
+
+struct subprocess_s;
+
+enum subprocess_option_e {
+  // stdout and stderr are the same FILE.
+  subprocess_option_combined_stdout_stderr = 0x1,
+
+  // The child process should inherit the environment variables of the parent.
+  subprocess_option_inherit_environment = 0x2,
+
+  // Enable asynchronous reading of stdout/stderr before it has completed.
+  subprocess_option_enable_async = 0x4,
+
+  // Enable the child process to be spawned with no window visible if supported
+  // by the platform.
+  subprocess_option_no_window = 0x8,
+
+  // Search for program names in the PATH variable. Always enabled on Windows.
+  // Note: this will **not** search for paths in any provided custom environment
+  // and instead uses the PATH of the spawning process.
+  subprocess_option_search_user_path = 0x10
+};
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/// @brief Create a process.
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+subprocess_weak int subprocess_create(const char *const command_line[],
+                                      int options,
+                                      struct subprocess_s *const out_process);
+
+/// @brief Create a process (extended create).
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param environment An optional array of strings for the environment to use
+/// for a child process (each element of the form FOO=BAR). The last element
+/// must be NULL to signify the end of the array.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+///
+/// If `options` contains `subprocess_option_inherit_environment`, then
+/// `environment` must be NULL.
+subprocess_weak int
+subprocess_create_ex(const char *const command_line[], int options,
+                     const char *const environment[],
+                     struct subprocess_s *const out_process);
+
+/// @brief Get the standard input file for a process.
+/// @param process The process to query.
+/// @return The file for standard input of the process.
+///
+/// The file returned can be written to by the parent process to feed data to
+/// the standard input of the process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdin(const struct subprocess_s *const process);
+
+/// @brief Get the standard output file for a process.
+/// @param process The process to query.
+/// @return The file for standard output of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard output of the child process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdout(const struct subprocess_s *const process);
+
+/// @brief Get the standard error file for a process.
+/// @param process The process to query.
+/// @return The file for standard error of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard error of the child process.
+///
+/// If the process was created with the subprocess_option_combined_stdout_stderr
+/// option bit set, this function will return NULL, and the subprocess_stdout
+/// function should be used for both the standard output and error combined.
+subprocess_pure subprocess_weak FILE *
+subprocess_stderr(const struct subprocess_s *const process);
+
+/// @brief Wait for a process to finish execution.
+/// @param process The process to wait for.
+/// @param out_return_code The return code of the returned process (can be
+/// NULL).
+/// @return On success zero is returned.
+///
+/// Joining a process will close the stdin pipe to the process.
+subprocess_weak int subprocess_join(struct subprocess_s *const process,
+                                    int *const out_return_code);
+
+/// @brief Destroy a previously created process.
+/// @param process The process to destroy.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it may out live
+/// the parent process.
+subprocess_weak int subprocess_destroy(struct subprocess_s *const process);
+
+/// @brief Terminate a previously created process.
+/// @param process The process to terminate.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it will be
+/// terminated (i.e killed).
+subprocess_weak int subprocess_terminate(struct subprocess_s *const process);
+
+/// @brief Read the standard output from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard output of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjunction with this method.
+subprocess_weak unsigned
+subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Read the standard error from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard error of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjunction with this method.
+subprocess_weak unsigned
+subprocess_read_stderr(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Returns if the subprocess is currently still alive and executing.
+/// @param process The process to check.
+/// @return If the process is still alive non-zero is returned.
+subprocess_weak int subprocess_alive(struct subprocess_s *const process);
+
+#if defined(__cplusplus)
+#define SUBPROCESS_CAST(type, x) static_cast<type>(x)
+#define SUBPROCESS_PTR_CAST(type, x) reinterpret_cast<type>(x)
+#define SUBPROCESS_CONST_CAST(type, x) const_cast<type>(x)
+#define SUBPROCESS_NULL NULL
+#else
+#define SUBPROCESS_CAST(type, x) ((type)(x))
+#define SUBPROCESS_PTR_CAST(type, x) ((type)(x))
+#define SUBPROCESS_CONST_CAST(type, x) ((type)(x))
+#define SUBPROCESS_NULL 0
+#endif
+
+#if !defined(_WIN32)
+#include <signal.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#if defined(_WIN32)
+
+#if (_MSC_VER < 1920)
+#ifdef _WIN64
+typedef __int64 subprocess_intptr_t;
+typedef unsigned __int64 subprocess_size_t;
+#else
+typedef int subprocess_intptr_t;
+typedef unsigned int subprocess_size_t;
+#endif
+#else
+#include <inttypes.h>
+
+typedef intptr_t subprocess_intptr_t;
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+typedef struct _PROCESS_INFORMATION *LPPROCESS_INFORMATION;
+typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
+typedef struct _STARTUPINFOA *LPSTARTUPINFOA;
+typedef struct _OVERLAPPED *LPOVERLAPPED;
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push, 1)
+#endif
+#ifdef __MINGW32__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+struct subprocess_subprocess_information_s {
+  void *hProcess;
+  void *hThread;
+  unsigned long dwProcessId;
+  unsigned long dwThreadId;
+};
+
+struct subprocess_security_attributes_s {
+  unsigned long nLength;
+  void *lpSecurityDescriptor;
+  int bInheritHandle;
+};
+
+struct subprocess_startup_info_s {
+  unsigned long cb;
+  char *lpReserved;
+  char *lpDesktop;
+  char *lpTitle;
+  unsigned long dwX;
+  unsigned long dwY;
+  unsigned long dwXSize;
+  unsigned long dwYSize;
+  unsigned long dwXCountChars;
+  unsigned long dwYCountChars;
+  unsigned long dwFillAttribute;
+  unsigned long dwFlags;
+  unsigned short wShowWindow;
+  unsigned short cbReserved2;
+  unsigned char *lpReserved2;
+  void *hStdInput;
+  void *hStdOutput;
+  void *hStdError;
+};
+
+struct subprocess_overlapped_s {
+  uintptr_t Internal;
+  uintptr_t InternalHigh;
+  union {
+    struct {
+      unsigned long Offset;
+      unsigned long OffsetHigh;
+    } DUMMYSTRUCTNAME;
+    void *Pointer;
+  } DUMMYUNIONNAME;
+
+  void *hEvent;
+};
+
+#ifdef __MINGW32__
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+__declspec(dllimport) unsigned long __stdcall GetLastError(void);
+__declspec(dllimport) int __stdcall SetHandleInformation(void *, unsigned long,
+                                                         unsigned long);
+__declspec(dllimport) int __stdcall CreatePipe(void **, void **,
+                                               LPSECURITY_ATTRIBUTES,
+                                               unsigned long);
+__declspec(dllimport) void *__stdcall CreateNamedPipeA(
+    const char *, unsigned long, unsigned long, unsigned long, unsigned long,
+    unsigned long, unsigned long, LPSECURITY_ATTRIBUTES);
+__declspec(dllimport) int __stdcall ReadFile(void *, void *, unsigned long,
+                                             unsigned long *, LPOVERLAPPED);
+__declspec(dllimport) unsigned long __stdcall GetCurrentProcessId(void);
+__declspec(dllimport) unsigned long __stdcall GetCurrentThreadId(void);
+__declspec(dllimport) void *__stdcall CreateFileA(const char *, unsigned long,
+                                                  unsigned long,
+                                                  LPSECURITY_ATTRIBUTES,
+                                                  unsigned long, unsigned long,
+                                                  void *);
+__declspec(dllimport) void *__stdcall CreateEventA(LPSECURITY_ATTRIBUTES, int,
+                                                   int, const char *);
+__declspec(dllimport) int __stdcall CreateProcessA(
+    const char *, char *, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, int,
+    unsigned long, void *, const char *, LPSTARTUPINFOA, LPPROCESS_INFORMATION);
+__declspec(dllimport) int __stdcall CloseHandle(void *);
+__declspec(dllimport) unsigned long __stdcall WaitForSingleObject(
+    void *, unsigned long);
+__declspec(dllimport) int __stdcall GetExitCodeProcess(
+    void *, unsigned long *lpExitCode);
+__declspec(dllimport) int __stdcall TerminateProcess(void *, unsigned int);
+__declspec(dllimport) unsigned long __stdcall WaitForMultipleObjects(
+    unsigned long, void *const *, int, unsigned long);
+__declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
+                                                        unsigned long *, int);
+
+#if defined(_DLL)
+#define SUBPROCESS_DLLIMPORT __declspec(dllimport)
+#else
+#define SUBPROCESS_DLLIMPORT
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
+SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
+SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+
+#ifndef __MINGW32__
+void *__cdecl _alloca(subprocess_size_t);
+#else
+#include <malloc.h>
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#else
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+struct subprocess_s {
+  FILE *stdin_file;
+  FILE *stdout_file;
+  FILE *stderr_file;
+
+#if defined(_WIN32)
+  void *hProcess;
+  void *hStdInput;
+  void *hEventOutput;
+  void *hEventError;
+#else
+  pid_t child;
+  int return_status;
+#endif
+
+  subprocess_size_t alive;
+};
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+#endif
+
+#if defined(_WIN32)
+subprocess_weak int subprocess_create_named_pipe_helper(void **rd, void **wr);
+int subprocess_create_named_pipe_helper(void **rd, void **wr) {
+  const unsigned long pipeAccessInbound = 0x00000001;
+  const unsigned long fileFlagOverlapped = 0x40000000;
+  const unsigned long pipeTypeByte = 0x00000000;
+  const unsigned long pipeWait = 0x00000000;
+  const unsigned long genericWrite = 0x40000000;
+  const unsigned long openExisting = 3;
+  const unsigned long fileAttributeNormal = 0x00000080;
+  const void *const invalidHandleValue =
+      SUBPROCESS_PTR_CAST(void *, ~(SUBPROCESS_CAST(subprocess_intptr_t, 0)));
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char name[256] = {0};
+  static subprocess_tls long index = 0;
+  const long unique = index++;
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#pragma warning(push, 1)
+#pragma warning(disable : 4996)
+  _snprintf(name, sizeof(name) - 1,
+            "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+            GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#pragma warning(pop)
+#else
+  snprintf(name, sizeof(name) - 1,
+           "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+           GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#endif
+
+  *rd =
+      CreateNamedPipeA(name, pipeAccessInbound | fileFlagOverlapped,
+                       pipeTypeByte | pipeWait, 1, 4096, 4096, SUBPROCESS_NULL,
+                       SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr));
+
+  if (invalidHandleValue == *rd) {
+    return -1;
+  }
+
+  *wr = CreateFileA(name, genericWrite, SUBPROCESS_NULL,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                    openExisting, fileAttributeNormal, SUBPROCESS_NULL);
+
+  if (invalidHandleValue == *wr) {
+    return -1;
+  }
+
+  return 0;
+}
+#endif
+
+int subprocess_create(const char *const commandLine[], int options,
+                      struct subprocess_s *const out_process) {
+  return subprocess_create_ex(commandLine, options, SUBPROCESS_NULL,
+                              out_process);
+}
+
+int subprocess_create_ex(const char *const commandLine[], int options,
+                         const char *const environment[],
+                         struct subprocess_s *const out_process) {
+#if defined(_WIN32)
+  int fd;
+  void *rd, *wr;
+  char *commandLineCombined;
+  subprocess_size_t len;
+  int i, j;
+  int need_quoting;
+  unsigned long flags = 0;
+  const unsigned long startFUseStdHandles = 0x00000100;
+  const unsigned long handleFlagInherit = 0x00000001;
+  const unsigned long createNoWindow = 0x08000000;
+  struct subprocess_subprocess_information_s processInfo;
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char *used_environment = SUBPROCESS_NULL;
+  struct subprocess_startup_info_s startInfo = {0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL};
+
+  startInfo.cb = sizeof(startInfo);
+  startInfo.dwFlags = startFUseStdHandles;
+
+  if (subprocess_option_no_window == (options & subprocess_option_no_window)) {
+    flags |= createNoWindow;
+  }
+
+  if (subprocess_option_inherit_environment !=
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL == environment) {
+      used_environment = SUBPROCESS_CONST_CAST(char *, "\0\0");
+    } else {
+      // We always end with two null terminators.
+      len = 2;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          len++;
+        }
+
+        // For the null terminator too.
+        len++;
+      }
+
+      used_environment = SUBPROCESS_CAST(char *, _alloca(len));
+
+      // Re-use len for the insertion position
+      len = 0;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          used_environment[len++] = environment[i][j];
+        }
+
+        used_environment[len++] = '\0';
+      }
+
+      // End with the two null terminators.
+      used_environment[len++] = '\0';
+      used_environment[len++] = '\0';
+    }
+  } else {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (!CreatePipe(&rd, &wr, SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                  0)) {
+    return -1;
+  }
+
+  if (!SetHandleInformation(wr, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, wr), 0);
+
+  if (-1 != fd) {
+    out_process->stdin_file = _fdopen(fd, "wb");
+
+    if (SUBPROCESS_NULL == out_process->stdin_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdInput = rd;
+
+  if (options & subprocess_option_enable_async) {
+    if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+      return -1;
+    }
+  } else {
+    if (!CreatePipe(&rd, &wr,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+      return -1;
+    }
+  }
+
+  if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+  if (-1 != fd) {
+    out_process->stdout_file = _fdopen(fd, "rb");
+
+    if (SUBPROCESS_NULL == out_process->stdout_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdOutput = wr;
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+    startInfo.hStdError = startInfo.hStdOutput;
+  } else {
+    if (options & subprocess_option_enable_async) {
+      if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+        return -1;
+      }
+    } else {
+      if (!CreatePipe(&rd, &wr,
+                      SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+        return -1;
+      }
+    }
+
+    if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+      return -1;
+    }
+
+    fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+    if (-1 != fd) {
+      out_process->stderr_file = _fdopen(fd, "rb");
+
+      if (SUBPROCESS_NULL == out_process->stderr_file) {
+        return -1;
+      }
+    }
+
+    startInfo.hStdError = wr;
+  }
+
+  if (options & subprocess_option_enable_async) {
+    out_process->hEventOutput =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+    out_process->hEventError =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+  } else {
+    out_process->hEventOutput = SUBPROCESS_NULL;
+    out_process->hEventError = SUBPROCESS_NULL;
+  }
+
+  // Combine commandLine together into a single string
+  len = 0;
+  for (i = 0; commandLine[i]; i++) {
+    // for the trailing \0
+    len++;
+
+    // Quote the argument if it has a space in it
+    if (strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL ||
+        commandLine[i][0] == SUBPROCESS_NULL)
+      len += 2;
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          len++;
+        }
+
+        break;
+      case '"':
+        len++;
+        break;
+      }
+      len++;
+    }
+  }
+
+  commandLineCombined = SUBPROCESS_CAST(char *, _alloca(len));
+
+  if (!commandLineCombined) {
+    return -1;
+  }
+
+  // Gonna re-use len to store the write index into commandLineCombined
+  len = 0;
+
+  for (i = 0; commandLine[i]; i++) {
+    if (0 != i) {
+      commandLineCombined[len++] = ' ';
+    }
+
+    need_quoting = strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL ||
+                   commandLine[i][0] == SUBPROCESS_NULL;
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          commandLineCombined[len++] = '\\';
+        }
+
+        break;
+      case '"':
+        commandLineCombined[len++] = '\\';
+        break;
+      }
+
+      commandLineCombined[len++] = commandLine[i][j];
+    }
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+  }
+
+  commandLineCombined[len] = '\0';
+
+  if (!CreateProcessA(
+          SUBPROCESS_NULL,
+          commandLineCombined, // command line
+          SUBPROCESS_NULL,     // process security attributes
+          SUBPROCESS_NULL,     // primary thread security attributes
+          1,                   // handles are inherited
+          flags,               // creation flags
+          used_environment,    // used environment
+          SUBPROCESS_NULL,     // use parent's current directory
+          SUBPROCESS_PTR_CAST(LPSTARTUPINFOA,
+                              &startInfo), // STARTUPINFO pointer
+          SUBPROCESS_PTR_CAST(LPPROCESS_INFORMATION, &processInfo))) {
+    return -1;
+  }
+
+  out_process->hProcess = processInfo.hProcess;
+
+  out_process->hStdInput = startInfo.hStdInput;
+
+  // We don't need the handle of the primary thread in the called process.
+  CloseHandle(processInfo.hThread);
+
+  if (SUBPROCESS_NULL != startInfo.hStdOutput) {
+    CloseHandle(startInfo.hStdOutput);
+
+    if (startInfo.hStdError != startInfo.hStdOutput) {
+      CloseHandle(startInfo.hStdError);
+    }
+  }
+
+  out_process->alive = 1;
+
+  return 0;
+#else
+  int stdinfd[2];
+  int stdoutfd[2];
+  int stderrfd[2];
+  pid_t child;
+  extern char **environ;
+  char *const empty_environment[1] = {SUBPROCESS_NULL};
+  posix_spawn_file_actions_t actions;
+  char *const *used_environment;
+
+  if (subprocess_option_inherit_environment ==
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (0 != pipe(stdinfd)) {
+    return -1;
+  }
+
+  if (0 != pipe(stdoutfd)) {
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr !=
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != pipe(stderrfd)) {
+      return -1;
+    }
+  }
+
+  if (environment) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+    used_environment = SUBPROCESS_CONST_CAST(char *const *, environment);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  } else if (subprocess_option_inherit_environment ==
+             (options & subprocess_option_inherit_environment)) {
+    used_environment = environ;
+  } else {
+    used_environment = empty_environment;
+  }
+
+  if (0 != posix_spawn_file_actions_init(&actions)) {
+    return -1;
+  }
+
+  // Close the stdin write end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdinfd[1])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the read end to stdin
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Close the stdout read end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdoutfd[0])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the write end to stdout
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    // Close the stderr read end
+    if (0 != posix_spawn_file_actions_addclose(&actions, stderrfd[0])) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+    // Map the write end to stdout
+    if (0 != posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+  if (subprocess_option_search_user_path ==
+      (options & subprocess_option_search_user_path)) {
+    if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                          SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                          used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                         SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                         used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+  // Close the stdin read end
+  close(stdinfd[0]);
+  // Store the stdin write end
+  out_process->stdin_file = fdopen(stdinfd[1], "wb");
+
+  // Close the stdout write end
+  close(stdoutfd[1]);
+  // Store the stdout read end
+  out_process->stdout_file = fdopen(stdoutfd[0], "rb");
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+  } else {
+    // Close the stderr write end
+    close(stderrfd[1]);
+    // Store the stderr read end
+    out_process->stderr_file = fdopen(stderrfd[0], "rb");
+  }
+
+  // Store the child's pid
+  out_process->child = child;
+
+  out_process->alive = 1;
+
+  posix_spawn_file_actions_destroy(&actions);
+  return 0;
+#endif
+}
+
+FILE *subprocess_stdin(const struct subprocess_s *const process) {
+  return process->stdin_file;
+}
+
+FILE *subprocess_stdout(const struct subprocess_s *const process) {
+  return process->stdout_file;
+}
+
+FILE *subprocess_stderr(const struct subprocess_s *const process) {
+  if (process->stdout_file != process->stderr_file) {
+    return process->stderr_file;
+  } else {
+    return SUBPROCESS_NULL;
+  }
+}
+
+int subprocess_join(struct subprocess_s *const process,
+                    int *const out_return_code) {
+#if defined(_WIN32)
+  const unsigned long infinite = 0xFFFFFFFF;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->hStdInput) {
+    CloseHandle(process->hStdInput);
+    process->hStdInput = SUBPROCESS_NULL;
+  }
+
+  WaitForSingleObject(process->hProcess, infinite);
+
+  if (out_return_code) {
+    if (!GetExitCodeProcess(
+            process->hProcess,
+            SUBPROCESS_PTR_CAST(unsigned long *, out_return_code))) {
+      return -1;
+    }
+  }
+
+  process->alive = 0;
+
+  return 0;
+#else
+  int status;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->child) {
+    if (process->child != waitpid(process->child, &status, 0)) {
+      return -1;
+    }
+
+    process->child = 0;
+
+    if (WIFEXITED(status)) {
+      process->return_status = WEXITSTATUS(status);
+    } else {
+      process->return_status = EXIT_FAILURE;
+    }
+
+    process->alive = 0;
+  }
+
+  if (out_return_code) {
+    *out_return_code = process->return_status;
+  }
+
+  return 0;
+#endif
+}
+
+int subprocess_destroy(struct subprocess_s *const process) {
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->stdout_file) {
+    fclose(process->stdout_file);
+
+    if (process->stdout_file != process->stderr_file) {
+      fclose(process->stderr_file);
+    }
+
+    process->stdout_file = SUBPROCESS_NULL;
+    process->stderr_file = SUBPROCESS_NULL;
+  }
+
+#if defined(_WIN32)
+  if (process->hProcess) {
+    CloseHandle(process->hProcess);
+    process->hProcess = SUBPROCESS_NULL;
+
+    if (process->hStdInput) {
+      CloseHandle(process->hStdInput);
+    }
+
+    if (process->hEventOutput) {
+      CloseHandle(process->hEventOutput);
+    }
+
+    if (process->hEventError) {
+      CloseHandle(process->hEventError);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+int subprocess_terminate(struct subprocess_s *const process) {
+#if defined(_WIN32)
+  unsigned int killed_process_exit_code;
+  int success_terminate;
+  int windows_call_result;
+
+  killed_process_exit_code = 99;
+  windows_call_result =
+      TerminateProcess(process->hProcess, killed_process_exit_code);
+  success_terminate = (windows_call_result == 0) ? 1 : 0;
+  return success_terminate;
+#else
+  int result;
+  result = kill(process->child, 9);
+  return result;
+#endif
+}
+
+unsigned subprocess_read_stdout(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventOutput;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stdout_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stdout_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+unsigned subprocess_read_stderr(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventError;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stderr_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stderr_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+int subprocess_alive(struct subprocess_s *const process) {
+  int is_alive = SUBPROCESS_CAST(int, process->alive);
+
+  if (!is_alive) {
+    return 0;
+  }
+#if defined(_WIN32)
+  {
+    const unsigned long zero = 0x0;
+    const unsigned long wait_object_0 = 0x00000000L;
+
+    is_alive = wait_object_0 != WaitForSingleObject(process->hProcess, zero);
+  }
+#else
+  {
+    int status;
+    is_alive = 0 == waitpid(process->child, &status, WNOHANG);
+
+    // If the process was successfully waited on we need to cleanup now.
+    if (!is_alive) {
+      if (WIFEXITED(status)) {
+        process->return_status = WEXITSTATUS(status);
+      } else {
+        process->return_status = EXIT_FAILURE;
+      }
+
+      // Since we've already successfully waited on the process, we need to wipe
+      // the child now.
+      process->child = 0;
+
+      if (subprocess_join(process, SUBPROCESS_NULL)) {
+        return -1;
+      }
+    }
+  }
+#endif
+
+  if (!is_alive) {
+    process->alive = 0;
+  }
+
+  return is_alive;
+}
+
+#if defined(__clang__)
+#if __has_warning("-Wunsafe-buffer-usage")
+#pragma clang diagnostic pop
+#endif
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif /* SHEREDOM_SUBPROCESS_H_INCLUDED */

--- a/tests/common/utils/executable.h
+++ b/tests/common/utils/executable.h
@@ -1,0 +1,42 @@
+/**
+ * @file utils/executable.h
+ * @brief High-level manipulation and running of executables
+ */
+
+#pragma once
+
+#include <doctest/parts/private/context_state.h>
+#include <utils/subprocess.h>
+
+#include <string>
+#include <vector>
+
+namespace utils {
+
+class executable {
+private:
+  std::string _exe;
+
+  inline executable(std::string exe) noexcept
+    : _exe(exe)
+  { }
+
+public:
+  /** @return the currentely running executable */
+  static executable current() noexcept {
+    return { doctest::detail::g_cs->binary_name.c_str() };
+  }
+
+  /**
+   * Runs the executable with the given args,
+   * and either produces a run_result or raises an error
+   */
+  subprocess::result run(std::vector<std::string> args) const {
+    const auto options = subprocess::option::inherit_environment
+                       | subprocess::option::no_window
+                       | subprocess::option::search_user_path;
+    return subprocess::run(_exe, args, options);
+  }
+};
+
+} // namespace utils

--- a/tests/common/utils/subprocess.h
+++ b/tests/common/utils/subprocess.h
@@ -1,0 +1,111 @@
+/**
+ * @file utils/subprocess.h
+ * @brief C++ convenience wrapper around sheredom/subprocess.h
+ */
+
+#pragma once
+
+#include <doctest/parts/public/warnings.h>
+
+#include <utils/text.h>
+
+#include <stdexcept>
+#include <array>
+#include <string>
+#include <vector>
+#include <cerrno>
+
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wgnu-anonymous-struct")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wnested-anon-types")
+#include "thirdparty/subprocess.h"
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+namespace utils {
+namespace subprocess {
+
+#if defined(__cpp_exceptions)
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wweak-vtables")
+class error : public std::runtime_error {
+public:
+  using runtime_error::runtime_error;
+};
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#endif // defined(__cpp_exceptions)
+
+namespace detail {
+
+/** -fno-exceptions friendly throw() method */
+[[noreturn]] inline void fail(const char *reason) {
+  static_cast<void>(reason);
+#if defined(__cpp_exceptions)
+  throw subprocess::error(reason);
+#else
+  std::abort();
+#endif // defined(__cpp_exceptions)
+}
+
+/** @return the contents of @p{fp} */
+inline std::string read(FILE *fp) {
+  auto result = std::string { };
+  auto block  = std::array<char, 256u> { };
+  while (!std::feof(fp) && std::fgets(block.data(), static_cast<int>(block.size()), fp)) {
+    result.append(block.data());
+  }
+
+  if (std::ferror(fp)) {
+    detail::fail("failed to read");
+  }
+
+  return result;
+}
+
+} // namespace detail
+
+enum class option : int {
+  combined_stdout_stderr = subprocess_option_combined_stdout_stderr,
+  inherit_environment    = subprocess_option_inherit_environment,
+  enable_async           = subprocess_option_enable_async,
+  no_window              = subprocess_option_no_window,
+  search_user_path       = subprocess_option_search_user_path,
+};
+
+inline option operator|(option lhs, option rhs) noexcept {
+  return static_cast<option>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4820)
+struct result {
+  int exit_code;
+  std::string out;
+  std::string err;
+
+  inline bool ok() const noexcept { return exit_code == 0; }
+};
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+static result run(std::string exe, std::vector<std::string> args, option options) {
+  auto command_line = std::vector<const char *> { };
+  command_line.push_back(exe.c_str());
+  for (const auto &arg: args) { command_line.push_back(arg.c_str()); }
+  command_line.push_back(nullptr);
+
+  auto state = subprocess_s { };
+  if (subprocess_create(command_line.data(), static_cast<int>(options), &state) != 0) {
+    detail::fail("failed to spawn process");
+  }
+
+  auto exit_code = int { };
+  if (subprocess_join(&state, &exit_code) != 0) {
+    detail::fail("failed to join process");
+  }
+
+  return {
+    exit_code,
+    text::sanitize(detail::read(subprocess_stdout(&state))),
+    text::sanitize(detail::read(subprocess_stderr(&state))),
+  };
+}
+
+} // namespace subprocess
+} // namespace utils

--- a/tests/common/utils/test_case.h
+++ b/tests/common/utils/test_case.h
@@ -1,0 +1,117 @@
+/**
+ * @file utils/test_case.h
+ * @brief High-level manipulation of the active test-case
+ */
+
+#include <doctest/parts/private/context_state.h>
+#include <utils/subprocess.h>
+#include <utils/executable.h>
+#include <string>
+#include <vector>
+
+namespace utils {
+
+/** Identifier for a test-case */
+class test_case
+{
+public:
+  class options {
+  private:
+    bool _junit              = false; ///< --reporters=junit
+    bool _xml                = false; ///< --reporters=xml
+    bool _success            = false; ///< --success
+    bool _no_intro           = true;  ///< --no-intro
+    bool _no_version         = true;  ///< --no-version
+    bool _no_colors          = true;  ///< --no-colors
+    bool _no_path_filenames  = true;  ///< --no-path-filenames
+    bool _no_skipped_summary = true;  ///< --no-skipped-summary
+    bool _no_time_in_output  = true;  ///< --no-time-in-output
+    bool _gnu_file_line      = true;  ///< --gnu-file-line
+
+  public:
+    /** Default-constructor */
+    inline options();
+
+    #define ACCESSORS(symbol)                                           \
+      decltype(DOCTEST_CAT(_,symbol)) symbol () const noexcept {        \
+        return DOCTEST_CAT(_,symbol);                                   \
+      }                                                                 \
+      options symbol (decltype(DOCTEST_CAT(_,symbol)) value) noexcept { \
+        auto result = *this;                                            \
+        result.DOCTEST_CAT(_,symbol) = value;                           \
+        return result;                                                  \
+      }
+    ACCESSORS(junit)
+    ACCESSORS(xml)
+    ACCESSORS(success)
+    ACCESSORS(no_intro)
+    ACCESSORS(no_version)
+    ACCESSORS(no_colors)
+    ACCESSORS(no_path_filenames)
+    ACCESSORS(no_skipped_summary)
+    ACCESSORS(no_time_in_output)
+    ACCESSORS(gnu_file_line)
+    #undef ACCESSORS
+  };
+
+private:
+  /** Executable that the test-case lives in */
+  executable _exe;
+
+  /** Test suite identifier */
+  std::string _suite;
+
+  /** Test case identifier */
+  std::string _name;
+
+  /** Subcase identifier */
+  std::string _subcase;
+
+public:
+  /** Constructs a test-case from its triple */
+  inline test_case(std::string suite, std::string name, std::string subcase)
+    : _exe(executable::current()), _suite(suite), _name(name), _subcase(subcase)
+  { }
+
+  /** @return the currently running test case */
+  static inline test_case current() noexcept {
+    const auto &cs = *doctest::detail::g_cs;
+    const auto &tc = *cs.currentTest;
+    if (cs.subcaseStack.empty()) {
+      return test_case(tc.m_test_suite, tc.m_name, "");
+    } else {
+      return test_case(tc.m_test_suite, tc.m_name, cs.subcaseStack.back().m_name.c_str());
+    }
+  }
+
+  /** @return the internal version of the test case */
+  inline test_case internal() noexcept {
+    return test_case("INTERNAL", _name, _subcase);
+  }
+
+  /** @return the result of executing the test case with the specified options */
+  inline subprocess::result run(options opts = { }) {
+    auto args = std::vector<std::string> { };
+
+    if (!_suite.empty())           args.push_back("-ts=" + _suite);
+    if (!_name.empty())            args.push_back("-tc=" + _name);
+    if (!_subcase.empty())         args.push_back("-sc=" + _subcase);
+    if (opts.junit())              args.push_back("--reporters=junit");
+    if (opts.xml())                args.push_back("--reporters=xml");
+    if (opts.success())            args.push_back("--success");
+    if (opts.no_intro())           args.push_back("--no-intro");
+    if (opts.no_version())         args.push_back("--no-version");
+    if (opts.no_colors())          args.push_back("--no-colors");
+    if (opts.no_path_filenames())  args.push_back("--no-path-filenames");
+    if (opts.no_skipped_summary()) args.push_back("--no-skipped-summary");
+    if (opts.no_time_in_output())  args.push_back("--no-time-in-output");
+    if (opts.gnu_file_line())      args.push_back("--gnu-file-line");
+
+    return _exe.run(args);
+  }
+};
+
+/** Required to be out-of-line to avoid errors */
+test_case::options::options() = default;
+
+} // namespace utils

--- a/tests/common/utils/text.h
+++ b/tests/common/utils/text.h
@@ -17,6 +17,19 @@ namespace text {
 
 DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 
+/** @return the input string, with @p{\r\n} replaced by @p{\n} */
+inline std::string sanitize(const std::string &text) noexcept {
+    auto result = std::string { };
+    result.reserve(text.size());
+    for (auto index = 0u; index < text.size(); ++index) {
+        if ((index + 1) < text.size() && (text[index] == '\r') && (text[index + 1] == '\n')) {
+            continue;
+        }
+        result += text[index];
+    }
+    return result;
+}
+
 /**
  * Splits the input @p{text} by the specified @p{delimiter}.
  * If @p{keep_ends} is set, then the @p{delimiter} is kept
@@ -62,7 +75,7 @@ inline std::string dedent(const std::string &text) noexcept {
     };
 
     // To support multiline raw-strings, we need to skip the first/last blank line
-    auto lines = split(text);
+    auto lines = split(sanitize(text));
 
     if ((lines.size() > 0) && is_blank(lines.front())) {
         lines.erase(lines.begin());
@@ -75,12 +88,18 @@ inline std::string dedent(const std::string &text) noexcept {
     // Past this point, we need to determine the max. common whitespace, and strip it
     auto prefix = std::numeric_limits<size_t>::max();
     for (const auto &line: lines) {
-        prefix = std::min(prefix, count_char(line, ' '));
+        const auto count = count_char(line, ' ');
+
+        // Likely entire whitespace, trimmed by editor
+        if (is_blank(line) && count == 0) { continue; }
+
+        prefix = std::min(prefix, count);
     }
 
     auto result = std::string();
     for (const auto &line: lines) {
-        result += line.substr(prefix);
+        const auto count = count_char(line, ' ');
+        result += line.substr(std::min(prefix, count));
     }
     return result;
 }

--- a/tests/integration/test_assert_out_of_test_context.cpp
+++ b/tests/integration/test_assert_out_of_test_context.cpp
@@ -1,0 +1,321 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+#include <utils/executable.h>
+#include <utils/text.h>
+#include <map>
+using namespace utils;
+
+
+namespace {
+
+class OneOf {
+private:
+    std::vector<std::string> _choices;
+
+public:
+    inline OneOf(std::initializer_list<std::string> choices)
+        : _choices(choices)
+    { }
+
+    inline friend bool operator==(const std::string &lhs, const OneOf &rhs) noexcept {
+        for (const auto &choice: rhs._choices) {
+            if (lhs == choice ) { return true; }
+        }
+        return false;
+    }
+};
+
+} // namespace
+
+namespace handlers {
+
+inline void no_op(const doctest::AssertData &data) {
+    static_cast<void>(data);
+}
+
+inline void log_and_continue(const doctest::AssertData &data) {
+    std::cout << doctest::failureString(data.m_at) << ": " << data.m_decomp.c_str() << std::endl;
+}
+
+[[noreturn]] inline void log_and_exit(const doctest::AssertData &data) {
+    log_and_continue(data);
+    std::exit(1);
+}
+
+static const auto table = std::map<std::string, doctest::detail::assert_handler> {
+    { "nullptr",          nullptr          },
+    { "no_op",            no_op            },
+    { "log_and_continue", log_and_continue },
+    { "log_and_exit",     log_and_exit     },
+};
+
+} // namespace handlers
+
+
+namespace actions {
+
+inline void passing_warn() { WARN(true); }
+inline void failing_warn() { WARN(false); }
+inline void passing_check() { CHECK(true); }
+inline void failing_check() { CHECK(false); }
+inline void passing_require() { REQUIRE(true); }
+inline void failing_require() { REQUIRE(false); }
+
+static const auto table = std::map<std::string, void(*)()> {
+    { "passing_warn",    passing_warn    },
+    { "failing_warn",    failing_warn    },
+    { "passing_check",   passing_check   },
+    { "failing_check",   failing_check   },
+    { "passing_require", passing_require },
+    { "failing_require", failing_require },
+};
+
+} // namespace actions
+
+
+int main(int argc, char **argv) {
+    doctest::Context ctx { argc, argv };
+
+    const auto handler_iter = (argc >= 3)? handlers::table.find(argv[1]) : handlers::table.end();
+    const auto action_iter  = (argc >= 3)? actions::table.find(argv[2]) : actions::table.end();
+
+    if ((handler_iter != handlers::table.end()) && (action_iter != actions::table.end())) {
+        const auto &handler = handler_iter->second;
+        const auto &action  = action_iter->second;
+
+        ctx.setAsDefaultForAssertsOutOfTestCases();
+        if (handler) { ctx.setAssertHandler(handler); }
+        action();
+        return 0;
+    } else {
+        return doctest::Context(argc, argv).run();
+    }
+}
+
+
+TEST_CASE("User-code containing a single passing WARN-like assertion") {
+    const auto exe = executable::current();
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "passing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "passing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "passing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "passing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+}
+
+
+TEST_CASE("User-code containing a single failing WARN-like assertion") {
+    const auto exe = executable::current();
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "failing_warn" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "failing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "failing_warn" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "WARNING: false\n");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "failing_warn" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "WARNING: false\n");
+    }
+}
+
+
+TEST_CASE("User-code containing a single passing CHECK-like assertion") {
+    const auto exe = executable::current();
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "passing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "passing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "passing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "passing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+}
+
+
+TEST_CASE("User-code containing a single failing CHECK-like assertion") {
+    const auto exe = executable::current();
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "failing_check" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "failing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "failing_check" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "ERROR: false\n");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "failing_check" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "ERROR: false\n");
+    }
+}
+
+
+TEST_CASE("User-code containing a single passing REQUIRE-like assertion") {
+    const auto exe = executable::current();
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "passing_require" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "passing_require" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "passing_require" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "passing_require" });
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+}
+
+
+TEST_CASE("User-code containing a single failing REQUIRE-like assertion") {
+    const auto exe = executable::current();
+
+    const auto unhandled_exception = OneOf {
+        "libc++abi: terminating due to uncaught exception of type doctest::detail::TestFailureException\n", // clang
+        "terminate called after throwing an instance of 'doctest::detail::TestFailureException'\n", // GCC
+        "", // MSVC
+    };
+
+    SUBCASE("With no user-supplied handler") {
+        const auto result = exe.run({ "nullptr", "failing_require" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::no_op") {
+        const auto result = exe.run({ "no_op", "failing_require" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == unhandled_exception);
+        CHECK(result.out == "");
+    }
+
+    SUBCASE("With handlers::log_and_continue") {
+        const auto result = exe.run({ "log_and_continue", "failing_require" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == unhandled_exception);
+        CHECK(result.out == "FATAL ERROR: false\n");
+    }
+
+    SUBCASE("With handlers::log_and_exit") {
+        const auto result = exe.run({ "log_and_exit", "failing_require" });
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == "FATAL ERROR: false\n");
+    }
+}

--- a/tests/integration/test_bdd.cpp
+++ b/tests/integration/test_bdd.cpp
@@ -1,0 +1,94 @@
+#include <doctest/doctest.h>
+#include <utils/test_case.h>
+#include <utils/text.h>
+using namespace utils;
+
+
+SCENARIO("Basic BDD usage" * doctest::test_suite("INTERNAL")) {
+  GIVEN("A precondition") {
+      WHEN("An action") {
+          THEN("An observation") { MESSAGE("Output"); }
+      }
+  }
+}
+
+SCENARIO("Basic BDD usage") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    const auto result = tc.run(opts);
+    CHECK(result.exit_code == 0);
+    CHECK(result.err == "");
+    CHECK(result.out == text::dedent(R"(
+        ===============================================================================
+        test_bdd.cpp:7:
+        TEST SUITE: INTERNAL
+          Scenario: Basic BDD usage
+             Given: A precondition
+              When: An action
+              Then: An observation
+
+        test_bdd.cpp:10: MESSAGE: Output
+
+        ===============================================================================
+        [doctest] test cases: 1 | 1 passed | 0 failed |
+        [doctest] assertions: 0 | 0 passed | 0 failed |
+        [doctest] Status: SUCCESS!
+    )"));
+}
+
+
+SCENARIO("Nested BDD usage" * doctest::test_suite("INTERNAL")) {
+    GIVEN("A precondition") {
+        WHEN("An action") {
+            THEN("First observation") { MESSAGE("Output"); }
+            THEN("Second observation") { MESSAGE("Output"); }
+            THEN("Third observation") { MESSAGE("Output"); }
+        }
+    }
+}
+
+SCENARIO("Nested BDD usage") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    const auto result = tc.run(opts);
+    CHECK(result.exit_code == 0);
+    CHECK(result.err == "");
+    CHECK(result.out == text::dedent(R"(
+        ===============================================================================
+        test_bdd.cpp:41:
+        TEST SUITE: INTERNAL
+          Scenario: Nested BDD usage
+             Given: A precondition
+              When: An action
+              Then: First observation
+
+        test_bdd.cpp:44: MESSAGE: Output
+
+        ===============================================================================
+        test_bdd.cpp:41:
+        TEST SUITE: INTERNAL
+          Scenario: Nested BDD usage
+             Given: A precondition
+              When: An action
+              Then: Second observation
+
+        test_bdd.cpp:45: MESSAGE: Output
+
+        ===============================================================================
+        test_bdd.cpp:41:
+        TEST SUITE: INTERNAL
+          Scenario: Nested BDD usage
+             Given: A precondition
+              When: An action
+              Then: Third observation
+
+        test_bdd.cpp:46: MESSAGE: Output
+
+        ===============================================================================
+        [doctest] test cases: 1 | 1 passed | 0 failed |
+        [doctest] assertions: 0 | 0 passed | 0 failed |
+        [doctest] Status: SUCCESS!
+    )"));
+}

--- a/tests/integration/test_capture.cpp
+++ b/tests/integration/test_capture.cpp
@@ -1,0 +1,60 @@
+#include <doctest/doctest.h>
+#include <doctest/parts/private/reporters/junit.h> // see issue #1035
+#include <doctest/parts/private/reporters/xml.h>
+#include <utils/test_case.h>
+#include <utils/text.h>
+using namespace utils;
+
+// CAPTURE(x) is just an alias to INFO(#x " := ", x)
+// So, we don't really need to test it particularly thoroughly
+// We can observe this aliasing best through the XML reporter,
+// as it has <Info> blocks to record these messages
+
+namespace {
+  constexpr auto x = 1, y = 2, z = 3;
+}
+
+TEST_CASE("Failing CHECK-like assertion" * doctest::test_suite("INTERNAL")) {
+    CAPTURE(x);
+    CHECK(1 + 1 == 2);
+    CAPTURE(y);
+    CHECK(2 + 2 == 5);
+    CAPTURE(z);
+}
+
+TEST_CASE("Failing CHECK-like assertion") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    const auto result = tc.run(opts.xml(true));
+
+    CHECK(result.exit_code != 0);
+    CHECK(result.err == "");
+    CHECK(result.out == text::dedent(R"(
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctest binary="integration_test_capture_cpp">
+          <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+          <TestSuite name="INTERNAL">
+            <TestCase name="Failing CHECK-like assertion" filename="test_capture.cpp" line="17">
+              <Expression success="false" type="CHECK" filename="test_capture.cpp" line="21">
+                <Original>
+                  2 + 2 == 5
+                </Original>
+                <Expanded>
+                  4 == 5
+                </Expanded>
+                <Info>
+                  x := 1
+                </Info>
+                <Info>
+                  y := 2
+                </Info>
+              </Expression>
+              <OverallResultsAsserts successes="1" failures="1" test_case_success="false"/>
+            </TestCase>
+          </TestSuite>
+          <OverallResultsAsserts successes="1" failures="1"/>
+          <OverallResultsTestCases successes="0" failures="1"/>
+        </doctest>
+    )"));
+}

--- a/tests/integration/test_info.cpp
+++ b/tests/integration/test_info.cpp
@@ -1,0 +1,550 @@
+#include <doctest/doctest.h>
+#include <doctest/parts/private/reporters/junit.h> // see issue #1035
+#include <doctest/parts/private/reporters/xml.h>
+#include <utils/test_case.h>
+#include <utils/text.h>
+using namespace utils;
+
+
+TEST_CASE("No interlaced assertions" * doctest::test_suite("INTERNAL")) {
+    INFO("Before");
+    INFO("Middle");
+    INFO("After");
+}
+
+TEST_CASE("No interlaced assertions") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting (without --success)") {
+        const auto result = tc.run(opts.success(false));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            [doctest] test cases: 1 | 1 passed | 0 failed |
+            [doctest] assertions: 0 | 0 passed | 0 failed |
+            [doctest] Status: SUCCESS!
+        )"));
+    }
+
+    SUBCASE("Console reporting (with --success)") {
+        const auto result = tc.run(opts.success(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            [doctest] test cases: 1 | 1 passed | 0 failed |
+            [doctest] assertions: 0 | 0 passed | 0 failed |
+            [doctest] Status: SUCCESS!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_info_cpp" errors="0" failures="0" tests="0">
+                <testcase classname="test_info.cpp" name="No interlaced assertions" status="run"/>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_info_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="No interlaced assertions" filename="test_info.cpp" line="9">
+                  <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="0" failures="0"/>
+              <OverallResultsTestCases successes="1" failures="0"/>
+            </doctest>
+        )"));
+    }
+}
+
+
+TEST_CASE("Failing WARN-like assertion" * doctest::test_suite("INTERNAL")) {
+    INFO("Before");
+    WARN(1 + 1 == 2);
+    INFO("Middle");
+    WARN(2 + 2 == 5);
+    INFO("After");
+}
+
+TEST_CASE("Failing WARN-like assertion") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting (without --success)") {
+        const auto result = tc.run(opts.success(false));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:82:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing WARN-like assertion
+
+            test_info.cpp:86: WARNING: WARN( 2 + 2 == 5 ) is NOT correct!
+              values: WARN( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 1 passed | 0 failed |
+            [doctest] assertions: 0 | 0 passed | 0 failed |
+            [doctest] Status: SUCCESS!
+        )"));
+    }
+
+    SUBCASE("Console reporting (with --success)") {
+        const auto result = tc.run(opts.success(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:82:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing WARN-like assertion
+
+            test_info.cpp:84: SUCCESS: WARN( 1 + 1 == 2 ) is correct!
+              values: WARN( 2 == 2 )
+              logged: Before
+
+            test_info.cpp:86: WARNING: WARN( 2 + 2 == 5 ) is NOT correct!
+              values: WARN( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 1 passed | 0 failed |
+            [doctest] assertions: 0 | 0 passed | 0 failed |
+            [doctest] Status: SUCCESS!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_info_cpp" errors="0" failures="1" tests="0">
+                <testcase classname="test_info.cpp" name="Failing WARN-like assertion" status="run">
+                  <failure message="4 == 5" type="WARN">
+            test_info.cpp:86:
+            WARN( 2 + 2 == 5 ) is NOT correct!
+              values: WARN( 4 == 5 )
+              logged: Before
+                      Middle
+
+                  </failure>
+                </testcase>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_info_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="Failing WARN-like assertion" filename="test_info.cpp" line="82">
+                  <Expression success="false" type="WARN" filename="test_info.cpp" line="86">
+                    <Original>
+                      2 + 2 == 5
+                    </Original>
+                    <Expanded>
+                      4 == 5
+                    </Expanded>
+                    <Info>
+                      Before
+                    </Info>
+                    <Info>
+                      Middle
+                    </Info>
+                  </Expression>
+                  <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="0" failures="0"/>
+              <OverallResultsTestCases successes="1" failures="0"/>
+            </doctest>
+        )"));
+    }
+}
+
+
+TEST_CASE("Failing CHECK-like assertion" * doctest::test_suite("INTERNAL")) {
+    INFO("Before");
+    CHECK(1 + 1 == 2);
+    INFO("Middle");
+    CHECK(2 + 2 == 5);
+    INFO("After");
+}
+
+TEST_CASE("Failing CHECK-like assertion") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting (without --success)") {
+        const auto result = tc.run(opts.success(false));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:204:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing CHECK-like assertion
+
+            test_info.cpp:208: ERROR: CHECK( 2 + 2 == 5 ) is NOT correct!
+              values: CHECK( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 2 | 1 passed | 1 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("Console reporting (with --success)") {
+        const auto result = tc.run(opts.success(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:204:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing CHECK-like assertion
+
+            test_info.cpp:206: SUCCESS: CHECK( 1 + 1 == 2 ) is correct!
+              values: CHECK( 2 == 2 )
+              logged: Before
+
+            test_info.cpp:208: ERROR: CHECK( 2 + 2 == 5 ) is NOT correct!
+              values: CHECK( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 2 | 1 passed | 1 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_info_cpp" errors="0" failures="1" tests="2">
+                <testcase classname="test_info.cpp" name="Failing CHECK-like assertion" status="run">
+                  <failure message="4 == 5" type="CHECK">
+            test_info.cpp:208:
+            CHECK( 2 + 2 == 5 ) is NOT correct!
+              values: CHECK( 4 == 5 )
+              logged: Before
+                      Middle
+
+                  </failure>
+                </testcase>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_info_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="Failing CHECK-like assertion" filename="test_info.cpp" line="204">
+                  <Expression success="false" type="CHECK" filename="test_info.cpp" line="208">
+                    <Original>
+                      2 + 2 == 5
+                    </Original>
+                    <Expanded>
+                      4 == 5
+                    </Expanded>
+                    <Info>
+                      Before
+                    </Info>
+                    <Info>
+                      Middle
+                    </Info>
+                  </Expression>
+                  <OverallResultsAsserts successes="1" failures="1" test_case_success="false"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="1" failures="1"/>
+              <OverallResultsTestCases successes="0" failures="1"/>
+            </doctest>
+        )"));
+    }
+}
+
+
+TEST_CASE("Failing REQUIRE-like assertion" * doctest::test_suite("INTERNAL")) {
+    INFO("Before");
+    REQUIRE(1 + 1 == 2);
+    INFO("Middle");
+    REQUIRE(2 + 2 == 5);
+    INFO("After");
+}
+
+TEST_CASE("Failing REQUIRE-like assertion") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting (without --success)") {
+        const auto result = tc.run(opts.success(false));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:326:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing REQUIRE-like assertion
+
+            test_info.cpp:330: FATAL ERROR: REQUIRE( 2 + 2 == 5 ) is NOT correct!
+              values: REQUIRE( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 2 | 1 passed | 1 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("Console reporting (with --success)") {
+        const auto result = tc.run(opts.success(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:326:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Failing REQUIRE-like assertion
+
+            test_info.cpp:328: SUCCESS: REQUIRE( 1 + 1 == 2 ) is correct!
+              values: REQUIRE( 2 == 2 )
+              logged: Before
+
+            test_info.cpp:330: FATAL ERROR: REQUIRE( 2 + 2 == 5 ) is NOT correct!
+              values: REQUIRE( 4 == 5 )
+              logged: Before
+                      Middle
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 2 | 1 passed | 1 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_info_cpp" errors="0" failures="1" tests="2">
+                <testcase classname="test_info.cpp" name="Failing REQUIRE-like assertion" status="run">
+                  <failure message="4 == 5" type="REQUIRE">
+            test_info.cpp:330:
+            REQUIRE( 2 + 2 == 5 ) is NOT correct!
+              values: REQUIRE( 4 == 5 )
+              logged: Before
+                      Middle
+
+                  </failure>
+                </testcase>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_info_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="Failing REQUIRE-like assertion" filename="test_info.cpp" line="326">
+                  <Expression success="false" type="REQUIRE" filename="test_info.cpp" line="330">
+                    <Original>
+                      2 + 2 == 5
+                    </Original>
+                    <Expanded>
+                      4 == 5
+                    </Expanded>
+                    <Info>
+                      Before
+                    </Info>
+                    <Info>
+                      Middle
+                    </Info>
+                  </Expression>
+                  <OverallResultsAsserts successes="1" failures="1" test_case_success="false"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="1" failures="1"/>
+              <OverallResultsTestCases successes="0" failures="1"/>
+            </doctest>
+        )"));
+    }
+}
+
+
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-noreturn")
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4702)
+TEST_CASE("Abnormal termination" * doctest::test_suite("INTERNAL")) {
+    INFO("Before");
+    CHECK(1 + 1 == 2);
+    INFO("Middle");
+    std::abort();
+    INFO("After");
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+TEST_CASE("Abnormal termination" * doctest::skip()) {
+    /** Currently triggers tsan violations */
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting (without --success)") {
+        const auto result = tc.run(opts.success(false));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:450:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Abnormal termination
+
+            test_info.cpp:450: FATAL ERROR: test case CRASHED: SIGABRT - Abort (abnormal termination) signal
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 1 | 1 passed | 0 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("Console reporting (with --success)") {
+        const auto result = tc.run(opts.success(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_info.cpp:450:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Abnormal termination
+
+            test_info.cpp:452: SUCCESS: CHECK( 1 + 1 == 2 ) is correct!
+              values: CHECK( 2 == 2 )
+              logged: Before
+
+            test_info.cpp:450: FATAL ERROR: test case CRASHED: SIGABRT - Abort (abnormal termination) signal
+
+            ===============================================================================
+            [doctest] test cases: 1 | 0 passed | 1 failed |
+            [doctest] assertions: 1 | 1 passed | 0 failed |
+            [doctest] Status: FAILURE!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_info_cpp" errors="1" failures="0" tests="1">
+                <testcase classname="test_info.cpp" name="Abnormal termination" status="run">
+                  <error message="exception">
+                    SIGABRT - Abort (abnormal termination) signal
+                  </error>
+                </testcase>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code != 0);
+        CHECK(result.err.empty());
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_info_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="Abnormal termination" filename="test_info.cpp" line="450">
+                  <Exception crash="true">
+                    SIGABRT - Abort (abnormal termination) signal
+                  </Exception>
+                  <OverallResultsAsserts successes="1" failures="0" test_case_success="false"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="1" failures="0"/>
+              <OverallResultsTestCases successes="0" failures="1"/>
+            </doctest>
+        )"));
+    }
+}

--- a/tests/integration/test_message.cpp
+++ b/tests/integration/test_message.cpp
@@ -1,0 +1,76 @@
+#include <doctest/doctest.h>
+#include <doctest/parts/private/reporters/junit.h> // see issue #1035
+#include <doctest/parts/private/reporters/xml.h>
+#include <utils/test_case.h>
+#include <utils/text.h>
+using namespace utils;
+
+
+TEST_CASE("Unconditional message" * doctest::test_suite("INTERNAL")) {
+    MESSAGE("Data");
+}
+
+TEST_CASE("Unconditional message") {
+    auto tc   = test_case::current().internal();
+    auto opts = test_case::options();
+
+    SUBCASE("Console reporting") {
+        const auto result = tc.run(opts);
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            ===============================================================================
+            test_message.cpp:9:
+            TEST SUITE: INTERNAL
+            TEST CASE:  Unconditional message
+
+            test_message.cpp:10: MESSAGE: Data
+
+            ===============================================================================
+            [doctest] test cases: 1 | 1 passed | 0 failed |
+            [doctest] assertions: 0 | 0 passed | 0 failed |
+            [doctest] Status: SUCCESS!
+        )"));
+    }
+
+    SUBCASE("JUnit reporting") {
+        const auto result = tc.run(opts.junit(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites>
+              <testsuite name="integration_test_message_cpp" errors="0" failures="0" tests="0">
+                <testcase classname="test_message.cpp" name="Unconditional message" status="run"/>
+              </testsuite>
+            </testsuites>
+        )"));
+    }
+
+    SUBCASE("XML reporting") {
+        const auto result = tc.run(opts.xml(true));
+
+        CHECK(result.exit_code == 0);
+        CHECK(result.err == "");
+        CHECK(result.out == text::dedent(R"(
+            <?xml version="1.0" encoding="UTF-8"?>
+            <doctest binary="integration_test_message_cpp">
+              <Options order_by="file" rand_seed="0" first="0" last="4294967295" abort_after="0" subcase_filter_levels="2147483647" case_sensitive="false" no_throw="false" no_skip="false"/>
+              <TestSuite name="INTERNAL">
+                <TestCase name="Unconditional message" filename="test_message.cpp" line="9">
+                  <Message type="WARNING" filename="test_message.cpp" line="10">
+                    <Text>
+                      Data
+                    </Text>
+                  </Message>
+                  <OverallResultsAsserts successes="0" failures="0" test_case_success="true"/>
+                </TestCase>
+              </TestSuite>
+              <OverallResultsAsserts successes="0" failures="0"/>
+              <OverallResultsTestCases successes="1" failures="0"/>
+            </doctest>
+        )"));
+    }
+}


### PR DESCRIPTION
## Description

Adds project integration tests. These are intended to be replacements for the existing `examples/` tests, which will be later replaced with more accessible, user-oriented examples.


## GitHub Issues

#1007