### PR TITLE
build(cmake): Use single-source `doctest.cpp` for `doctest_with_main` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,40 +65,7 @@ endif()
 if(${DOCTEST_WITH_MAIN_IN_STATIC_LIB})
     add_library(
         ${PROJECT_NAME}_with_main STATIC
-        ${doctest_parts_folder}/private/assert/data.cpp
-        ${doctest_parts_folder}/private/assert/expression.cpp
-        ${doctest_parts_folder}/private/assert/handler.cpp
-        ${doctest_parts_folder}/private/assert/message.cpp
-        ${doctest_parts_folder}/private/assert/result.cpp
-        ${doctest_parts_folder}/private/assert/type.cpp
-        ${doctest_parts_folder}/private/color.cpp
-        ${doctest_parts_folder}/private/context.cpp
-        ${doctest_parts_folder}/private/context/options.cpp
-        ${doctest_parts_folder}/private/context_scope.cpp
-        ${doctest_parts_folder}/private/context_state.cpp
-        ${doctest_parts_folder}/private/debugger.cpp
-        ${doctest_parts_folder}/private/exception_translator.cpp
-        ${doctest_parts_folder}/private/exceptions.cpp
-        ${doctest_parts_folder}/private/filters.cpp
-        ${doctest_parts_folder}/private/main.cpp
-        ${doctest_parts_folder}/private/matchers/approx.cpp
-        ${doctest_parts_folder}/private/matchers/contains.cpp
-        ${doctest_parts_folder}/private/matchers/is_nan.cpp
-        ${doctest_parts_folder}/private/path.cpp
-        ${doctest_parts_folder}/private/traversal.cpp
-        ${doctest_parts_folder}/private/reporter.cpp
-        ${doctest_parts_folder}/private/reporters/common.cpp
-        ${doctest_parts_folder}/private/reporters/console.cpp
-        ${doctest_parts_folder}/private/reporters/debug_output_window.cpp
-        ${doctest_parts_folder}/private/reporters/junit.cpp
-        ${doctest_parts_folder}/private/reporters/xml.cpp
-        ${doctest_parts_folder}/private/signals.cpp
-        ${doctest_parts_folder}/private/string.cpp
-        ${doctest_parts_folder}/private/subcase.cpp
-        ${doctest_parts_folder}/private/test_case.cpp
-        ${doctest_parts_folder}/private/test_suite.cpp
-        ${doctest_parts_folder}/private/timer.cpp
-        ${doctest_parts_folder}/private/xml.cpp
+        ${doctest_folder}/doctest/doctest.cpp
     )
     add_library(${PROJECT_NAME}::${PROJECT_NAME}_with_main ALIAS ${PROJECT_NAME}_with_main)
     target_compile_definitions(${PROJECT_NAME}_with_main PRIVATE

--- a/doctest/doctest.cpp
+++ b/doctest/doctest.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2026 doctest.h Authors
+//
+// Distributed under the MIT Software License
+// See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/MIT
+//
+// The documentation can be found at the library's page:
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "doctest/doctest.h"

--- a/tests/regression/test.915.cpp
+++ b/tests/regression/test.915.cpp
@@ -1,3 +1,9 @@
+// mingw has issues with thread_local in our setup
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define DOCTEST_THREAD_LOCAL /*nothing*/
+#endif
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
## Description

Cherry-pick of #1103 into v2.5.x

## GitHub Issues

See #1103
