### PR TITLE
fix: omit failure-message context on successful assertions

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -7262,7 +7262,8 @@ void ConsoleReporter::log_assert(const AssertData &rb) {
 
     fulltext_log_assert_to_stream(s, rb);
 
-    log_contexts();
+    if (rb.m_failed)
+        log_contexts();
 }
 
 void ConsoleReporter::log_message(const MessageData &mb) {
@@ -7789,7 +7790,8 @@ void XmlReporter::log_assert(const AssertData &rb) {
     if ((rb.m_at & assertType::is_normal) && !rb.m_threw)
         xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
-    log_contexts();
+    if (rb.m_failed)
+        log_contexts();
 
     xml.endElement();
 }

--- a/doctest/parts/private/reporters/console.cpp
+++ b/doctest/parts/private/reporters/console.cpp
@@ -429,7 +429,8 @@ void ConsoleReporter::log_assert(const AssertData &rb) {
 
     fulltext_log_assert_to_stream(s, rb);
 
-    log_contexts();
+    if (rb.m_failed)
+        log_contexts();
 }
 
 void ConsoleReporter::log_message(const MessageData &mb) {

--- a/doctest/parts/private/reporters/xml.cpp
+++ b/doctest/parts/private/reporters/xml.cpp
@@ -204,7 +204,8 @@ void XmlReporter::log_assert(const AssertData &rb) {
     if ((rb.m_at & assertType::is_normal) && !rb.m_threw)
         xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
 
-    log_contexts();
+    if (rb.m_failed)
+        log_contexts();
 
     xml.endElement();
 }

--- a/tests/doctest/assert/test_check_message.cpp
+++ b/tests/doctest/assert/test_check_message.cpp
@@ -1,0 +1,12 @@
+#include <doctest/doctest.h>
+
+#include <functional>
+
+TEST_CASE("CHECK_MESSAGE with lambda and MESSAGE") {
+    CHECK_MESSAGE(
+        []() {
+            MESSAGE("message!!");
+            return true;
+        }(),
+        "lambda Failed!!");
+}


### PR DESCRIPTION
## Summary
- Skip `log_contexts()` in console and XML reporters when a logged assertion passed.
- Prevents `CHECK_MESSAGE(..., "failure text")` from printing the failure message under `logged:` on success while still showing nested `MESSAGE()` output via `log_message`.
- Add regression test mirroring the issue reproducer.

Fixes #658

## Test plan
- [ ] `doctest --success` no longer prints `logged: lambda Failed!!` for passing `CHECK_MESSAGE` with lambda
- [ ] Failed `CHECK_MESSAGE` still includes failure context in output
- [ ] CI passes