### PR TITLE
build(cmake): Use single-source `doctest.cpp` for `doctest_with_main` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,40 +65,7 @@ endif()
 if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
     add_library(
         ${PROJECT_NAME}_with_main STATIC
-        ${doctest_parts_folder}/private/assert/data.cpp
-        ${doctest_parts_folder}/private/assert/expression.cpp
-        ${doctest_parts_folder}/private/assert/handler.cpp
-        ${doctest_parts_folder}/private/assert/message.cpp
-        ${doctest_parts_folder}/private/assert/result.cpp
-        ${doctest_parts_folder}/private/assert/type.cpp
-        ${doctest_parts_folder}/private/color.cpp
-        ${doctest_parts_folder}/private/context.cpp
-        ${doctest_parts_folder}/private/context/options.cpp
-        ${doctest_parts_folder}/private/context_scope.cpp
-        ${doctest_parts_folder}/private/context_state.cpp
-        ${doctest_parts_folder}/private/debugger.cpp
-        ${doctest_parts_folder}/private/exception_translator.cpp
-        ${doctest_parts_folder}/private/exceptions.cpp
-        ${doctest_parts_folder}/private/filters.cpp
-        ${doctest_parts_folder}/private/main.cpp
-        ${doctest_parts_folder}/private/matchers/approx.cpp
-        ${doctest_parts_folder}/private/matchers/contains.cpp
-        ${doctest_parts_folder}/private/matchers/is_nan.cpp
-        ${doctest_parts_folder}/private/path.cpp
-        ${doctest_parts_folder}/private/traversal.cpp
-        ${doctest_parts_folder}/private/reporter.cpp
-        ${doctest_parts_folder}/private/reporters/common.cpp
-        ${doctest_parts_folder}/private/reporters/console.cpp
-        ${doctest_parts_folder}/private/reporters/debug_output_window.cpp
-        ${doctest_parts_folder}/private/reporters/junit.cpp
-        ${doctest_parts_folder}/private/reporters/xml.cpp
-        ${doctest_parts_folder}/private/signals.cpp
-        ${doctest_parts_folder}/private/string.cpp
-        ${doctest_parts_folder}/private/subcase.cpp
-        ${doctest_parts_folder}/private/test_case.cpp
-        ${doctest_parts_folder}/private/test_suite.cpp
-        ${doctest_parts_folder}/private/timer.cpp
-        ${doctest_parts_folder}/private/xml.cpp
+        ${doctest_folder}/doctest/doctest.cpp
     )
     add_library(${PROJECT_NAME}::${PROJECT_NAME}_with_main ALIAS ${PROJECT_NAME}_with_main)
     target_compile_definitions(${PROJECT_NAME}_with_main PRIVATE

--- a/doctest/doctest.cpp
+++ b/doctest/doctest.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2026 doctest.h Authors
+//
+// Distributed under the MIT Software License
+// See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/MIT
+//
+// The documentation can be found at the library's page:
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "doctest/doctest.h"

--- a/tests/regression/test.915.cpp
+++ b/tests/regression/test.915.cpp
@@ -1,3 +1,9 @@
+// mingw has issues with thread_local in our setup
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define DOCTEST_THREAD_LOCAL /*nothing*/
+#endif
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
## Description

Drops all `parts/*` sources from `doctest_with_main` in favour of a singular `doctest.cpp` source which internally just contains:

```cpp
#define DOCTEST_CONFIG_IMPLEMENT
#include "doctest.h"
```

This should approximate the original `doctest.cpp` file that we use to have in `parts/*` _before_ it was broken down into individual sources. By having a singular source, it should pay down some of the extreme include costs from `prelude.h`. This was benchmarked further to confirm:

```bash
$ hyperfine                                       \
  --warmup 3 --runs 16                          \
  --parameter-list commit "47ce36f,1af15d2"     \
  --setup "git checkout {commit}"               \
  --prepare "ninja -C ${BUILD_DIR} clean"       \
  "ninja -C ${BUILD_DIR} -j1 doctest_with_main" \

Benchmark 1: ninja -C build/gcc -j1 doctest_with_main [47ce36f]
  Time (mean ± σ):     22.884 s ±  0.265 s    [User: 20.518 s, System: 2.342 s]
  Range (min … max):   22.594 s … 23.596 s    16 runs
 
Benchmark 2: ninja -C build/gcc -j1 doctest_with_main [1af15d2]
  Time (mean ± σ):      2.781 s ±  0.247 s    [User: 2.539 s, System: 0.241 s]
  Range (min … max):    2.479 s …  3.261 s    16 runs
 
Summary
  'ninja -C build/gcc -j1 doctest_with_main [1af15d2]' ran
    8.23 ± 0.74 times faster than 'ninja -C build/gcc -j1 doctest_with_main [47ce36f]'
```

In our CMake configuration, we define `DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN` -- the in-source define is just to more adequately indicate that this source will actually provide some implementation.

Long-term, it would be good to provide at-least the following library forms for consumers to pick-and-choose from:

1. **The single-header form**: A dependency that provides _just_ `doctest.h` and nothing else
2. **The single-TU form**: A dependency that provides `doctest.h`, and the accompanying `doctest.cpp` for convenience
3. **The unassembled form**: A dependency that provides all of `parts/*`, primarily for internal testing

All of these should be available via unambiguous names, and _possibly_ aliased to `doctest` / `doctest::doctest` based off a user-supplied option (if this is more convenient to consumers). These targets should also be replicated into the `bazel` and `meson` build system configurations.

## GitHub Issues

Fixes #1102