### PR TITLE
fix: avoid SIGSEGV when translating null pointer exceptions

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6384,11 +6384,14 @@ String translateActiveException() noexcept {
     try {
         throw;
     } catch (std::exception &ex) {
-        return ex.what();
+        const char *what = ex.what();
+        return what ? what : "";
     } catch (std::string &msg) {
         return msg.c_str();
+    } catch (std::nullptr_t) {
+        return "nullptr";
     } catch (const char *msg) {
-        return msg;
+        return msg ? msg : "null";
     } catch (...) {
         return "unknown exception";
     }

--- a/doctest/parts/private/exception_translator.cpp
+++ b/doctest/parts/private/exception_translator.cpp
@@ -33,11 +33,14 @@ String translateActiveException() noexcept {
     try {
         throw;
     } catch (std::exception &ex) {
-        return ex.what();
+        const char *what = ex.what();
+        return what ? what : "";
     } catch (std::string &msg) {
         return msg.c_str();
+    } catch (std::nullptr_t) {
+        return "nullptr";
     } catch (const char *msg) {
-        return msg;
+        return msg ? msg : "null";
     } catch (...) {
         return "unknown exception";
     }

--- a/tests/doctest/test_exception_translator.cpp
+++ b/tests/doctest/test_exception_translator.cpp
@@ -5,6 +5,8 @@
 #if !defined(DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS)
 
 #include <doctest/doctest.h>
+
+#include <cstddef>
 #include <type_traits>
 
 namespace {
@@ -78,6 +80,27 @@ TEST_CASE("Translating custom exceptions" * doctest::skip(should_skip())) {
 
         CHECK(result == "exception3");
     }
+}
+
+TEST_CASE("translateActiveException handles nullptr" * doctest::skip(should_skip())) {
+    auto result = with_ambient_exception(std::nullptr_t{}, [] {
+        return doctest::detail::translateActiveException();
+    });
+
+    CHECK(result == "nullptr");
+}
+
+TEST_CASE("translateActiveException handles null char pointer" * doctest::skip(should_skip())) {
+    const char *null_msg = nullptr;
+    auto result = with_ambient_exception(null_msg, [] {
+        return doctest::detail::translateActiveException();
+    });
+
+    CHECK(result == "null");
+}
+
+TEST_CASE("CHECK_NOTHROW does not crash when nullptr is thrown" * doctest::skip(should_skip())) {
+    CHECK_FALSE(CHECK_NOTHROW(throw nullptr));
 }
 
 #endif // !defined(DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS)


### PR DESCRIPTION
## Summary
- Handle `std::nullptr_t` and null `const char*` in `translateActiveException()`.
- Guard `std::exception::what()` when it returns a null pointer.
- Add regression tests for `CHECK_NOTHROW(throw nullptr)` and related cases.

Fixes #1045

## Test plan
- [ ] CI runs exception translator tests on GCC/Clang/MSVC
- [ ] `CHECK_NOTHROW(throw nullptr)` fails the assertion without crashing