### PR TITLE
ci: Block pull-requests if targeting `master`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,18 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [dev, master]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  forbid-merge-to-master:
+    runs-on: ubuntu-latest
+    if: (github.base_ref == 'master') && (github.head_ref != 'dev')
+
+    steps:
+      - name: Fail
+        run: |
+          echo Pull requests should not target 'master'
+          echo Refer to CONTRIBUTING.md
+          exit 1


### PR DESCRIPTION
## Description

Adds a job which checks if the target branch is `master`, and if the source-branch is not `dev`, blocks the CI. Mostly a way to ensure that people are following `CONTRIBUTING.md` correctly.

## GitHub Issues

N/A