### PR TITLE
fix(bench): require compile or runtime subcommand

### DIFF
--- a/scripts/bench/bench.py
+++ b/scripts/bench/bench.py
@@ -27,7 +27,7 @@ def addCommonFlags(parser):
                                                                 help = "<doctest> type of assert used - Catch: only normal")
 
 parser = argparse.ArgumentParser()
-subparsers = parser.add_subparsers()
+subparsers = parser.add_subparsers(dest="command", required=True)
 parser_c = subparsers.add_parser('compile', help='benchmark compile times')
 addCommonFlags(parser_c)
 parser_c.add_argument("--implement",    action = "store_true",  help = "implement the framework test runner")


### PR DESCRIPTION
## Summary
- Mark the `compile` / `runtime` subcommands as required in `scripts/bench/bench.py`.
- Running the script with no arguments now prints argparse usage instead of raising `AttributeError: 'Namespace' object has no attribute 'func'`.

Fixes #889

## Test plan
- [ ] `python3 scripts/bench/bench.py` prints usage and exits non-zero
- [ ] `python3 scripts/bench/bench.py compile gcc` still works