### PR TITLE
docs: clarify Approx semantics and SUBCASE setup re-entry

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -166,6 +166,26 @@ REQUIRE(22.0/7 == doctest::Approx(3.141).epsilon(0.01)); // allow for a 1% error
 
 When dealing with very large or very small numbers it can be useful to specify a scale, which can be achieved by calling the ```scale()``` method on the ```doctest::Approx``` instance.
 
+**Comparison semantics:** `lhs` matches `Approx(value)` when
+
+```text
+|lhs - value| < epsilon * (scale + max(|lhs|, |value|))
+```
+
+**Defaults:** `epsilon` defaults to `std::numeric_limits<float>::epsilon() * 100` (about `1.2e-5`), even though comparisons use `double`. `scale` defaults to `1.0`. That is why `CHECK(Approx(0.98765) == 0.98766)` can pass despite an absolute difference of `1e-5`.
+
+**Absolute tolerances:** doctest has no separate absolute `margin()` like Catch2. For a fixed absolute threshold, compare manually:
+
+```c++
+CHECK(std::fabs(a - b) < 1e-12);
+```
+
+Or tune `epsilon()` together with `scale(0)` so `epsilon * max(|lhs|, |value|)` matches your tolerance at the magnitudes you care about:
+
+```c++
+CHECK(lhs == doctest::Approx(rhs).epsilon(1e-12).scale(0));
+```
+
 ## NaN checking
 
 Two NaN floating point numbers do not compare equal to each other. This makes it quite inconvenient to check for NaN while capturing the value.

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -13,6 +13,7 @@
 - [**Can different versions of the framework be used within the same binary (executable/dll)?**](#can-different-versions-of-the-framework-be-used-within-the-same-binary-executabledll)
 - [**Why is doctest using macros?**](#why-is-doctest-using-macros)
 - [**How to use with multiple files?**](#how-to-use-with-multiple-files)
+- [**Why does expensive setup run again for every SUBCASE?**](#why-does-expensive-setup-run-again-for-every-subcase)
 
 ### How is **doctest** different from Catch?
 
@@ -164,11 +165,23 @@ Currently no. Single header libraries like [**stb**](https://github.com/nothings
 
 ### Why is doctest using macros?
 
-Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](http://accu.org/index.php/journals/2064) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
+Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](https://accu.org/index.php/journals/2064) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
 
 ### How to use with multiple files?
 
 All you need to do is define either [**```DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN```**](configuration.md#doctest_config_implement_with_main) or [**```DOCTEST_CONFIG_IMPLEMENT```**](configuration.md#doctest_config_implement) in only ONE of the source files just before including the doctest header - in all other source files you just include the header and use the framework. The difference between the two is that one of them provides a `main()` entry point - for more info on that please refer to [`The main() entry point`](main.md).
+
+### Why does expensive setup run again for every SUBCASE?
+
+By design, the `TEST_CASE` body is **re-entered from the start once per leaf `SUBCASE`**. Code before the first `SUBCASE` therefore runs again for every sibling subcase, and `TEST_CASE_FIXTURE` constructors run on each re-entry as well.
+
+If setup is costly (GPU context, large file load, etc.) and you need deterministic teardown when the whole case finishes, the subcase model does not offer a built-in "run once per `TEST_CASE`" hook today. Practical options:
+
+- **Split scenarios** into separate `TEST_CASE`s without `SUBCASE` when branches do not need a shared subcase tree.
+- **Share state explicitly** with a helper or fixture whose lifetime you control (accepting that teardown timing is your responsibility).
+- **Keep `SUBCASE`s** when the extra setup cost is acceptable for clarity of the tree.
+
+See also the [**tutorial on subcases**](tutorial.md#test-cases-and-subcases) and [issue #1108](https://github.com/doctest/doctest/issues/1108).
 
 ---------------
 


### PR DESCRIPTION
## Summary
- **`assertions.md`**: document `Approx` comparison formula, default `epsilon`/`scale`, and absolute-tolerance workarounds (addresses #389).
- **`faq.md`**: explain why setup before `SUBCASE` runs per leaf and list practical alternatives (addresses #1108).

## Motivation
Users are surprised by default `Approx` tolerances and by expensive setup re-running for every sibling subcase.

## Test plan
- [x] Documentation only.