### PR TITLE
doc: Correct skip-path-prefixes to strip-file-prefixes

### DIFF
--- a/doc/markdown/commandline.md
+++ b/doc/markdown/commandline.md
@@ -6,7 +6,7 @@
 
 **Int/String options** - they require a value after the ```=``` sign - without spaces! For example: ```--order-by=rand```.
 
-**Bool options** - they expect ```1```/```yes```/```on```/```true``` or ```0```/```no```/```off```/```false``` after the ```=``` sign - but they can also be used like flags and the ```=value``` part can be skipped - then ```true``` is assumed.  
+**Bool options** - they expect ```1```/```yes```/```on```/```true``` or ```0```/```no```/```off```/```false``` after the ```=``` sign - but they can also be used like flags and the ```=value``` part can be skipped - then ```true``` is assumed.
 
 **Filters** - a comma-separated list of wildcards for matching values - where ```*``` means "match any sequence" and ```?``` means "match any one character".
 To pass patterns with intervals use ```""``` like this:  ```--test-case="*no sound*,vaguely named test number ?"```. Patterns that contain a comma or a backslash can be escaped with ```\``` (example: ```--test-case=this\,test\,has\,commas\,and\,a\\\,backslash\,followed\,by\,a\,comma```).
@@ -58,7 +58,7 @@ All the options can also be set with code (defaults/overrides) if the user [**su
 | ```-ns``` &nbsp; ```--no-skip=<bool>``` | Don't skip test cases marked as skip with a decorator |
 | ```-gfl``` ```--gnu-file-line=<bool>``` | ```:n:``` vs ```(n):``` for line numbers in output (gnu mode is usually for linux tools/IDEs and is with the ```:``` separator) |
 | ```-npf``` ```--no-path-filenames=<bool>``` | Paths are removed from the output when a filename is printed - useful if you want the same output from the testing framework on different environments |
-| ```-spp``` ```--skip-path-prefixes=<string>``` | Remove the longest matching one in [**a list of prefixes**](configuration.md#doctest_config_options_file_prefix_separator) from any file path in the output - similar to ```-npf```, but can preserve some context by not removing the entire relative paths. Try: ```--spp=${CMAKE_SOURCE_DIR}/:${CMAKE_BINARY_DIR}/``` |
+| ```-sfp``` ```--strip-file-prefixes=<string>``` | Remove the longest matching one in [**a list of prefixes**](configuration.md#doctest_config_options_file_prefix_separator) from any file path in the output - similar to ```-npf```, but can preserve some context by not removing the entire relative paths. Try: ```--sfp=${CMAKE_SOURCE_DIR}/:${CMAKE_BINARY_DIR}/``` |
 | ```-nln``` ```--no-line-numbers=<bool>``` | Line numbers are replaced with ```0``` in the output when a source location is printed - useful if you want the same output from the testing framework even when test positions change within a source file |
 | ```-ndo``` ```--no-debug-output=<bool>``` | Disables output in the debug console when a debugger is attached |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| |

--- a/doc/markdown/configuration.md
+++ b/doc/markdown/configuration.md
@@ -153,8 +153,8 @@ This should be defined only in the source file where the library is implemented 
 
 ### **```DOCTEST_CONFIG_OPTIONS_FILE_PREFIX_SEPARATOR```**
 
-Use the [**command line**](commandline.md) option ```-spp``` to strip the longest matching in a list of prefixes from all file names in the output.
-The prefixes are passed as a single string that gets split at this separator character, ```':'``` by default. 
+Use the [**command line**](commandline.md) option ```-sfp``` to strip the longest matching in a list of prefixes from all file names in the output.
+The prefixes are passed as a single string that gets split at this separator character, ```':'``` by default.
 
 ### **```DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS```**
 

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6543,7 +6543,7 @@ void ConsoleReporter::printHelp() {
       << Whitespace(sizePrefixDisplay * 1) << ":n: vs (n): for line numbers in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
       << Whitespace(sizePrefixDisplay * 1) << "only filenames and no paths in output\n";
-    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "spp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "skip-path-prefixes=<p1:p2>    "
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "strip-file-prefixes=<p1:p2>   "
       << Whitespace(sizePrefixDisplay * 1) << "whenever file paths start with this prefix, remove it from the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
       << Whitespace(sizePrefixDisplay * 1) << "0 instead of real line numbers in output\n";

--- a/doctest/parts/private/reporters/console.cpp
+++ b/doctest/parts/private/reporters/console.cpp
@@ -222,7 +222,7 @@ void ConsoleReporter::printHelp() {
       << Whitespace(sizePrefixDisplay * 1) << ":n: vs (n): for line numbers in output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
       << Whitespace(sizePrefixDisplay * 1) << "only filenames and no paths in output\n";
-    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "spp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "skip-path-prefixes=<p1:p2>    "
+    s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "sfp, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "strip-file-prefixes=<p1:p2>   "
       << Whitespace(sizePrefixDisplay * 1) << "whenever file paths start with this prefix, remove it from the output\n";
     s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
       << Whitespace(sizePrefixDisplay * 1) << "0 instead of real line numbers in output\n";

--- a/examples/all_features/test_output/help.txt
+++ b/examples/all_features/test_output/help.txt
@@ -57,7 +57,7 @@
  -ns,  --no-skip=<bool>                don't skip test cases marked as skip
  -gfl, --gnu-file-line=<bool>          :n: vs (n): for line numbers in output
  -npf, --no-path-filenames=<bool>      only filenames and no paths in output
- -spp, --skip-path-prefixes=<p1:p2>    whenever file paths start with this prefix, remove it from the output
+ -sfp, --strip-file-prefixes=<p1:p2>   whenever file paths start with this prefix, remove it from the output
  -nln, --no-line-numbers=<bool>        0 instead of real line numbers in output
 
 [doctest] for more information visit the project documentation


### PR DESCRIPTION
## Description

Updates references from `skip-path-prefixes` to `strip-file-prefixes`, which is what the implementation actually respects. Ditto for `spp` to `sfp`.

`context.cpp` parses `sfp` / `strip-file-prefixes`, which establishes this as the correct behaviour. The documentation and the `console.cpp` help-text instead report `spp` / `skip-path-prefixes`.

<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues

Fixes #1017 