### PR TITLE
ci: Enable GCC 15 on CI, bump checkout actions

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -30,6 +30,6 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - run: bazelisk test --config=ci ...
       working-directory: examples

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -34,7 +34,7 @@ jobs:
         tests
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Configure LLVM Upstream
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -32,7 +32,7 @@ jobs:
       LLVM_VERSION: 22
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Configure LLVM Upstream
         run: |

--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Generate Single-Header File
         run: python scripts/assemble.py

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install
         run: sudo apt-get install -y ninja-build lcov

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
           - { arch: x86, target: tsan }
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Ref: https://github.com/actions/checkout/issues/1590#issuecomment-2567109195
       - name: Prepare Container
@@ -133,12 +133,12 @@ jobs:
           - { version: "12",  container: ubuntu:24.04, arch: x64, build-type: Release, target: test }
           - { version: "13",  container: ubuntu:24.04, arch: x64, build-type: Release, target: test }
           - { version: "14",  container: ubuntu:24.04, arch: x64, build-type: Release, target: test }
-          - { version: "15",  container: ubuntu:24.04, arch: x64, build-type: Release, target: test }
+          - { version: "15",  container: ubuntu:26.04, arch: x64, build-type: Release, target: test }
         exclude:
           - { arch: x86, target: tsan }
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Ref: https://github.com/actions/checkout/issues/1590#issuecomment-2567109195
       - name: Prepare Container
@@ -186,7 +186,7 @@ jobs:
         compiler: ["icpc", "icx"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -39,7 +39,7 @@ jobs:
           - { os: macos-14, version: "16.2",   arch: arm64, build-type: Release, target: test } # Apple Clang 16.0.0
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install
         run: |
@@ -68,7 +68,7 @@ jobs:
         target:     [test, fno-exceptions, fno-rtti]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install
         run: |

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: DavidAnson/markdownlint-cli2-action@v23
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: git archive $GITHUB_REF -o "doctest-${GITHUB_REF:10}.tar.gz"
       - run: gh release upload ${GITHUB_REF:10} "doctest-${GITHUB_REF:10}.tar.gz"
         env:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
         sanitizers: ["address", "thread", "undefined", "integer", "implicit-conversion", "nullability", "safe-stack"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install
         run: sudo apt-get install -y ninja-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
       CMAKE_GENERATOR: MinGW Makefiles
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up MinGW-w64
         uses: egor-tensin/setup-mingw@v2
@@ -68,7 +68,7 @@ jobs:
           - { compiler: clang-cl, arch: x86 }
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Configure MSVC (x64)
         if:   matrix.arch == 'x64'
@@ -101,7 +101,7 @@ jobs:
         configuration: ["Debug", "Release"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Generate
         run:


### PR DESCRIPTION
## Description
Tweaks the GitHub Actions in two small ways to ensure all runners are successful once more:
- Bumps all checkout actions from v5 to v6 (future-proofing)
- Change GCC 15 Ubuntu runner from 24.04 to 26.04 (`g++-15-multilib` is unavailable on 24.04)

## GitHub Issues
See: https://github.com/doctest/doctest/pull/1067#issuecomment-4473480092