### PR TITLE
ci: Fix backslash in Windows CI config

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,6 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Dummy commit for reprod
       - name: Generate
         run:
           cmake -B build -S . -G "Visual Studio 17 2022" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,11 +103,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Dummy commit for reprod
       - name: Generate
         run:
-          cmake -B build -S . -G "Visual Studio 17 2022" \
-          -A ${{ matrix.architecture }} -T ${{ matrix.toolset }}
+          cmake -B build -S . -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -T ${{ matrix.toolset }}
 
       - name: Build
         run: cmake --build build --config ${{ matrix.configuration }}


### PR DESCRIPTION
## Description

Removes a `\` from the `msvs` job definition. This was fine up until recently; presumably the Windows runner shell changed. Currently blocking #1166.

Reproduced via dummy commit on this PR: https://github.com/doctest/doctest/actions/runs/27520702873/job/81337908269?pr=1167

## GitHub Issues

N/A