### PR TITLE
docs: expand FAQ on char* pointer vs string comparison (#707)

### DIFF
--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -166,7 +166,7 @@ Currently no. Single header libraries like [**stb**](https://github.com/nothings
 
 ### Why is doctest using macros?
 
-Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](http://accu.org/index.php/journals/2064) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
+Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to this question [**here**](https://accu.org/journals/2064) (the creator of [**Catch**](https://github.com/catchorg/Catch2)).
 
 ### How to use with multiple files?
 

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -139,7 +139,9 @@ A compiler-specific solution for MSVC is to use the [```/OPT:NOREF```](https://m
 
 ### Why is comparing C strings (```char*```) actually comparing pointers?
 
-**doctest** by default treats ```char*``` as normal pointers. Using the [**```DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING```**](configuration.md#doctest_config_treat_char_star_as_string) changes that.
+**doctest** by default treats ```char*``` as normal pointers in comparisons and stringification, so `CHECK("foo" == ptr)` compares addresses, not text. Enable [**```DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING```**](configuration.md#doctest_config_treat_char_star_as_string) globally before including the header to use `strcmp()`-based comparisons and print string contents in failures.
+
+Prefer `const char*` literals or `std::string` when possible. For `char*` buffers, the config macro is the supported approach; see [issue #707](https://github.com/doctest/doctest/issues/707) for remaining edge cases.
 
 ### How to write tests in header-only libraries?
 


### PR DESCRIPTION
## Summary
- Expand the FAQ entry on `char*` comparisons to explain default pointer semantics
- Recommend `DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING` with link to configuration docs
- Link to #707 for remaining edge cases

Complements #1140 (configuration reference) with user-facing FAQ guidance.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)