### PR TITLE
cmake: drop deprecated `-Wstrict-overflow=1` `gcc` flag

### DIFF
--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -109,7 +109,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compiler_flags(-Wundef)
     add_compiler_flags(-Wredundant-decls)
     add_compiler_flags(-Wshadow)
-    add_compiler_flags(-Wstrict-overflow=5)
     add_compiler_flags(-Wwrite-strings)
     add_compiler_flags(-Wpointer-arith)
     add_compiler_flags(-Wcast-qual)
@@ -176,6 +175,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
         add_compiler_flags(-Wcast-align=strict)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
+        add_compiler_flags(-Wstrict-overflow=5)
     endif()
 endif()
 


### PR DESCRIPTION
## Description

`gcc-17` formally deprecated `-Wstrict-overflow` options in https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=b31a43560e88600d412318f75a43ac8e562ba8c5. Informally the option was depracated since `gcc-8`.

I only noticed it because `gcc-17` deprecated it slightly incorrectly and started to fail `doctest` build: https://gcc.gnu.org/PR125558

While it's a `gcc` bug `gcc` devs suggested removing use of the flag. This change does the removal.