### PR TITLE
docs: subcase filtering and Approx scale defaults

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -204,6 +204,20 @@ REQUIRE(22.0/7 == doctest::Approx(3.141).epsilon(0.01)); // allow for a 1% error
 When dealing with very large or very small numbers it can be useful to specify a scale, which can be achieved by calling
 the `scale()` method on the `doctest::Approx` instance.
 
+The default `scale()` is `1.0`. Comparisons use:
+
+`fabs(lhs - rhs) < epsilon * (scale + max(fabs(lhs), fabs(rhs)))`
+
+So with the default scale, even a small explicit `epsilon()` still allows a tolerance of at least
+`epsilon * 1.0` before the operand magnitudes add to the budget. For comparisons near zero where
+you want tolerance driven only by `epsilon` and the operand values, call `.scale(0.0)`:
+
+```c++
+CHECK_FALSE(1.0 == doctest::Approx(0.89).epsilon(0.1).scale(0.0));
+```
+
+See [issue #713](https://github.com/doctest/doctest/issues/713) for discussion.
+
 ## NaN checking
 
 Two NaN floating point numbers do not compare equal to each other. This makes it quite inconvenient to check for NaN

--- a/doc/markdown/commandline.md
+++ b/doc/markdown/commandline.md
@@ -36,7 +36,7 @@ All the options can also be set with code (defaults/overrides) if the user [**su
 | `-sfe` `--source-file-exclude=<filters>` | Same as `--test-case-exclude=<filters>` but filters based on the file in which test cases are written |
 | `-ts` &nbsp; `--test-suite=<filters>` | Same as `--test-case=<filters>` but filters based on the test suite in which test cases are in |
 | `-tse` `--test-suite-exclude=<filters>` | Same as `--test-case-exclude=<filters>` but filters based on the test suite in which test cases are in |
-| `-sc` &nbsp; `--subcase=<filters>` | Same as `--test-case=<filters>` but filters subcases based on their names. Does not filter test cases (they have to be executed for subcases to be discovered) so you might want to use this together with `--test-case=<filters>`. This will **not** run any subcases within the selected subcase, however this behaviour will change in v2.6. See #519 for details. |
+| `-sc` &nbsp; `--subcase=<filters>` | Same as `--test-case=<filters>` but filters subcases based on their names. Does not filter test cases (they have to be executed for subcases to be discovered) so you might want to use this together with `--test-case=<filters>`. A matching subcase is entered, but nested subcases are still filtered unless you limit filtering with `--subcase-filter-levels` or target a deeper name. See [Filtering subcases](testcases.md#filtering-subcases) ([#519](https://github.com/doctest/doctest/issues/519)). |
 | `-sce` `--subcase-exclude=<filters>` | Same as `--test-case-exclude=<filters>` but filters based on subcase names |
 | `-r` `--reporters=<filters>` | List of [**reporters**](reporters.md) to use (default is `console`) |
 | `-o` &nbsp; `--out=<string>` | Output filename |

--- a/doc/markdown/testcases.md
+++ b/doc/markdown/testcases.md
@@ -22,6 +22,38 @@ Test cases can also be parameterized - see the [**documentation**](parameterized
 
 Test cases and subcases can be filtered through the use of the [**command line**](commandline.md)
 
+## Filtering subcases
+
+`--subcase=<filters>` (`-sc`) applies a wildcard filter to subcase **names at each nesting
+level** (by default at all levels; see [`--subcase-filter-levels`](commandline.md)). When a
+subcase matches, it is entered, but **deeper nested subcases are still filtered** by the same
+pattern. They are not run unless their names match too.
+
+This differs from an unfiltered run, where doctest executes **one leaf subcase path** per run
+and always enters nested subcases on that path.
+
+Example from [issue #519](https://github.com/doctest/doctest/issues/519):
+
+```cpp
+TEST_CASE("foo") {
+    SUBCASE("bar") {
+        int i{};
+        SUBCASE("baz") { i = 42; }
+        CHECK(i == 42);
+    }
+}
+```
+
+`test.exe -sc=bar` enters `bar` but skips `baz` (the name does not match `bar`), so `i`
+remains `0` and the `CHECK` fails.
+
+**Workarounds:**
+
+- Filter the leaf subcase: `-sc=baz` (and usually `-tc=foo` to limit the test case).
+- Combine patterns: `-sc=bar,baz`.
+- Apply the name filter only at the outer level and run all nested subcases beneath it:
+  `-sc=bar --subcase-filter-levels=1` (`-scfl=1`).
+
 ## BDD-style test cases
 
 In addition to **doctest**'s take on the classic style of test cases, **doctest** supports an alternative syntax


### PR DESCRIPTION
## Summary
- Document how `--subcase` filters nested subcases (#519), including `-scfl=1` and other workarounds
- Update `--subcase` CLI description to match current behavior (remove outdated v2.6 note)
- Explain default `Approx::scale(1.0)` and the tolerance formula (#713)

## Test plan
- [x] Doc-only change

Fixes #519
Fixes #713