### PR TITLE
fix: Allow doctest::String to be constructed from null values

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -8209,7 +8209,7 @@ String::~String() {
 } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 String::String(const char *in)
-    : String(in, std::strlen(in)) {}
+    : String(in, in? std::strlen(in) : 0) {}
 
 String::String(const char *in, size_type in_size) {
     memcpy(allocate(in_size), in, in_size);

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -109,7 +109,7 @@ String::~String() {
 } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 String::String(const char *in)
-    : String(in, std::strlen(in)) {}
+    : String(in, in? std::strlen(in) : 0) {}
 
 String::String(const char *in, size_type in_size) {
     memcpy(allocate(in_size), in, in_size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ doctest_add_unit_test(          SOURCE regression/test.782.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.786.cpp)
 doctest_add_unit_test(          SOURCE regression/test.873.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.915.cpp)
+doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1045.cpp EXCEPT ${FNOEXCEPT})
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1165.cpp EXCEPT ${FNOEXCEPT})
 
 set_tests_properties(

--- a/tests/regression/test.1045.cpp
+++ b/tests/regression/test.1045.cpp
@@ -1,0 +1,27 @@
+#include <doctest/doctest.h>
+#include <doctest/parts/private/exception_translator.h>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+template <typename T>
+doctest::String translate(T failure) try {
+  throw failure;
+} catch (...) {
+  return doctest::detail::translateActiveException();
+}
+
+} // namespace
+
+
+TEST_CASE("Throwing a null const char *") {
+  const char *failure = nullptr;
+  const auto reason = translate(failure);
+  CHECK(reason == "");
+}
+
+TEST_CASE("Throwing an untyped nullptr") {
+  const auto reason = translate(nullptr);
+  CHECK(reason == "");
+}


### PR DESCRIPTION
## Description

Update the `String(const char *)` constructor to accept `nullptr` values. The `String(const char *, size_type)` constructor already passively handles the case of `(nullptr, 0)`, but the `String(const char *)` variant unconditionally passes the input to `std::strlen`; this is not safe, since `strlen` is undefined on null inputs. 

This manifested in the problem of:

```cpp
CHECK_NOTHROW(throw nullptr);
```

...resulting in a SIGSEGV, since...

1. The `translateActiveException` handler specialized for `const char *` inputs, which `nullptr` would convert to, which
2. Was implicitly converted into a `doctest::String` via the `String(const char *)` converting-constructor, which
3. Provided the value to `std::strlen`

This fix essentially just adds a conditional check to the constructor to yield 0 in such cases. 

## GitHub Issues

Fixes #1045