### PR TITLE
fix: Remove the unnecessary link options in doctest.pc.in

### DIFF
--- a/doctest.pc.in
+++ b/doctest.pc.in
@@ -6,5 +6,4 @@ includedir="${prefix}/include"
 Name: @PROJECT_NAME@
 Description: The fastest feature-rich C++11/14/17/20/23 single-header testing framework
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -ldoctest
 Cflags: -I${includedir}


### PR DESCRIPTION
## Description

Cherry-pick of #1099 into v2.5.x

## GitHub Issues

See #1099 