### PR TITLE
fix: Annotate std::uncaught_exceptions with -Wdeprecated-declarations

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -6186,9 +6186,6 @@ ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
     g_infoContexts.push_back(this);
 }
 
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 // destroy cannot be inlined into the destructor because that would mean calling stringify after
 // ContextScope has been destroyed (base class destructors run after derived class destructors).
 // Instead, ContextScope calls this method directly from its destructor.
@@ -6200,9 +6197,7 @@ void ContextScopeBase::destroy() {
     }
     g_infoContexts.pop_back();
 }
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 
@@ -6448,6 +6443,10 @@ bool checkIfShouldThrow(assertType::Enum at) {
     return false;
 }
 
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
 bool has_uncaught_exceptions() {
 // Derived from https://github.com/uxlfoundation/oneTBB/blob/v2023.0.0/include/oneapi/tbb/detail/_config.h#L342
 #if (defined(_MSC_VER) && _MSC_VER >= 1900) ||                                                                         \
@@ -6459,6 +6458,10 @@ bool has_uncaught_exceptions() {
     return std::uncaught_exception();
 #endif
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 DOCTEST_NORETURN void throwException() {
@@ -8593,10 +8596,6 @@ Subcase::Subcase(const String &name, const char *file, int line)
     DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
 }
 
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
 Subcase::~Subcase() {
     if (m_entered) {
         g_cs->traversal.leaveSubcase();
@@ -8615,10 +8614,6 @@ Subcase::~Subcase() {
         DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
 }
-
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 Subcase::operator bool() const {
     return m_entered;

--- a/doctest/parts/private/context_scope.cpp
+++ b/doctest/parts/private/context_scope.cpp
@@ -26,9 +26,6 @@ ContextScopeBase::ContextScopeBase(ContextScopeBase &&other) noexcept {
     g_infoContexts.push_back(this);
 }
 
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 // destroy cannot be inlined into the destructor because that would mean calling stringify after
 // ContextScope has been destroyed (base class destructors run after derived class destructors).
 // Instead, ContextScope calls this method directly from its destructor.
@@ -40,9 +37,7 @@ void ContextScopeBase::destroy() {
     }
     g_infoContexts.pop_back();
 }
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
 } // namespace detail
 #endif // DOCTEST_CONFIG_DISABLE
 

--- a/doctest/parts/private/exceptions.cpp
+++ b/doctest/parts/private/exceptions.cpp
@@ -19,6 +19,10 @@ bool checkIfShouldThrow(assertType::Enum at) {
     return false;
 }
 
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
 bool has_uncaught_exceptions() {
 // Derived from https://github.com/uxlfoundation/oneTBB/blob/v2023.0.0/include/oneapi/tbb/detail/_config.h#L342
 #if (defined(_MSC_VER) && _MSC_VER >= 1900) ||                                                                         \
@@ -30,6 +34,10 @@ bool has_uncaught_exceptions() {
     return std::uncaught_exception();
 #endif
 }
+
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 DOCTEST_NORETURN void throwException() {

--- a/doctest/parts/private/subcase.cpp
+++ b/doctest/parts/private/subcase.cpp
@@ -46,10 +46,6 @@ Subcase::Subcase(const String &name, const char *file, int line)
     DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
 }
 
-DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-
 Subcase::~Subcase() {
     if (m_entered) {
         g_cs->traversal.leaveSubcase();
@@ -68,10 +64,6 @@ Subcase::~Subcase() {
         DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
     }
 }
-
-DOCTEST_CLANG_SUPPRESS_WARNING_POP
-DOCTEST_GCC_SUPPRESS_WARNING_POP
-DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 Subcase::operator bool() const {
     return m_entered;


### PR DESCRIPTION
## Description

Re-adds `-Wdeprecated-declarations` to `std::uncaught_exception(s)` which was not transferred correctly in #1174

## GitHub Issues

N/A