### PR TITLE
chore: Remove funding references and links from docs/ and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,5 @@
 ## Contributing
 
-This library is free, and will stay free but needs your support to sustain its development.
-There are lots of [**new features**](https://github.com/doctest/doctest/issues/600)
-and maintenance to do. If you work for a company using **doctest** or have the means to do so,
-please consider financial support.
-
-[<img src="https://c5.patreon.com/external/logo/become_a_patron_button.png" align="top">](https://www.patreon.com/onqtam)
-[<img src="https://user-images.githubusercontent.com/29021710/150090263-50ce0fa7-7813-4648-8273-fec3bbbd171c.jpg" width=175>](https://www.paypal.me/onqtam/10)
-
 ## Bug reports
 
 Found a bug? Let's make it disappear forever.

--- a/doc/markdown/readme.md
+++ b/doc/markdown/readme.md
@@ -26,13 +26,6 @@ Usage:
 - [Build systems](build-systems.md)
 - [Examples](../../examples)
 
-This library is free, and will stay free but needs your support to sustain its development. There are lots of [**new features**](https://github.com/doctest/doctest/issues/600)
-and maintenance to do. If you work for a company using **doctest** or have the means to do so,
-please consider financial support.
-
-[![Patreon](https://cloud.githubusercontent.com/assets/8225057/5990484/70413560-a9ab-11e4-8942-1a63607c0b00.png)](http://www.patreon.com/onqtam)
-[![PayPal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.me/onqtam/10)
-
 ------------
 
 <p align="center"><img src="../../scripts/data/logo/icon_2.svg"></p>


### PR DESCRIPTION
## Description

Drops even more funding notes missed by #1085 and #1087

## GitHub Issues

N/A