### PR TITLE
fix: Handle null pointers during exception translation

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6381,7 +6381,9 @@ String translateActiveException() noexcept {
     } catch (std::string &msg) {
         return msg.c_str();
     } catch (const char *msg) {
-        return msg;
+        return msg? msg : "(nullptr)";
+    } catch (std::nullptr_t) {
+        return "(nullptr)";
     } catch (...) {
         return "unknown exception";
     }

--- a/doctest/parts/private/exception_translator.cpp
+++ b/doctest/parts/private/exception_translator.cpp
@@ -39,7 +39,9 @@ String translateActiveException() noexcept {
     } catch (std::string &msg) {
         return msg.c_str();
     } catch (const char *msg) {
-        return msg;
+        return msg? msg : "(nullptr)";
+    } catch (std::nullptr_t) {
+        return "(nullptr)";
     } catch (...) {
         return "unknown exception";
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ doctest_add_unit_test(          SOURCE regression/test.782.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.786.cpp)
 doctest_add_unit_test(          SOURCE regression/test.873.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.915.cpp)
+doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1045.cpp EXCEPT ${FNOEXCEPT})
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1165.cpp EXCEPT ${FNOEXCEPT})
 
 set_tests_properties(

--- a/tests/regression/test.1045.cpp
+++ b/tests/regression/test.1045.cpp
@@ -1,0 +1,33 @@
+#include <doctest/doctest.h>
+#include <doctest/parts/private/exception_translator.h>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+template <typename T>
+doctest::String translate(T failure) {
+    static_cast<void>(failure);
+    try {
+        // NOLINTNEXTLINE
+        throw failure;
+    } catch (...) { return doctest::detail::translateActiveException(); }
+}
+
+} // namespace
+
+TEST_CASE("Throwing a null const char *") {
+    const char *failure = nullptr;
+    const auto reason = translate(failure);
+    CHECK(reason == "(nullptr)");
+}
+
+TEST_CASE("Throwing an untyped nullptr") {
+    const auto reason = translate(nullptr);
+#if defined(_MSC_VER) && !defined(__clang__)
+    /* cl / msvs are a bit weird when handling `std::nullptr_t` */
+    CHECK(reason == "unknown exception");
+#else
+    CHECK(reason == "(nullptr)");
+#endif
+}


### PR DESCRIPTION
## Description

Updates `doctest::detail::translateActiveException()` to tolerate possibly-null `const char *` values. This is done to handle the unlikely, but possible case of:

```cpp
CHECK_NOTHROW(throw nullptr);
```

or similar, which otherwise triggers a `SIGSEGV` since...

- The `translateActiveException` handler specialized for `const char *` inputs, which `nullptr` would convert to, which
- Was implicitly converted into a `doctest::String` via the `String(const char *)` converting-constructor, which
- Provided the value to `std::strlen`, which is undefined for null inputs.

This supersedes #1170 which fixed the problem by making `String(nullptr)` defined. In retrospect, this is a bad idea since `doctest::String` maintains parity with `std::string`, which is similarly undefined on null inputs.

## GitHub Issues

Fixes #1045