### PR TITLE
fix(bench): bump bundled Catch2 header to v2.13.10

### DIFF
--- a/scripts/bench/bench.py
+++ b/scripts/bench/bench.py
@@ -52,7 +52,7 @@ pprint.pprint(vars(args), width = 1)
 # ==============================================================================
 
 # catch version
-catch_ver = "2.3.0"
+catch_ver = "2.13.10"
 catch_header = "catch." + catch_ver + ".hpp"
 
 # get the catch header


### PR DESCRIPTION
## Summary
- Update the Catch2 single-header version used by `scripts/bench/bench.py` from 2.3.0 to 2.13.10.
- Fixes benchmark builds against recent glibc where Catch 2.3.0 hits non-constexpr `sysconf` in signal stack sizing.

Fixes #890

## Test plan
- [ ] `python3 scripts/bench/bench.py compile gcc --catch --files 1 --tests 1` succeeds (delete cached `catch.2.3.0.hpp` if present)