### PR TITLE
ci: Bump MSVS to use Visual Studio 18 2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: ["v142", "v143"]
+        toolset: ["v142", "v143", "v145"]
         architecture: ["Win32", "x64"]
         configuration: ["Debug", "Release"]
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Generate
         run:
-          cmake -B build -S . -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -T ${{ matrix.toolset }}
+          cmake -B build -S . -G "Visual Studio 18 2026" -A ${{ matrix.architecture }} -T ${{ matrix.toolset }}
 
       - name: Build
         run: cmake --build build --config ${{ matrix.configuration }}


### PR DESCRIPTION
## Description

Backport of #1169 

## GitHub Issues

N/A