### PR TITLE
docs: ESP32 thread_local workarounds (#861)

### DIFF
--- a/doc/markdown/configuration.md
+++ b/doc/markdown/configuration.md
@@ -276,6 +276,10 @@ Includes [**```DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS```**](#doctest_config_no_mul
 
 This should be defined only in the source file where the library is implemented (it's relevant only there).
 
+On embedded targets such as **ESP32**, `thread_local` storage can increase every task's stack usage and trigger early stack overflows in system tasks (for example the IPC task). If you do not use assertions from multiple threads, define this macro in the translation unit that implements doctest before including `doctest.h`. See [issue #861](https://github.com/doctest/doctest/issues/861).
+
+Alternatively, define **`DOCTEST_THREAD_LOCAL`** as empty before including `doctest.h` to disable `thread_local` while keeping the default multithreading support (higher overhead than `DOCTEST_CONFIG_NO_MULTITHREADING` on single-threaded firmware).
+
 ### **```DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS```**
 
 This can be used to disable multi lane atomics. Multi lane atomics can speed up highly parallel use of assert statements, but have a small overhead for single threaded applications.

--- a/doc/markdown/faq.md
+++ b/doc/markdown/faq.md
@@ -3,6 +3,7 @@
 - [**How is doctest different from Catch?**](#how-is-doctest-different-from-catch)
 - [**How is doctest different from Google Test?**](#how-is-doctest-different-from-google-test)
 - [**How to get the best compile-time performance with the framework?**](#how-to-get-the-best-compile-time-performance-with-the-framework)
+- [**doctest crashes at startup on ESP32 (stack canary / IPC task)**](#doctest-crashes-at-startup-on-esp32-stack-canary--ipc-task)
 - [**Is doctest thread-aware?**](#is-doctest-thread-aware)
 - [**Is mocking supported?**](#is-mocking-supported)
 - [**Why are my tests in a static library not getting registered?**](#why-are-my-tests-in-a-static-library-not-getting-registered)
@@ -87,6 +88,12 @@ There are only 2 tiny drawbacks of using this config option:
 - when an assert fails and a debugger is present - the framework will break inside a doctest function so the user will have to go 1 level up in the callstack to see where the actual assert is in the source code.
 
 These 2 things can be considered negligible and totally worth it if you are dealing mainly with expressions unlikely to throw exceptions and all the tests usually pass (you don't need to navigate often to a failing assert with a debugger attached).
+
+### doctest crashes at startup on ESP32 (stack canary / IPC task)
+
+ESP-IDF allocates C++ `thread_local` variables in each task's stack. doctest's defaults can push small system stacks (such as the 4 KiB IPC task) over their limit before your `setup()` runs.
+
+If you run tests only from the main/test runner thread, define [**```DOCTEST_CONFIG_NO_MULTITHREADING```**](configuration.md#doctest_config_no_multithreading) in the translation unit that implements doctest (recommended on firmware). Otherwise define `DOCTEST_THREAD_LOCAL` as empty before `#include "doctest.h"`. Details and background: [issue #861](https://github.com/doctest/doctest/issues/861).
 
 ### Is doctest thread-aware?
 


### PR DESCRIPTION
## Summary
- Document `DOCTEST_CONFIG_NO_MULTITHREADING` and empty `DOCTEST_THREAD_LOCAL` for ESP32 stack overflows
- Add FAQ entry for IPC task / stack canary crashes at startup

Recreates the #861 portion of closed PR #1126 (HTTPS changes omitted; covered by #1143).

Fixes #861 (documentation)

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)