### PR TITLE
fix(cmake): apply ADD_LABELS to discovered CTest tests (#859)

### DIFF
--- a/scripts/cmake/doctest.cmake
+++ b/scripts/cmake/doctest.cmake
@@ -86,8 +86,9 @@ same as the doctest name; see also ``TEST_PREFIX`` and ``TEST_SUFFIX``.
     Specifies additional properties to be set on all tests discovered by this
     invocation of ``doctest_discover_tests``.
 
-  ``ADD_LABELS value``
-    Specifies if the test labels should be set automatically.
+  ``ADD_LABELS label...``
+    Adds the given label(s) to every discovered test. When specified, test suite
+    names are also discovered and added as labels.
 
   ``TEST_LIST var``
     Make the list of tests available in the variable ``var``, rather than the

--- a/scripts/cmake/doctestAddTests.cmake
+++ b/scripts/cmake/doctestAddTests.cmake
@@ -58,7 +58,10 @@ foreach(line ${output})
   endif()
   set(test ${line})
   set(labels "")
-  if(${add_labels})
+  if(TEST_ADD_LABELS)
+    list(APPEND labels ${TEST_ADD_LABELS})
+  endif()
+  if(TEST_ADD_LABELS)
     # get test suite that test belongs to
     execute_process(
       COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" --test-case=${test} --list-test-suites


### PR DESCRIPTION
## Summary
- Append `ADD_LABELS` from `doctest_discover_tests()` to each registered CTest test
- Still discover suite names when `ADD_LABELS` is specified

Recreates closed PR #1116.

Fixes #859

## Test plan
- [ ] CI

Made with [Cursor](https://cursor.com)