### PR TITLE
fix: Fully implement IReporter even if library is disabled

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6201,6 +6201,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
+DOCTEST_DEFINE_INTERFACE(IReporter)
+
 int IReporter::get_num_active_contexts() {
     return 0;
 }

--- a/doctest/parts/private/reporter.cpp
+++ b/doctest/parts/private/reporter.cpp
@@ -8,6 +8,8 @@ DOCTEST_SUPPRESS_PRIVATE_WARNINGS_PUSH
 namespace doctest {
 #ifdef DOCTEST_CONFIG_DISABLE
 
+DOCTEST_DEFINE_INTERFACE(IReporter)
+
 int IReporter::get_num_active_contexts() {
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,3 +113,4 @@ doctest_add_unit_test(
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.630.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.651.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.786.cpp)
+doctest_add_unit_test(          SOURCE regression/test.873.cpp)

--- a/tests/regression/test.873.cpp
+++ b/tests/regression/test.873.cpp
@@ -1,0 +1,38 @@
+#define DOCTEST_CONFIG_DISABLE
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+namespace {
+
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+DOCTEST_MSVC_SUPPRESS_WARNING(4625)
+DOCTEST_MSVC_SUPPRESS_WARNING(5026)
+DOCTEST_MSVC_SUPPRESS_WARNING(4626)
+DOCTEST_MSVC_SUPPRESS_WARNING(5027)
+class reporter : public doctest::IReporter {
+public:
+    inline void report_query(const doctest::QueryData &) override { }
+    inline void test_run_start() override { }
+    inline void test_run_end(const doctest::TestRunStats &) override { }
+    inline void test_case_start(const doctest::TestCaseData &) override { }
+    inline void test_case_reenter(const doctest::TestCaseData &) override { }
+    inline void test_case_end(const doctest::CurrentTestCaseStats &) override { }
+    inline void test_case_exception(const doctest::TestCaseException &) override { }
+    inline void subcase_start(const doctest::SubcaseSignature &) override { }
+    inline void subcase_end() override { }
+    inline void log_assert(const doctest::AssertData &) override { }
+    inline void log_message(const doctest::MessageData &) override { }
+    inline void test_case_skipped(const doctest::TestCaseData &) override { }
+};
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+} // namespace
+
+int main() {
+  reporter r;
+  static_cast<void>(r);
+
+  // Required to fix issues with xcode optimizing away `main`
+  volatile int result = 0;
+  return result;
+}


### PR DESCRIPTION
## Description

Adds a missing `DOCTEST_DEFINE_INTERFACE(IReporter)` statement in `reporter.cpp` when `DOCTEST_CONFIG_DISABLE` is set.

Required to ensure that, if under strict linkage requirements, all symbols are implemented.

## GitHub Issues

Fixes #873