### PR TITLE
fix(bench): bump bundled Catch2 header to v2.13.10 (#890)

### DIFF
--- a/scripts/bench/bench.py
+++ b/scripts/bench/bench.py
@@ -52,7 +52,7 @@ pprint.pprint(vars(args), width = 1)
 # ==============================================================================
 
 # catch version
-catch_ver = "2.3.0"
+catch_ver = "2.13.10"
 catch_header = "catch." + catch_ver + ".hpp"
 
 # get the catch header


### PR DESCRIPTION
## Summary
- Bump benchmark script Catch2 single-header from 2.3.0 to 2.13.10
- Fixes glibc build failures from constexpr use of sysconf(MINSIGSTKSZ) in old Catch2

Recreates closed PR #1118. Fixes #890

Made with [Cursor](https://cursor.com)