### PR TITLE
Fix doctest::Approx when epsilon is 1 or greater

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -204,6 +204,9 @@ REQUIRE(22.0/7 == doctest::Approx(3.141).epsilon(0.01)); // allow for a 1% error
 When dealing with very large or very small numbers it can be useful to specify a scale, which can be achieved by calling
 the `scale()` method on the `doctest::Approx` instance.
 
+`epsilon` is a relative tolerance and is expected to be in the `[0, 1)` range for the usual comparison formula. Values of
+`1.0` or greater are treated as “match anything” (100% tolerance or more).
+
 ## NaN checking
 
 Two NaN floating point numbers do not compare equal to each other. This makes it quite inconvenient to check for NaN

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6529,6 +6529,9 @@ Approx &Approx::scale(double newScale) {
 }
 
 bool operator==(double lhs, const Approx &rhs) {
+    // 100% (or greater) relative tolerance matches any finite comparison operand.
+    if (rhs.m_epsilon >= 1.0)
+        return true;
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -24,6 +24,9 @@ Approx &Approx::scale(double newScale) {
 }
 
 bool operator==(double lhs, const Approx &rhs) {
+    // 100% (or greater) relative tolerance matches any finite comparison operand.
+    if (rhs.m_epsilon >= 1.0)
+        return true;
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));

--- a/tests/doctest/matchers/test_approx.cpp
+++ b/tests/doctest/matchers/test_approx.cpp
@@ -24,6 +24,10 @@ struct bounds {
         if (std::isinf(C)) {
             return {C, C};
         }
+        if (e >= 1.0) {
+            return {std::numeric_limits<double>::lowest(),
+                    std::numeric_limits<double>::max()};
+        }
         const auto min = std::min((C - e * s) / (1 - e), C - e * (s + std::abs(C)));
         const auto max = std::max((C + e * s) / (1 - e), C + e * (s + std::abs(C)));
         return {min, max};
@@ -167,11 +171,11 @@ TEST_CASE("Comparison with finite floating-point values" * doctest::expected_fai
 
     SUBCASE("Matcher focused around 0 with an error of 100% and no scaling") {
         const auto m = Approx(0.0).epsilon(1.0).scale(0);
-        CAPTURE(bounds::determine(m)); // [-NaN, +NaN]
+        CAPTURE(bounds::determine(m)); // [lowest, max]
 
-        CHECK(-epsilon != m);
-        CHECK(     0.0 == m); // FAIL
-        CHECK(+epsilon != m);
+        CHECK(-epsilon == m);
+        CHECK(     0.0 == m);
+        CHECK(+epsilon == m);
     }
 
     SUBCASE("Matcher focused around smallest positive normalized value") {


### PR DESCRIPTION
## Summary

Fixes #1019.

When `epsilon()` is set to `1.0` (100% relative tolerance), `Approx::operator==` now matches any operand instead of using the usual formula (which divides by `1 - epsilon` and misbehaves).

- Document that `[0, 1)` is the normal range and `>= 1` means “match anything”
- Update unit tests for the `epsilon(1.0)` at zero case

## Test plan

- [ ] `tests/doctest/matchers/test_approx.cpp` (CI)