### PR TITLE
fix: accept =true suffix for flag options in Context::setOption (#910)

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -5526,8 +5526,21 @@ bool parseOptionImpl(int argc, const char *const *argv, const char *pattern, Str
                         return true;
                     }
                 } else {
-                    // just a flag - no value
-                    return true;
+                    // flag - exact match or boolean assignment (e.g. --dt-foo=true)
+                    const char *suffix = temp + strlen(pattern);
+                    if (*suffix == '\0')
+                        return true;
+                    if (*suffix == '=') {
+                        const char positive[][5] = {"1", "true", "on", "yes"};
+                        const char negative[][6] = {"0", "false", "off", "no"};
+                        const char *val = suffix + 1;
+                        for (unsigned i = 0; i < 4; i++) {
+                            if (std::strcmp(val, positive[i]) == 0)
+                                return true;
+                            if (std::strcmp(val, negative[i]) == 0)
+                                return true;
+                        }
+                    }
                 }
             }
         }

--- a/doctest/parts/private/context.cpp
+++ b/doctest/parts/private/context.cpp
@@ -98,8 +98,21 @@ bool parseOptionImpl(int argc, const char *const *argv, const char *pattern, Str
                         return true;
                     }
                 } else {
-                    // just a flag - no value
-                    return true;
+                    // flag - exact match or boolean assignment (e.g. --dt-foo=true)
+                    const char *suffix = temp + strlen(pattern);
+                    if (*suffix == '\0')
+                        return true;
+                    if (*suffix == '=') {
+                        const char positive[][5] = {"1", "true", "on", "yes"};
+                        const char negative[][6] = {"0", "false", "off", "no"};
+                        const char *val = suffix + 1;
+                        for (unsigned i = 0; i < 4; i++) {
+                            if (std::strcmp(val, positive[i]) == 0)
+                                return true;
+                            if (std::strcmp(val, negative[i]) == 0)
+                                return true;
+                        }
+                    }
                 }
             }
         }

--- a/tests/doctest/test_context_options.cpp
+++ b/tests/doctest/test_context_options.cpp
@@ -1,0 +1,13 @@
+#include <doctest/doctest.h>
+
+TEST_CASE("Context::setOption(bool) works for query flags") {
+    doctest::Context ctx(0, nullptr);
+    ctx.setOption("list-test-suites", true);
+    CHECK(ctx.shouldExit());
+}
+
+TEST_CASE("Context::setOption(bool) works for help") {
+    doctest::Context ctx(0, nullptr);
+    ctx.setOption("help", true);
+    CHECK(ctx.shouldExit());
+}


### PR DESCRIPTION
## Summary
- Treat `--flag=true` like `--flag` for boolean query flags in `parseOptionImpl`
- Fixes `Context::setOption("list-test-suites", true)` and similar API usage
- Add regression test in `test_context_options.cpp`

Recreates closed PR #1119.

Fixes #910

## Test plan
- [x] Added context options test
- [ ] CI

Made with [Cursor](https://cursor.com)