### PR TITLE
fix(bench): require compile or runtime subcommand (#889)

### DIFF
--- a/scripts/bench/bench.py
+++ b/scripts/bench/bench.py
@@ -27,7 +27,7 @@ def addCommonFlags(parser):
                                                                 help = "<doctest> type of assert used - Catch: only normal")
 
 parser = argparse.ArgumentParser()
-subparsers = parser.add_subparsers()
+subparsers = parser.add_subparsers(dest="command", required=True)
 parser_c = subparsers.add_parser('compile', help='benchmark compile times')
 addCommonFlags(parser_c)
 parser_c.add_argument("--implement",    action = "store_true",  help = "implement the framework test runner")


### PR DESCRIPTION
## Summary
- Require an argparse subcommand so `bench.py` without arguments prints usage instead of crashing

Recreates closed PR #1115.

Fixes #889

## Test plan
- [x] One-line argparse fix
- [ ] CI

Made with [Cursor](https://cursor.com)