### PR TITLE
Update Godbolt playground to v2.5.2 with standard macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![download](https://img.shields.io/badge/download%20%20-link-blue.svg)](https://raw.githubusercontent.com/doctest/doctest/master/doctest/doctest.h)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/503/badge)](https://bestpractices.coreinfrastructure.org/projects/503)
-[![Try it online](https://img.shields.io/badge/try%20it-online-orange.svg)](https://godbolt.org/z/fx7T11afK)
+[![Try it online](https://img.shields.io/badge/try%20it-online-orange.svg)](https://godbolt.org/z/zTr69fG3z)
 
 A complete example with a self-registering test that compiles to an executable looks like this:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![download](https://img.shields.io/badge/download%20%20-link-blue.svg)](https://raw.githubusercontent.com/doctest/doctest/master/doctest/doctest.h)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/503/badge)](https://bestpractices.coreinfrastructure.org/projects/503)
-[![Try it online](https://img.shields.io/badge/try%20it-online-orange.svg)](https://godbolt.org/z/4s389Kbfs)
+[![Try it online](https://img.shields.io/badge/try%20it-online-orange.svg)](https://godbolt.org/z/fx7T11afK)
 
 A complete example with a self-registering test that compiles to an executable looks like this:
 

--- a/doc/markdown/tutorial.md
+++ b/doc/markdown/tutorial.md
@@ -6,6 +6,10 @@ This tutorial assumes you can use the header directly: ```#include "doctest.h"``
 
 [TDD](https://en.wikipedia.org/wiki/Test-driven_development) is not discussed in this tutorial.
 
+## Try it online
+
+You can try **doctest** right now in your browser without installing anything — just open the [**interactive playground on Compiler Explorer (Godbolt)**](https://godbolt.org/z/fx7T11afK). It comes pre-configured with **doctest v2.5.2** (the latest release), GCC 14.3, and C++20. Edit the code, hit "Compile & Run", and see the test results immediately.
+
 ## A simple example
 
 Suppose we have a ```factorial()``` function that we want to test:


### PR DESCRIPTION
Update "Try it online" Godbolt badge to a clean playground using doctest v2.5.2 with standard macros.

🔗 https://godbolt.org/z/zTr69fG3z

Closes #1163
