### PR TITLE
ci: Add actionlint job

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,24 @@
+name: actionlint
+
+on:
+  push:
+    branches: [dev, master]
+    paths:
+      - ".github/**"
+
+  pull_request:
+    paths:
+      - ".github/**"
+
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}|actionlint
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2


### PR DESCRIPTION
## Description

Adds `.github/workflows/actionlint.yml` (derived from `leanprover/lean4`). This is mostly to have a suite of checks to cover the Actions config, which can be a bit fickle.

This change mostly exists to cover #1177 

## GitHub Issues

N/A