### PR TITLE
fix: Check ostream::fail after performing stringification

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -8070,6 +8070,9 @@ public:
         if (stack.empty())
             DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
 
+        if (ss.fail())
+            DOCTEST_INTERNAL_ERROR("Output stream is bad");
+
         const std::streampos pos = stack.back();
         stack.pop_back();
         const unsigned sz = static_cast<unsigned>(ss.tellp() - pos);

--- a/doctest/parts/private/string.cpp
+++ b/doctest/parts/private/string.cpp
@@ -20,6 +20,9 @@ public:
         if (stack.empty())
             DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
 
+        if (ss.fail())
+            DOCTEST_INTERNAL_ERROR("Output stream is bad");
+
         const std::streampos pos = stack.back();
         stack.pop_back();
         const unsigned sz = static_cast<unsigned>(ss.tellp() - pos);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set(MAC ON)
 endif()
 
+set(FNOEXCEPT OFF)
+if(CMAKE_CXX_FLAGS MATCHES "DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS")
+    set(FNOEXCEPT ON)
+endif()
+
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_expression.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_message.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE doctest/assert/test_type.cpp)
@@ -123,6 +128,7 @@ doctest_add_unit_test(          SOURCE regression/test.782.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.786.cpp)
 doctest_add_unit_test(          SOURCE regression/test.873.cpp)
 doctest_add_unit_test(WITH_MAIN SOURCE regression/test.915.cpp)
+doctest_add_unit_test(WITH_MAIN SOURCE regression/test.1165.cpp EXCEPT ${FNOEXCEPT})
 
 set_tests_properties(
     regression/test.782.cpp

--- a/tests/regression/test.1165.cpp
+++ b/tests/regression/test.1165.cpp
@@ -1,0 +1,39 @@
+#include <doctest/doctest.h>
+#include <ostream>
+#include <iomanip>
+
+namespace {
+
+std::ostream *g_stream = nullptr;
+
+struct object {};
+
+inline std::ostream &operator<<(std::ostream &os, object) {
+    // Hold a pointer to the stream so we can recover within the test
+    g_stream = &os;
+
+    // Emulate some failure in writing to the stream
+    os << "{}";
+    os.setstate(std::ios::failbit);
+
+    return os;
+}
+
+inline void recover_from_failure() {
+    g_stream->setstate(std::ios::goodbit);
+}
+
+} // namespace
+
+TEST_CASE("Printing a value which causes a failure in the underlying stream") {
+    auto o = object{};
+
+    try {
+        static_cast<void>(doctest::toString(o));
+        FAIL("Expression should have failed");
+    } catch (const std::logic_error &e) {
+        CHECK(e.what() == doctest::Contains("Internal doctest error: Output stream is bad"));
+
+        recover_from_failure();
+    }
+}


### PR DESCRIPTION
## Description

Backport of #1166

## GitHub Issues

N/A