### PR TITLE
fix: Suppress the "Specializing standard library template std::tuple is forbidden" warning

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -683,7 +683,9 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285) // Specializing template std::tuple is forbidden
 class tuple;
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>

--- a/doctest/parts/public/std/fwd.h
+++ b/doctest/parts/public/std/fwd.h
@@ -34,7 +34,9 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285) // Specializing template std::tuple is forbidden
 class tuple;
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>


### PR DESCRIPTION
## Description

Backport of #1160

## GitHub Issues

N/A