### PR TITLE
docs: HTTPS external links in README and markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A complete example with a self-registering test that compiles to an executable l
 
 ![cover-example](scripts/data/using_doctest_888px_wide.gif)
 
-There are many C++ testing frameworks - [Catch](https://github.com/catchorg/Catch2), [Boost.Test](http://www.boost.org/doc/libs/1_64_0/libs/test/doc/html/index.html), [UnitTest++](https://github.com/unittest-cpp/unittest-cpp), [cpputest](https://github.com/cpputest/cpputest), [googletest](https://github.com/google/googletest) and [others](https://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#C.2B.2B).
+There are many C++ testing frameworks - [Catch](https://github.com/catchorg/Catch2), [Boost.Test](https://www.boost.org/doc/libs/release/libs/test/doc/html/index.html), [UnitTest++](https://github.com/unittest-cpp/unittest-cpp), [cpputest](https://github.com/cpputest/cpputest), [googletest](https://github.com/google/googletest) and [others](https://en.wikipedia.org/wiki/List_of_unit_testing_frameworks#C.2B.2B).
 
 The **key** differences between it and other testing frameworks are that it is light and unintrusive:
 - Ultra light on compile times both in terms of [**including the header**](doc/markdown/benchmarks.md#cost-of-including-the-header) and writing [**thousands of asserts**](doc/markdown/benchmarks.md#cost-of-an-assertion-macro)

--- a/doc/markdown/benchmarks.md
+++ b/doc/markdown/benchmarks.md
@@ -191,7 +191,7 @@ Note that the assert always passes - the goal should be to optimize for the comm
 
 The bar charts were generated using [**this google spreadsheet**](https://docs.google.com/spreadsheets/d/1p3MAURUfPzKT7gtJOVuJU2_yVKSqkoD1nbypA1K3618) by pasting the data from the tables.
 
-If you want a benchmark that is not synthetic - check out [**this blog post**](http://baptiste-wicht.com/posts/2016/09/blazing-fast-unit-test-compilation-with-doctest-11.html) of [**Baptiste Wicht**](https://github.com/wichtounet) who tested the compile times of the asserts in the 1.1 release with his [**Expression Templates Library**](https://github.com/wichtounet/etl)!
+If you want a benchmark that is not synthetic - check out [**this blog post**](https://baptiste-wicht.com/posts/2016/09/blazing-fast-unit-test-compilation-with-doctest-11.html) of [**Baptiste Wicht**](https://github.com/wichtounet) who tested the compile times of the asserts in the 1.1 release with his [**Expression Templates Library**](https://github.com/wichtounet/etl)!
 
 While reading the post - keep in mind that if a part of a process takes 50% of the time and is made 10000 times faster - the overall process would still be only roughly 50% faster.
 

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -164,7 +164,7 @@ Currently no. Single header libraries like [**stb**](https://github.com/nothings
 
 ### Why is doctest using macros?
 
-Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](http://accu.org/index.php/journals/2064) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
+Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](https://accu.org/journals/2064/) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
 
 ### How to use with multiple files?
 

--- a/doc/markdown/features.md
+++ b/doc/markdown/features.md
@@ -29,7 +29,7 @@
 - tested with **MSVC**: **2015**, **2017**, **2019**, **2022** (also in 32 bit mode)
 - per-commit tested on [**GitHub Actions**](https://github.com/doctest/doctest/actions)
     - warnings as errors even on the most aggressive warning levels - see [**here**](../../scripts/cmake/common.cmake#L84)
-    - statically analyzed on the CI - [**Cppcheck**](http://cppcheck.sourceforge.net/) / [**Clang-Tidy**](https://clang.llvm.org/extra/clang-tidy/) / [**Coverity Scan**](https://scan.coverity.com/) / [**OCLint**](http://oclint.org/) / [**Visual Studio Analyzer**](https://docs.microsoft.com/en-us/visualstudio/code-quality/analyzing-c-cpp-code-quality-by-using-code-analysis)
+    - statically analyzed on the CI - [**Cppcheck**](https://cppcheck.sourceforge.io/) / [**Clang-Tidy**](https://clang.llvm.org/extra/clang-tidy/) / [**Coverity Scan**](https://scan.coverity.com/) / [**OCLint**](https://oclint.org/) / [**Visual Studio Analyzer**](https://docs.microsoft.com/en-us/visualstudio/code-quality/analyzing-c-cpp-code-quality-by-using-code-analysis)
     - all tests have their output compared to reference output of a previous known good run
     - all tests built and run in **Debug**/**Release** modes
     - all tests ran through **valgrind** under **Linux** (sadly [not under OSX](https://github.com/doctest/doctest/issues/11))

--- a/doc/markdown/readme.md
+++ b/doc/markdown/readme.md
@@ -28,7 +28,7 @@ Usage:
 
 This library is free, and will stay free but needs your support to sustain its development. There are lots of [**new features**](https://github.com/doctest/doctest/issues/600) and maintenance to do. If you work for a company using **doctest** or have the means to do so, please consider financial support.
 
-[![Patreon](https://cloud.githubusercontent.com/assets/8225057/5990484/70413560-a9ab-11e4-8942-1a63607c0b00.png)](http://www.patreon.com/onqtam)
+[![Patreon](https://cloud.githubusercontent.com/assets/8225057/5990484/70413560-a9ab-11e4-8942-1a63607c0b00.png)](https://www.patreon.com/onqtam)
 [![PayPal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.me/onqtam/10)
 
 ------------

--- a/doc/markdown/testcases.md
+++ b/doc/markdown/testcases.md
@@ -21,7 +21,7 @@ Test cases and subcases can be filtered through the use of the [**command line**
 
 ## BDD-style test cases
 
-In addition to **doctest**'s take on the classic style of test cases, **doctest** supports an alternative syntax that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](http://dannorth.net/introducing-bdd/)). This set of macros map on to ```TEST_CASE```s and ```SUBCASE```s, with a little internal support to make them smoother to work with.
+In addition to **doctest**'s take on the classic style of test cases, **doctest** supports an alternative syntax that allow tests to be written as "executable specifications" (one of the early goals of [Behaviour Driven Development](https://dannorth.net/introducing-bdd/)). This set of macros map on to ```TEST_CASE```s and ```SUBCASE```s, with a little internal support to make them smoother to work with.
 
 * **SCENARIO(** _scenario name_ **)**
 


### PR DESCRIPTION
## Summary

Updates external documentation links from HTTP to HTTPS where supported:

- `README.md` — Boost.Test release docs
- `doc/markdown/features.md`, `readme.md`, `faq.md`, `benchmarks.md`
- `doc/markdown/testcases.md` — Behaviour Driven Development intro

Independent of #1133 (`Approx` behavior fix).

## Test plan

- [x] Documentation only
- [x] Link targets verified