### PR TITLE
build(cmake): drop deprecated `-Wstrict-overflow=1` flag for `gcc-17+`

### DIFF
--- a/scripts/cmake/common.cmake
+++ b/scripts/cmake/common.cmake
@@ -109,7 +109,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compiler_flags(-Wundef)
     add_compiler_flags(-Wredundant-decls)
     add_compiler_flags(-Wshadow)
-    add_compiler_flags(-Wstrict-overflow=5)
     add_compiler_flags(-Wwrite-strings)
     add_compiler_flags(-Wpointer-arith)
     add_compiler_flags(-Wcast-qual)
@@ -176,6 +175,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
         add_compiler_flags(-Wcast-align=strict)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
+        add_compiler_flags(-Wstrict-overflow=5)
     endif()
 endif()
 


### PR DESCRIPTION
## Description

Backport of #1161

## GitHub Issues

N/A