### PR TITLE
fix(Approx): treat epsilon >= 1 as matching any finite value

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -166,6 +166,8 @@ REQUIRE(22.0/7 == doctest::Approx(3.141).epsilon(0.01)); // allow for a 1% error
 
 When dealing with very large or very small numbers it can be useful to specify a scale, which can be achieved by calling the ```scale()``` method on the ```doctest::Approx``` instance.
 
+An epsilon of `1.0` or greater is treated as accepting any finite value (comparisons involving NaN still fail). Values in `[0, 1)` use the relative tolerance formula above.
+
 ## NaN checking
 
 Two NaN floating point numbers do not compare equal to each other. This makes it quite inconvenient to check for NaN while capturing the value.

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6529,6 +6529,10 @@ Approx &Approx::scale(double newScale) {
 }
 
 bool operator==(double lhs, const Approx &rhs) {
+    // A relative tolerance of 100% or more matches any finite value (but not NaN).
+    if(rhs.m_epsilon >= 1.0) {
+        return !std::isnan(lhs) && !std::isnan(rhs.m_value);
+    }
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6530,7 +6530,7 @@ Approx &Approx::scale(double newScale) {
 
 bool operator==(double lhs, const Approx &rhs) {
     // A relative tolerance of 100% or more matches any finite value (but not NaN).
-    if(rhs.m_epsilon >= 1.0) {
+    if (rhs.m_epsilon >= 1.0) {
         return !std::isnan(lhs) && !std::isnan(rhs.m_value);
     }
     // Thanks to Richard Harris for his help refining this formula

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -24,6 +24,10 @@ Approx &Approx::scale(double newScale) {
 }
 
 bool operator==(double lhs, const Approx &rhs) {
+    // A relative tolerance of 100% or more matches any finite value (but not NaN).
+    if(rhs.m_epsilon >= 1.0) {
+        return !std::isnan(lhs) && !std::isnan(rhs.m_value);
+    }
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));

--- a/doctest/parts/private/matchers/approx.cpp
+++ b/doctest/parts/private/matchers/approx.cpp
@@ -25,7 +25,7 @@ Approx &Approx::scale(double newScale) {
 
 bool operator==(double lhs, const Approx &rhs) {
     // A relative tolerance of 100% or more matches any finite value (but not NaN).
-    if(rhs.m_epsilon >= 1.0) {
+    if (rhs.m_epsilon >= 1.0) {
         return !std::isnan(lhs) && !std::isnan(rhs.m_value);
     }
     // Thanks to Richard Harris for his help refining this formula

--- a/tests/doctest/matchers/test_approx.cpp
+++ b/tests/doctest/matchers/test_approx.cpp
@@ -311,6 +311,30 @@ TEST_CASE("Comparison with non-finite floating-point values") {
     }
 }
 
+TEST_CASE("epsilon >= 1 matches any finite value") {
+    SUBCASE("epsilon = 1 with expected value 0") {
+        const auto m = Approx(0.0).epsilon(1.0);
+        CHECK(-1.0 == m);
+        CHECK(0.0 == m);
+        CHECK(1.0 == m);
+        CHECK(std::numeric_limits<double>::infinity() == m);
+    }
+
+    SUBCASE("epsilon = 1 with positive expected value") {
+        const auto m = Approx(100.0).epsilon(1.0);
+        CHECK(-50.0 == m);
+        CHECK(100.0 == m);
+        CHECK(250.0 == m);
+    }
+
+    SUBCASE("NaN is never equal") {
+        const auto qnan = std::numeric_limits<double>::quiet_NaN();
+        const auto m = Approx(0.0).epsilon(1.0);
+        CHECK_FALSE(qnan == m);
+        CHECK_FALSE(m == qnan);
+    }
+}
+
 TEST_CASE("Stringification") {
     SUBCASE("Matcher without epsilon or scale set") {
         constexpr auto inf = std::numeric_limits<double>::infinity();

--- a/tests/doctest/matchers/test_approx.cpp
+++ b/tests/doctest/matchers/test_approx.cpp
@@ -140,7 +140,7 @@ TEST_CASE_TEMPLATE("Verification of relational operators", T, float, double, lon
     // clang-format on
 }
 
-TEST_CASE("Comparison with finite floating-point values" * doctest::expected_failures(2)) {
+TEST_CASE("Comparison with finite floating-point values" * doctest::expected_failures(1)) {
     const auto epsilon = std::numeric_limits<double>::epsilon();
     const auto inf = std::numeric_limits<double>::infinity();
 
@@ -167,11 +167,10 @@ TEST_CASE("Comparison with finite floating-point values" * doctest::expected_fai
 
     SUBCASE("Matcher focused around 0 with an error of 100% and no scaling") {
         const auto m = Approx(0.0).epsilon(1.0).scale(0);
-        CAPTURE(bounds::determine(m)); // [-NaN, +NaN]
 
-        CHECK(-epsilon != m);
-        CHECK(     0.0 == m); // FAIL
-        CHECK(+epsilon != m);
+        CHECK(-epsilon == m);
+        CHECK(     0.0 == m);
+        CHECK(+epsilon == m);
     }
 
     SUBCASE("Matcher focused around smallest positive normalized value") {
@@ -228,9 +227,8 @@ TEST_CASE("Comparison with finite floating-point values" * doctest::expected_fai
 
     SUBCASE("Matcher focused around 100 with an error of 100% and no scaling") {
         const auto m = Approx(100.0).epsilon(1.0).scale(0);
-        CAPTURE(bounds::determine(m)); // [0, inf]
 
-        CHECK(  0.0 != m);
+        CHECK(  0.0 == m);
         CHECK(1e-14 == m);
         CHECK(100.0 == m);
         CHECK(1e+18 == m);


### PR DESCRIPTION
## Summary

`Approx::operator==` divides by `(1 - epsilon)` in the equivalent bound formula when `epsilon` approaches 1, which breaks comparisons (e.g. `Approx(0).epsilon(1)` matched nothing).

When `epsilon >= 1.0`, treat the tolerance as accepting any finite value; NaN comparisons still fail.

- Implementation: `doctest/parts/private/matchers/approx.cpp`
- Docs: `doc/markdown/assertions.md`
- Tests: `tests/doctest/matchers/test_approx.cpp`

Fixes #1019

## Test plan

- [x] New `epsilon >= 1 matches any finite value` test case (compiled and run locally)
- [ ] CI

Made with [Cursor](https://cursor.com)