### PR TITLE
docs: CMake ASAN discovery, char* config, HTTPS BDD link

### DIFF
--- a/doc/markdown/build-systems.md
+++ b/doc/markdown/build-systems.md
@@ -114,6 +114,11 @@ target_link_libraries(my_tests doctest)
   from scripts/cmake/doctest.cmake](../../scripts/cmake/doctest.cmake) - read the comments in the file on how to use it.
   It works just like [the same functionality in Catch](https://github.com/catchorg/Catch2/blob/master/docs/cmake-integration.md#automatic-test-registration).
 
+  On **Windows**, if the test executable is built with MSVC AddressSanitizer (`/fsanitize=address`), discovery runs the
+  binary at build time and must be able to load the ASAN runtime DLLs (usually next to the executable). Recent doctest
+  versions prepend the executable directory to `PATH` during discovery ([#836](https://github.com/doctest/doctest/issues/836)).
+  If you use an older release, upgrade or apply the same workaround locally.
+
 ### Package managers
 
 **doctest** is available through the following package managers:

--- a/doc/markdown/configuration.md
+++ b/doc/markdown/configuration.md
@@ -104,6 +104,9 @@ This can be defined both globally and in specific source files only.
 By default `char*` is being treated as a pointer. With this option comparing `char*` pointers will switch to
 using `strcmp()` for comparisons and when stringified the string will be printed instead of the pointer value.
 
+Null pointers and mixed comparisons between string literals and `char*` buffers can behave differently than
+in the default mode; see [issue #707](https://github.com/doctest/doctest/issues/707) for reports and edge cases.
+
 This should be defined globally.
 
 ### **`DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES`**

--- a/doc/markdown/testcases.md
+++ b/doc/markdown/testcases.md
@@ -25,7 +25,7 @@ Test cases and subcases can be filtered through the use of the [**command line**
 ## BDD-style test cases
 
 In addition to **doctest**'s take on the classic style of test cases, **doctest** supports an alternative syntax
-that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](http://dannorth.net/introducing-bdd/)).
+that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](https://dannorth.net/introducing-bdd/)).
 This set of macros map on to `TEST_CASE`s and `SUBCASE`s, with a little internal support to make them smoother to work with.
 
 - **SCENARIO(** _scenario name_ **)**


### PR DESCRIPTION
## Summary
- Document `doctest_discover_tests` and MSVC ASAN on Windows (#836)
- Note `DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING` edge cases (#707)
- Use HTTPS for the BDD intro link in `testcases.md`

## Test plan
- [x] Doc-only change

Relates to #836, #707