### PR TITLE
ci: Add job to check clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,79 @@
+name: Clang-Format
+
+on:
+  push:
+    branches: [dev, master]
+    paths-ignore:
+      - "doc/**"
+      - "scripts/**"
+      - "LICENSE.txt"
+      - "README.md"
+
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "scripts/**"
+      - "LICENSE.txt"
+      - "README.md"
+
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|clang-format
+  cancel-in-progress: true
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+    env:
+      LLVM_VERSION: 22
+      DIRECTORIES: >-
+        doctest/parts
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure LLVM Upstream
+        run: |
+          # See apt.llvm.org
+          wget -qO- http://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+
+          sudo add-apt-repository \
+            "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ env.LLVM_VERSION}} main"
+
+      - name: Install
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-format-${{ env.LLVM_VERSION }}
+
+      - name: Apply
+        run: |
+          find ${{ env.DIRECTORIES }} \
+            -regextype posix-extended \
+            -regex '^.*\.(cpp|hpp|cxx|hxx|cc|c|h)$' \
+            -exec clang-format-${{ env.LLVM_VERSION }} --style=file -i {} + \
+
+      - name: Diff
+        id: diff
+        run: |
+          git diff | tee clang-format.patch
+          if [[ -s clang-format.patch ]]; then
+            echo "formatted=false" >> $GITHUB_OUTPUT
+          else
+            echo "formatted=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload Patch
+        if: steps.diff.outputs.formatted == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-format.patch
+          path: clang-format.patch
+
+      - name: Block Pipeline
+        if: steps.diff.outputs.formatted == 'false'
+        run: |
+          echo "::error::Code is not formatted!"
+          echo "Either run clang-format-${{ env.LLVM_VERSION }} locally,"
+          echo "or download the clang-format.patch file and apply via"
+          echo "$ git apply clang-format.patch"
+          exit 1

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5189,8 +5189,10 @@ void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
     if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||                     \
         parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))                      \
         p->var = static_cast<bool>(intRes);                                                                            \
-    else if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                              \
-             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                                               \
+    else if (                                                                                                          \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                                   \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname)                                                     \
+    )                                                                                                                  \
         p->var = true;                                                                                                 \
     else if (withDefaults)                                                                                             \
     p->var = default
@@ -8276,10 +8278,12 @@ Subcase::Subcase(const String &name, const char *file, int line)
             g_cs->currentSubcaseDepth++;
             m_entered = true;
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-        } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
-                   g_cs->fullyTraversedSubcases.find(
-                       hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
-                   ) == g_cs->fullyTraversedSubcases.end()) {
+        } else if (
+            g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+            g_cs->fullyTraversedSubcases.find(
+                hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
+            ) == g_cs->fullyTraversedSubcases.end()
+        ) {
             if (checkFilters()) {
                 return;
             }

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -254,8 +254,10 @@ void Context::parseArgs(int argc, const char *const *argv, bool withDefaults) {
     if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||                     \
         parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))                      \
         p->var = static_cast<bool>(intRes);                                                                            \
-    else if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                              \
-             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                                               \
+    else if (                                                                                                          \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                                                   \
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname)                                                     \
+    )                                                                                                                  \
         p->var = true;                                                                                                 \
     else if (withDefaults)                                                                                             \
     p->var = default

--- a/doctest/parts/private/subcase.cpp
+++ b/doctest/parts/private/subcase.cpp
@@ -94,10 +94,12 @@ Subcase::Subcase(const String &name, const char *file, int line)
             g_cs->currentSubcaseDepth++;
             m_entered = true;
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
-        } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
-                   g_cs->fullyTraversedSubcases.find(
-                       hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
-                   ) == g_cs->fullyTraversedSubcases.end()) {
+        } else if (
+            g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth &&
+            g_cs->fullyTraversedSubcases.find(
+                hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature))
+            ) == g_cs->fullyTraversedSubcases.end()
+        ) {
             if (checkFilters()) {
                 return;
             }


### PR DESCRIPTION
## Description

Adds `.github/workflows/clang-format.yml`, which provides a `clang-format` job to check that our source-files adhere to the project `.clang-format` file. If failures occur, a `clang-format.patch` file will be uploaded, which can be applied via `git apply clang-format.patch` to apply formatting fixes and fix the job.

~~Currently this will break as our code does not adhere to the `.clang-format` file. This will be fixed in #1015~~

## GitHub Issues

Relates to #1015 