### PR TITLE
docs: Approx semantics, SUBCASE setup FAQ, duplicate SUBCASE names

### DIFF
--- a/doc/markdown/assertions.md
+++ b/doc/markdown/assertions.md
@@ -166,6 +166,26 @@ REQUIRE(22.0/7 == doctest::Approx(3.141).epsilon(0.01)); // allow for a 1% error
 
 When dealing with very large or very small numbers it can be useful to specify a scale, which can be achieved by calling the ```scale()``` method on the ```doctest::Approx``` instance.
 
+**Comparison semantics:** `lhs` matches `Approx(value)` when
+
+```text
+|lhs - value| < epsilon * (scale + max(|lhs|, |value|))
+```
+
+**Defaults:** `epsilon` defaults to `std::numeric_limits<float>::epsilon() * 100` (about `1.2e-5`), even though comparisons use `double`. `scale` defaults to `1.0`. That is why `CHECK(Approx(0.98765) == 0.98766)` can pass despite an absolute difference of `1e-5`.
+
+**Absolute tolerances:** doctest has no separate absolute `margin()` like Catch2. For a fixed absolute threshold, compare manually:
+
+```c++
+CHECK(std::fabs(a - b) < 1e-12);
+```
+
+Or tune `epsilon()` together with `scale(0)` so `epsilon * max(|lhs|, |value|)` matches your tolerance at the magnitudes you care about:
+
+```c++
+CHECK(lhs == doctest::Approx(rhs).epsilon(1e-12).scale(0));
+```
+
 ## NaN checking
 
 Two NaN floating point numbers do not compare equal to each other. This makes it quite inconvenient to check for NaN while capturing the value.

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -13,6 +13,7 @@
 - [**Can different versions of the framework be used within the same binary (executable/dll)?**](#can-different-versions-of-the-framework-be-used-within-the-same-binary-executabledll)
 - [**Why is doctest using macros?**](#why-is-doctest-using-macros)
 - [**How to use with multiple files?**](#how-to-use-with-multiple-files)
+- [**Why does expensive setup run again for every SUBCASE?**](#why-does-expensive-setup-run-again-for-every-subcase)
 
 ### How is **doctest** different from Catch?
 
@@ -169,6 +170,18 @@ Aren't they evil and not *modern*? - Check out the answer Phil Nash gives to thi
 ### How to use with multiple files?
 
 All you need to do is define either [**```DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN```**](configuration.md#doctest_config_implement_with_main) or [**```DOCTEST_CONFIG_IMPLEMENT```**](configuration.md#doctest_config_implement) in only ONE of the source files just before including the doctest header - in all other source files you just include the header and use the framework. The difference between the two is that one of them provides a `main()` entry point - for more info on that please refer to [`The main() entry point`](main.md).
+
+### Why does expensive setup run again for every SUBCASE?
+
+By design, the `TEST_CASE` body is **re-entered from the start once per leaf `SUBCASE`**. Code before the first `SUBCASE` therefore runs again for every sibling subcase, and `TEST_CASE_FIXTURE` constructors run on each re-entry as well.
+
+If setup is costly (GPU context, large file load, etc.) and you need deterministic teardown when the whole case finishes, the subcase model does not offer a built-in "run once per `TEST_CASE`" hook today. Practical options:
+
+- **Split scenarios** into separate `TEST_CASE`s without `SUBCASE` when branches do not need a shared subcase tree.
+- **Share state explicitly** with a helper or fixture whose lifetime you control (accepting that teardown timing is your responsibility).
+- **Keep `SUBCASE`s** when the extra setup cost is acceptable for clarity of the tree.
+
+See also the [**tutorial on subcases**](tutorial.md#test-cases-and-subcases) and [issue #1108](https://github.com/doctest/doctest/issues/1108).
 
 ---------------
 

--- a/doc/markdown/parameterized-tests.md
+++ b/doc/markdown/parameterized-tests.md
@@ -71,7 +71,9 @@ for(int j = 0; j < 3; ++j) {
 }
 ```
 
-is unsupported because each iteration reuses the same subcase identity at the same source location and this leads to unpredictable (but deterministic) behavior.
+is unsupported because each iteration reuses the same subcase identity at the same source location and this leads to unpredictable (but deterministic) behavior. Only one of the iterations may run; failures in others can be missed (see [#939](https://github.com/doctest/doctest/issues/939)).
+
+Two `SUBCASE` macros with the **same name on the same source line** (for example `SUBCASE("x") { } SUBCASE("x") { }`) are also unsupported for the same reason.
 
 If the name varies per iteration, the discovered loop subcases behave as siblings at that nesting depth:
 


### PR DESCRIPTION
## Summary
- **assertions.md:** document `doctest::Approx` comparison formula, default `epsilon`/`scale`, and absolute-tolerance workarounds (#389)
- **faq.md:** explain why expensive setup runs again for every leaf `SUBCASE` and practical mitigations (#1108)
- **parameterized-tests.md:** clarify duplicate `SUBCASE` name pitfalls in loops and on the same source line (#939)

Recreates closed PR #1129 and #1131 as a single consolidated docs change.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)