### PR TITLE
Suppress the "Specializing standard library template std::tuple is forbidden" warning

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -683,8 +683,7 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
-// Specializing template std::tuple is forbidden
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285)
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285) // Specializing template std::tuple is forbidden
 class tuple;
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -682,15 +682,8 @@ basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const cha
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5285) // Suppress "Specializing template std::tuple is forbidden" warning
-#endif
 template <class... Types>
 class tuple;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -213,6 +213,7 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5285) /* specializing template std::tuple is forbidden */                            \
     /* static analysis */                                                                                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
     DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -213,7 +213,6 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5285) /* specializing template std::tuple is forbidden */                            \
     /* static analysis */                                                                                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
     DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -684,7 +684,10 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
+// Specializing template std::tuple is forbidden
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285)
 class tuple;
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -682,8 +682,12 @@ basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const cha
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
-template <class... Types>
-class tuple;
+#ifdef _MSC_VER
+#pragma warning(suppress: 5285)        // Suppress "Specializing template std::tuple is forbidden" warning
+template <class... Types> class tuple; // on this line only
+#else
+template <class... Types> class tuple;
+#endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -683,10 +683,13 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 #ifdef _MSC_VER
-#pragma warning(suppress: 5285)        // Suppress "Specializing template std::tuple is forbidden" warning
-template <class... Types> class tuple; // on this line only
-#else
-template <class... Types> class tuple;
+#pragma warning(push)
+#pragma warning(disable : 5285) // Suppress "Specializing template std::tuple is forbidden" warning
+#endif
+template <class... Types>
+class tuple;
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -33,8 +33,12 @@ basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const cha
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
-template <class... Types>
-class tuple;
+#ifdef _MSC_VER
+#pragma warning(suppress: 5285)        // Suppress "Specializing template std::tuple is forbidden" warning
+template <class... Types> class tuple; // on this line only
+#else
+template <class... Types> class tuple;
+#endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -34,8 +34,7 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
-// Specializing template std::tuple is forbidden
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285)
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285) // Specializing template std::tuple is forbidden
 class tuple;
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -34,7 +34,10 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
+// Specializing template std::tuple is forbidden
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285)
 class tuple;
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -34,10 +34,13 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 #ifdef _MSC_VER
-#pragma warning(suppress: 5285)        // Suppress "Specializing template std::tuple is forbidden" warning
-template <class... Types> class tuple; // on this line only
-#else
-template <class... Types> class tuple;
+#pragma warning(push)
+#pragma warning(disable : 5285) // Suppress "Specializing template std::tuple is forbidden" warning
+#endif
+template <class... Types>
+class tuple;
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -33,15 +33,8 @@ basic_ostream<char, traits> &operator<<(basic_ostream<char, traits> &, const cha
 template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5285) // Suppress "Specializing template std::tuple is forbidden" warning
-#endif
 template <class... Types>
 class tuple;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/parts/public/warnings.h
+++ b/doctest/parts/public/warnings.h
@@ -96,7 +96,6 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5285) /* specializing template std::tuple is forbidden */                            \
     /* static analysis */                                                                                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
     DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \

--- a/doctest/parts/public/warnings.h
+++ b/doctest/parts/public/warnings.h
@@ -96,6 +96,7 @@
     DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */                      \
     DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                                       \
     DOCTEST_MSVC_SUPPRESS_WARNING(5264) /* 'variable-name': 'const' variable is not used */                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5285) /* specializing template std::tuple is forbidden */                            \
     /* static analysis */                                                                                              \
     DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */                           \
     DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                                     \


### PR DESCRIPTION
## Description

TBD

## GitHub Issues

#1159