### PR TITLE
fix: Include csignal only if POSIX_SIGNALS or WINDOWS_SEH is defined

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -3787,7 +3787,9 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <unordered_set>
 #include <exception>
 #include <stdexcept>
+#if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #include <csignal>
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS
 #include <cfloat>
 #include <cctype>
 #include <cstdint>

--- a/doctest/parts/private/prelude.h
+++ b/doctest/parts/private/prelude.h
@@ -46,7 +46,9 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <unordered_set>
 #include <exception>
 #include <stdexcept>
+#if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #include <csignal>
+#endif // DOCTEST_CONFIG_POSIX_SIGNALS
 #include <cfloat>
 #include <cctype>
 #include <cstdint>


### PR DESCRIPTION
## Description

Replays a7c56b3149627645aac025ab825e2ca7f4e7df8d with further additions to accommodate SEH code

## GitHub Issues

Fixes #177