### PR TITLE
feat: Use __builtin_debugtrap where available

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -524,6 +524,12 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
+#if defined(__has_builtin)
+#define DOCTEST_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define DOCTEST_HAS_BUILTIN(x) 0
+#endif // __has_builtin
+
 #endif // DOCTEST_PARTS_PUBLIC_CONFIG
 
 // =================================================================================================
@@ -583,8 +589,12 @@ DOCTEST_SUPPRESS_PUBLIC_WARNINGS_POP
 
 
 #ifndef DOCTEST_BREAK_INTO_DEBUGGER
+
 // should probably take a look at https://github.com/scottt/debugbreak
-#ifdef DOCTEST_PLATFORM_LINUX
+#if DOCTEST_CLANG && DOCTEST_HAS_BUILTIN(__builtin_debugtrap)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __builtin_debugtrap()
+
+#elif defined(DOCTEST_PLATFORM_LINUX)
 #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
 // Break at the location of the failing check if possible
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
@@ -594,6 +604,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
 #endif
+
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
@@ -604,8 +615,10 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
+
 #elif DOCTEST_MSVC
 #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+
 #elif defined(__MINGW32__)
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wredundant-decls")
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();

--- a/doctest/parts/public/config.h
+++ b/doctest/parts/public/config.h
@@ -193,6 +193,12 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #endif // DOCTEST_CONFIG_USE_STD_HEADERS
 
+#if defined(__has_builtin)
+#define DOCTEST_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define DOCTEST_HAS_BUILTIN(x) 0
+#endif // __has_builtin
+
 #endif // DOCTEST_PARTS_PUBLIC_CONFIG
 
 // =================================================================================================

--- a/doctest/parts/public/debugger.h
+++ b/doctest/parts/public/debugger.h
@@ -4,8 +4,12 @@
 #include "doctest/parts/public/config.h"
 
 #ifndef DOCTEST_BREAK_INTO_DEBUGGER
+
 // should probably take a look at https://github.com/scottt/debugbreak
-#ifdef DOCTEST_PLATFORM_LINUX
+#if DOCTEST_CLANG && DOCTEST_HAS_BUILTIN(__builtin_debugtrap)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __builtin_debugtrap()
+
+#elif defined(DOCTEST_PLATFORM_LINUX)
 #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
 // Break at the location of the failing check if possible
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
@@ -15,6 +19,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
 #endif
+
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" ::) // NOLINT(hicpp-no-assembler)
@@ -25,8 +30,10 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
 #endif
+
 #elif DOCTEST_MSVC
 #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+
 #elif defined(__MINGW32__)
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wredundant-decls")
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();


### PR DESCRIPTION
## Description

Uses `__builtin_debugtrap` for debugging if it is available.

## GitHub Issues

Fixes #874 