### PR TITLE
feat: Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.8
+    hooks:
+      - id: clang-format
+        types: [c++]
+        exclude: |
+          (?x)^(
+            doctest/doctest\.h|
+            examples/.*|
+            scripts/.*|
+            tests/.*
+          )$
+
+  - repo: local
+    hooks:
+      - id: assemble-doctest
+        name: assemble doctest.h
+        language: python
+        entry: python scripts/assemble.py
+        pass_filenames: false
+        files: ^(scripts/assemble.py$|doctest/.*)


### PR DESCRIPTION
- Companion to #1038

## Description
Add the pre-commit framework[^1] to the repository, to help catch errors/issues as early as possible. Only includes two hooks for the time being: `clang-format` for `doctest/(extensions|parts)/*`, and `doctest.h` auto-assembly if the builder or `doctest/parts/*` are changed. As `clang-format` is rolled out to more of the repo, the `exclude` list can be adjusted to check those files too

[^1]: https://pre-commit.com/